### PR TITLE
Update docs dir packages/vitepress > packages/docs

### DIFF
--- a/packages/docs/.vitepress/config.ts
+++ b/packages/docs/.vitepress/config.ts
@@ -19,7 +19,7 @@ export default defineConfig({
   themeConfig: {
     version: pkg.version,
     repo: 'studiometa/ui',
-    docsDir: 'packages/vitepress',
+    docsDir: 'packages/docs',
     lastUpdated: 'Last updated',
     editLinks: true,
     editLinkText: 'Edit this page on GitHub',


### PR DESCRIPTION
Update the docsDir entry with the new path for the docs. This fixes the `Edit this page on GitHub` link at the bottom of the pages.