### PR TITLE
[Bugfix] Slider expose origin

### DIFF
--- a/packages/ui/molecules/Slider/Slider.js
+++ b/packages/ui/molecules/Slider/Slider.js
@@ -94,6 +94,16 @@ export default class Slider extends Base {
   states = [];
 
   /**
+   * Origins for the different modes.
+   * @type {Record<SliderModes, number>}
+   */
+  origins = {
+    left: 0,
+    center: 0,
+    right: 0,
+  };
+
+  /**
    * Get the current state.
    * @returns {SliderState}
    */
@@ -163,7 +173,7 @@ export default class Slider extends Base {
     const { wrapper } = this.$refs;
     const originRect = wrapper.getBoundingClientRect();
 
-    const origins = {
+    this.origins = {
       left: originRect.left,
       center: originRect.x + originRect.width / 2,
       right: originRect.x + originRect.width,
@@ -172,12 +182,21 @@ export default class Slider extends Base {
     return this.$children.SliderItem.map((item) => {
       return {
         x: {
-          left: (item.rect.x - origins.left) * -1,
-          center: (item.rect.x + item.rect.width / 2 - origins.center) * -1,
-          right: (item.rect.x + item.rect.width - origins.right) * -1,
+          left: (item.rect.x - this.origins.left) * -1,
+          center: (item.rect.x + item.rect.width / 2 - this.origins.center) * -1,
+          right: (item.rect.x + item.rect.width - this.origins.right) * -1,
         },
       };
     });
+  }
+
+  /**
+   * Get an origin by mode.
+   * @param   {SliderOptions['mode']} [mode]
+   * @returns {number}
+   */
+  getOriginByMode(mode) {
+    return this.origins[mode ?? this.$options.mode];
   }
 
   /**

--- a/packages/ui/molecules/Slider/SliderItem.js
+++ b/packages/ui/molecules/Slider/SliderItem.js
@@ -86,9 +86,7 @@ export default class SliderItem extends withIntersectionObserver(Base, { thresho
    */
   ticked() {
     this.dampedX = damp(this.x, this.dampedX, 0.2, 0.00001);
-    this.$el.style.transform = `${matrix({
-      translateX: this.dampedX,
-    })} translateZ(0px)`;
+    this.render();
 
     if (this.dampedX === this.x) {
       this.$services.disable('ticked');
@@ -136,8 +134,16 @@ export default class SliderItem extends withIntersectionObserver(Base, { thresho
   moveInstantly(targetPosition) {
     this.x = targetPosition;
     this.dampedX = targetPosition;
+    this.render();
+  }
+
+  /**
+   * Render the transform.
+   * @returns {void}
+   */
+  render() {
     this.$el.style.transform = `${matrix({
-      translateX: targetPosition,
+      translateX: this.dampedX,
     })} translateZ(0px)`;
   }
 


### PR DESCRIPTION
This PR improves extension of the Slider components.

## Changelog

### Changed
- Expose the origins of the `Slider` component (c1a4316)
- Refactor the `SliderItem` style update in one `render` method (7252839)

<a href="https://gitpod.io/#https://github.com/studiometa/ui/pull/41"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

