### PR TITLE
Add scrollLock option to Modal

### DIFF
--- a/packages/ui/molecules/Modal/Modal.js
+++ b/packages/ui/molecules/Modal/Modal.js
@@ -75,7 +75,7 @@ export default class Modal extends Base {
        */
       scrollLock: {
         type: Boolean,
-        default: () => true,
+        default: true,
       },
     },
   };

--- a/packages/ui/molecules/Modal/Modal.js
+++ b/packages/ui/molecules/Modal/Modal.js
@@ -20,9 +20,10 @@ const { trap, untrap, saveActiveElement } = focusTrap();
 
 /**
  * @typedef {Object} ModalOptions
- * @property {String}            move      A selector where to move the modal to.
- * @property {String}            autofocus A selector for the element to set the focus to when the modal opens.
- * @property {ModalStylesOption} styles    The styles for the different state of the modal.
+ * @property {String}            move       A selector where to move the modal to.
+ * @property {String}            autofocus  A selector for the element to set the focus to when the modal opens.
+ * @property {Boolean}           scrollLock Lock or allow scroll in the documentElement.
+ * @property {ModalStylesOption} styles     The styles for the different state of the modal.
  */
 
 /**
@@ -68,6 +69,13 @@ export default class Modal extends Base {
             },
           },
         }),
+      },
+      /**
+       * @return {ModalScrollLockOption}
+       */
+      scrollLock: {
+        type: Boolean,
+        default: () => true,
       },
     },
   };
@@ -194,7 +202,10 @@ export default class Modal extends Base {
     }
 
     this.$refs.modal.setAttribute('aria-hidden', 'false');
-    document.documentElement.style.overflow = 'hidden';
+
+    if (this.$options.scrollLock) {
+      document.documentElement.style.overflow = 'hidden';
+    }
 
     this.isOpen = true;
     this.$emit('open');
@@ -238,7 +249,10 @@ export default class Modal extends Base {
     }
 
     this.$refs.modal.setAttribute('aria-hidden', 'true');
-    document.documentElement.style.overflow = '';
+
+    if (this.$options.scrollLock) {
+      document.documentElement.style.overflow = '';
+    }
 
     this.isOpen = false;
     untrap();


### PR DESCRIPTION
## Add
- Add `scrollLock`option to Modal to control the scroll status on documentElement (enable/disable)

#### Context
Making a custom component based on `Modal` which does not need to lock the scroll on `documentElement`

#### Question
- Where shall I add this inside the documentation ? Mostly the `*.twig` files parameters are documented, not the `*.js` component options. Any recommandations ?
- Not sure if it is possible to add a test for this with jest ?

<a href="https://gitpod.io/#https://github.com/studiometa/ui/pull/43"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

