### PR TITLE
Fix Button class attribute merging twice

### DIFF
--- a/packages/ui/atoms/Button/Button.twig
+++ b/packages/ui/atoms/Button/Button.twig
@@ -33,7 +33,7 @@
       href: tag == 'a' and href is defined ? href : false,
       aria_label: icon_only ? label : false
     },
-    { class: ['btn', attr is defined and attr.class is defined ? attr.class : ''] }
+    { class: ['btn'] }
   )
 %}
 

--- a/tests/__snapshots__/ButtonTest__it_renders_a_button__1.txt
+++ b/tests/__snapshots__/ButtonTest__it_renders_a_button__1.txt
@@ -4,6 +4,6 @@
 
 
 
-<button title="Label" type="button" class="py-4&#x20;btn&#x20;py-4">
+<button title="Label" type="button" class="py-4&#x20;btn">
                         Label
                 </button>    

--- a/tests/__snapshots__/ButtonTest__it_renders_a_button_with_classes__1.txt
+++ b/tests/__snapshots__/ButtonTest__it_renders_a_button_with_classes__1.txt
@@ -1,0 +1,8 @@
+
+
+
+
+
+<button title="" type="button" class="py-4&#x20;btn">
+                        
+                </button>

--- a/tests/__snapshots__/ButtonTest__it_renders_a_button_with_type_submit__1.txt
+++ b/tests/__snapshots__/ButtonTest__it_renders_a_button_with_type_submit__1.txt
@@ -1,9 +1,9 @@
 
-        
 
 
 
 
-<button title="Label" type="submit" class="btn&#x20;">
+
+<button title="Label" type="submit" class="btn">
                         Label
                 </button>    

--- a/tests/__snapshots__/ButtonTest__it_renders_a_link__1.txt
+++ b/tests/__snapshots__/ButtonTest__it_renders_a_link__1.txt
@@ -4,6 +4,6 @@
 
 
 
-<a title="Label" href="&#x23;" class="btn&#x20;">
+<a title="Label" href="&#x23;" class="btn">
                         Label
                 </a>    

--- a/tests/atoms/Button/ButtonTest.php
+++ b/tests/atoms/Button/ButtonTest.php
@@ -28,3 +28,12 @@ test('it renders a button with type submit', function () {
 } %}
     ");
 });
+
+test('it renders a button without duplicate classes', function() {
+    assertTwigMatchesSnapshot("
+{% set attr = {
+  class: ['py-4']
+} %}
+{% extends '@ui/atoms/Button/Button.twig' %}
+    ");
+});


### PR DESCRIPTION
Using `merge_html_attributes()` on `attr` and later on `attr.class` result in twice the class names when using `attr.class` to customise the button classes.

Exemple :
```
{% set attr = {
  class: ['py-4']
} %}
{% extends '@ui-pkg/atoms/Button/Button.twig' %}
```

will output the following classes : `py-4 btn py-4`. 

<a href="https://gitpod.io/#https://github.com/studiometa/ui/pull/22"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

