### PR TITLE
[Feature] Prevent unnecessary image requests

### DIFF
--- a/packages/ui/atoms/Figure/Figure.js
+++ b/packages/ui/atoms/Figure/Figure.js
@@ -34,7 +34,10 @@ export default class Figure extends withMountWhenInView(Base, { threshold: [0, 1
       throw new Error('[Figure] The `img` ref must be an `<img>` element.');
     }
 
-    if (this.$refs.img.hasAttribute('data-src')) {
+    if (
+      this.$refs.img.hasAttribute('data-src') &&
+      this.$refs.img.getAttribute('data-src') !== this.$refs.img.src
+    ) {
       this.$refs.img.src = this.$refs.img.getAttribute('data-src');
     }
   }


### PR DESCRIPTION
As this component uses the `withMountWhenInView` decorator, the `src` attribute is set everytime the component re-enter the view which triggers a new network request for the image.

This behavior is especially visible when using a service like https://picsum.photos/ which serves a random image for each request.

This PR fixes it by checking if the `src` and `data-src` attributes already match before setting them.