### PR TITLE
[Bugfix] Fix the attribute used to managed the open state in the twig template 

### DIFF
--- a/packages/ui/molecules/Accordion/Accordion.twig
+++ b/packages/ui/molecules/Accordion/Accordion.twig
@@ -23,8 +23,8 @@
 
 <div {{ html_attributes(attributes) }}>
   {% for item in items %}
-    {% set is_open = item.attr.data_option_is_open ?? false %}
     {% set item_attributes = merge_html_attributes(item_attr ?? null, { data_component: 'AccordionItem' }, item.attr ?? null) %}
+    {% set is_open = item_attributes.data_option_is_open ?? false %}
     <div {{ html_attributes(item_attributes) }}>
       <button data-ref="btn" class="block w-full" aria-expanded="{{ is_open ? 'true' : 'false' }}">
         {% block title %}


### PR DESCRIPTION
### Fixed
- Fix the attribute used to managed the open state in the twig template

*benefits :*
This way, we can now leverage the `$item_attr` to manage the `data_option_is_open` state, in case you need to have them all closed or all opened.