### PR TITLE
[Feature] Add options to the `LargeText` component 

### DIFF
--- a/packages/docs/components/atoms/LargeText/app.js
+++ b/packages/docs/components/atoms/LargeText/app.js
@@ -1,0 +1,13 @@
+import { Base, createApp } from '@studiometa/js-toolkit';
+import { LargeText } from '@studiometa/ui';
+
+class App extends Base {
+  static config = {
+    name: 'App',
+    components: {
+      LargeText,
+    },
+  };
+}
+
+export default createApp(App);

--- a/packages/docs/components/atoms/LargeText/app.twig
+++ b/packages/docs/components/atoms/LargeText/app.twig
@@ -1,0 +1,32 @@
+<div class="h-96"></div>
+
+{% include '@ui/atoms/LargeText/LargeText.twig' with {
+  content: 'Lorem ipsum dolor sit amet elit.'
+} %}
+{% include '@ui/atoms/LargeText/LargeText.twig' with {
+  content: 'Lorem ipsum dolor sit amet elit.',
+  attr: { data_option_sensitivity: - 1 }
+} %}
+
+<div class="h-96"></div>
+
+{% include '@ui/atoms/LargeText/LargeText.twig' with {
+  content: 'Hello world !',
+  repeat: 4,
+  attr: {
+    data_option_skew: true,
+    data_option_sensitivity: 0.25,
+    data_option_skew_sensitivity: 0.5
+  }
+} %}
+{% include '@ui/atoms/LargeText/LargeText.twig' with {
+  content: 'Hello world ! Hello world ! Hello world !',
+  repeat: 2,
+  attr: {
+    data_option_skew: true,
+    data_option_sensitivity: - 0.25,
+    data_option_skew_sensitivity: - 0.5
+  }
+} %}
+
+<div class="h-screen"></div>

--- a/packages/docs/components/atoms/LargeText/index.md
+++ b/packages/docs/components/atoms/LargeText/index.md
@@ -2,9 +2,27 @@
 
 <script setup>
   import pkg from '@studiometa/ui/atoms/LargeText/package.json';
+  import appJsRaw from './app.js?raw';
+  import AppTwigRaw from './app.twig?raw';
 
   const badges = [`v${pkg.version}`, 'JS'];
+
+  const story = {
+    src: './story.html',
+    name: 'LargeText',
+    files: [
+      {
+        label: 'app.js',
+        lang: 'js',
+        content: appJsRaw,
+      },
+      {
+        label: 'app.twig',
+        lang: 'twig',
+        content: AppTwigRaw,
+      },
+    ],
+  };
 </script>
 
-
-- [ ] todo
+<Story v-bind="story" />

--- a/packages/docs/components/atoms/LargeText/index.md
+++ b/packages/docs/components/atoms/LargeText/index.md
@@ -5,7 +5,7 @@
   import appJsRaw from './app.js?raw';
   import AppTwigRaw from './app.twig?raw';
 
-  const badges = [`v${pkg.version}`, 'JS'];
+  const badges = [`v${pkg.version}`, 'JS', 'Twig'];
 
   const story = {
     src: './story.html',

--- a/packages/docs/components/atoms/LargeText/story.md
+++ b/packages/docs/components/atoms/LargeText/story.md
@@ -1,0 +1,7 @@
+---
+sidebar: false
+navbar: false
+customLayout: true
+---
+
+<RenderTwig :js-importer="() => import('./app.js')" :tpl-importer="() => import('./app.twig?raw')" />

--- a/packages/ui/atoms/LargeText/LargeText.twig
+++ b/packages/ui/atoms/LargeText/LargeText.twig
@@ -1,0 +1,49 @@
+{#
+/**
+ * @file
+ *   LargeText component.
+ *
+ * @param string $content
+ *   The text content.
+ * @param number $repeat
+ *   The number of times the content should be repeated, defaults to 2.
+ * @param array $attr
+ *   Custom attributes for the root element.
+ * @param array $target_attr
+ *   Custom attributes for the target element.
+ */
+#}
+
+{% set attributes =
+  merge_html_attributes(
+    attr ?? null,
+    { data_component: 'LargeText' },
+    { class: 'overflow-x-hidden pointer-events-none' }
+  )
+%}
+
+{% set target_attributes =
+  merge_html_attributes(
+    target_attr ?? null,
+    { class: 'text-9xl font-bold' },
+    { data_ref: 'target', class: 'relative inline-block whitespace-nowrap' }
+  )
+%}
+
+{% set position_factor = attributes.data_option_sensitivity is defined
+  and attributes.data_option_sensitivity < 0
+  ? - 100
+  : 100
+%}
+
+<div {{ html_attributes(attributes) }}>
+  <span {{ html_attributes(target_attributes) }}>
+    {% for count in 1..repeat ?? 2 %}
+      {% set content_attributes = {
+        style: { left: loop.first ? '' : loop.index0 * position_factor ~ '%' },
+        class: { 'absolute top-0': not loop.first }
+      } %}
+      <span {{ html_attributes(content_attributes) }}>&nbsp;{{ content }}</span>
+    {% endfor %}
+  </span>
+</div>

--- a/packages/ui/atoms/LargeText/package.json
+++ b/packages/ui/atoms/LargeText/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@studiometa/ui-large-text",
   "type": "module",
-  "version": "0.0.0"
+  "version": "0.1.0"
 }


### PR DESCRIPTION
## Changelog

### Added
- **JS:** Add options to the `LargeText` component (#27)
- **Twig:** Add a Twig template for the `LargeText` component (#27)
- **Doc:** Add a demo for the `LargeText` component (#27)

<a href="https://gitpod.io/#https://github.com/studiometa/ui/pull/27"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

