### PR TITLE
Add a scale option to Cursor component

### DIFF
--- a/packages/ui/atoms/Cursor/Cursor.js
+++ b/packages/ui/atoms/Cursor/Cursor.js
@@ -10,6 +10,7 @@ import { damp, matrix } from '@studiometa/js-toolkit/utils';
  * @typedef {Object} CursorOptions
  * @property {string} growSelectors
  * @property {string} shrinkSelectors
+ * @property {number} scale
  * @property {number} growTo
  * @property {number} shrinkTo
  * @property {number} translateDampFactor
@@ -43,6 +44,10 @@ export default class Cursor extends Base {
       shrinkSelectors: {
         type: String,
         default: '[data-cursor-shrink], [data-cursor-shrink] *',
+      },
+      scale: {
+        type: Number,
+        default: 1,
       },
       growTo: {
         type: Number,
@@ -127,7 +132,7 @@ export default class Cursor extends Base {
     this.pointerX = x;
     this.pointerY = y;
 
-    let scale = 1;
+    let { scale } = this.$options;
 
     if (!event) {
       this.pointerScale = scale;


### PR DESCRIPTION
## Add
- Add a scale option to Cursor component. Allow the customisation of the default scale for the component. For exemple to have a Cursor with a scale 0 as default.

<a href="https://gitpod.io/#https://github.com/studiometa/ui/pull/48"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

