### PR TITLE
Use @babel/preset-env

### DIFF
--- a/babel.config.cjs
+++ b/babel.config.cjs
@@ -1,0 +1,3 @@
+module.exports = {
+  presets: [[ '@babel/preset-env' ]],
+};


### PR DESCRIPTION
**@babel/preset-env** is installed but is not configured to run at build time. This pull request adds the missing configuration file to make it work.