### PR TITLE
Update open and close refs

### DIFF
--- a/packages/docs/components/molecules/Modal/app.twig
+++ b/packages/docs/components/molecules/Modal/app.twig
@@ -2,16 +2,19 @@
   {% embed '@ui/molecules/Modal/StyledModal.twig' %}
     {% block content %}
       <p>
-        Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt
-        ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco
-        laboris nisi ut aliquip ex <a href="#">ea commodo consequat</a>. Duis aute irure dolor in reprehenderit in
-        voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
-        cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+        Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex <a href="#">
+          ea commodo consequat
+        </a>. Duis aute irure dolor in reprehenderit in voluptate velit esse
+        cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+        cupidatat non proident, sunt in culpa qui officia deserunt mollit anim
+        id est laborum.
       </p>
 
       {% include '@ui/atoms/Button/StyledButton.twig' with {
         label: 'Custom close trigger',
-        attr: { data_ref: 'close' }
+        attr: { data_ref: 'close[]' }
       } %}
     {% endblock %}
   {% endembed %}

--- a/packages/docs/components/molecules/Panel/app-bottom.twig
+++ b/packages/docs/components/molecules/Panel/app-bottom.twig
@@ -18,7 +18,7 @@
 
       {% include '@ui/atoms/Button/StyledButton.twig' with {
         label: 'Custom close trigger',
-        attr: { data_ref: 'close' }
+        attr: { data_ref: 'close[]' }
       } %}
     {% endblock %}
   {% endembed %}

--- a/packages/docs/components/molecules/Panel/app-left.twig
+++ b/packages/docs/components/molecules/Panel/app-left.twig
@@ -14,7 +14,7 @@
 
       {% include '@ui/atoms/Button/StyledButton.twig' with {
         label: 'Custom close trigger',
-        attr: { data_ref: 'close' }
+        attr: { data_ref: 'close[]' }
       } %}
     {% endblock %}
   {% endembed %}

--- a/packages/docs/components/molecules/Panel/app-right.twig
+++ b/packages/docs/components/molecules/Panel/app-right.twig
@@ -15,7 +15,7 @@
 
       {% include '@ui/atoms/Button/StyledButton.twig' with {
         label: 'Ok',
-        attr: { data_ref: 'close' }
+        attr: { data_ref: 'close[]' }
       } %}
     {% endblock %}
     {% block close %}

--- a/packages/docs/components/molecules/Panel/app-top.twig
+++ b/packages/docs/components/molecules/Panel/app-top.twig
@@ -16,7 +16,7 @@
 
       {% include '@ui/atoms/Button/StyledButton.twig' with {
         label: 'Custom close trigger',
-        attr: { data_ref: 'close' }
+        attr: { data_ref: 'close[]' }
       } %}
     {% endblock %}
   {% endembed %}

--- a/packages/tests/molecules/Modal.spec.js
+++ b/packages/tests/molecules/Modal.spec.js
@@ -64,8 +64,8 @@ describe('The Modal component', () => {
 
   it('should trap the focus when open.', async () => {
     const tabKeydown = new KeyboardEvent('keydown', { keyCode: 9, bubbles: true });
-    const closeButton = modal.$refs.modal.querySelector('[data-ref="close"]');
-    const openButton = modal.$el.querySelector('[data-ref="open"]');
+    const closeButton = modal.$refs.modal.querySelector('[data-ref="close[]"]');
+    const openButton = modal.$el.querySelector('[data-ref="open[]"]');
     openButton.focus();
 
     jest.spyOn(closeButton, 'focus');
@@ -85,7 +85,7 @@ describe('The Modal component', () => {
   });
 
   it('should open when clicking the open button.', async () => {
-    const btn = document.querySelector('[data-ref="open"]');
+    const btn = document.querySelector('[data-ref="open[]"]');
     await modal.close();
     expect(modal.isOpen).toBe(false);
     btn.click();
@@ -112,7 +112,7 @@ describe('The Modal component', () => {
   });
 
   it('should close when clicking the close button.', async () => {
-    const btn = document.querySelector('[data-ref="close"]');
+    const btn = document.querySelector('[data-ref="close[]"]');
 
     await modal.open();
     expect(modal.isOpen).toBe(true);

--- a/packages/tests/molecules/Modal.template.html
+++ b/packages/tests/molecules/Modal.template.html
@@ -3,7 +3,7 @@
     Modal opening trigger.
     This ref will be used to open the modal on click.
   -->
-  <button data-ref="open" type="button" class="py-2 px-4 text-white rounded bg-black focus:opacity-50">
+  <button data-ref="open[]" type="button" class="py-2 px-4 text-white rounded bg-black focus:opacity-50">
     Open
   </button>
   <!-- Modal element -->
@@ -24,7 +24,7 @@
           Modal close button
           This will be used to close the modal on click.
         -->
-        <button data-ref="close" type="button" class="absolute top-0 right-0 m-2 py-2 px-4 text-white rounded bg-black focus:opacity-50">
+        <button data-ref="close[]" type="button" class="absolute top-0 right-0 m-2 py-2 px-4 text-white rounded bg-black focus:opacity-50">
           Close
         </button>
         <!--

--- a/packages/ui/molecules/Modal/Modal.js
+++ b/packages/ui/molecules/Modal/Modal.js
@@ -5,11 +5,11 @@ const { trap, untrap, saveActiveElement } = focusTrap();
 
 /**
  * @typedef {Object} ModalRefs
- * @property {HTMLElement} close
+ * @property {HTMLElement} close[]
  * @property {HTMLElement} container
  * @property {HTMLElement} content
  * @property {HTMLElement} modal
- * @property {HTMLElement} open
+ * @property {HTMLElement} open[]
  * @property {HTMLElement} overlay
  */
 
@@ -49,7 +49,7 @@ export default class Modal extends Base {
    */
   static config = {
     name: 'Modal',
-    refs: ['close', 'container', 'content', 'modal', 'open', 'overlay'],
+    refs: ['close[]', 'container', 'content', 'modal', 'open[]', 'overlay'],
     emits: ['open', 'close'],
     options: {
       move: String,

--- a/packages/ui/molecules/Modal/Modal.twig
+++ b/packages/ui/molecules/Modal/Modal.twig
@@ -83,7 +83,10 @@
 
 <div {{ html_attributes(attributes) }}>
   {% block open %}
-    {% include '@ui/atoms/Button/Button.twig' with { label: 'Open', attr: { data_ref: 'open' } } %}
+    {% include '@ui/atoms/Button/Button.twig' with {
+      label: 'Open',
+      attr: { data_ref: 'open[]' }
+    } %}
   {% endblock %}
   <div {{ html_attributes(modal_attributes) }}>
     <div {{ html_attributes(overlay_attributes) }}></div>
@@ -93,7 +96,7 @@
           <div class="absolute top-0 right-0 m-2">
             {% include '@ui/atoms/Button/Button.twig' with {
               label: 'Close',
-              attr: { data_ref: 'close' }
+              attr: { data_ref: 'close[]' }
             } %}
           </div>
         {% endblock %}

--- a/packages/ui/molecules/Modal/StyledModal.twig
+++ b/packages/ui/molecules/Modal/StyledModal.twig
@@ -26,14 +26,17 @@
 {% extends '@ui/molecules/Modal/Modal.twig' %}
 
 {% block open %}
-  {% include '@ui/atoms/Button/StyledButton.twig' with { label: 'Open', attr: { data_ref: 'open' } } %}
+  {% include '@ui/atoms/Button/StyledButton.twig' with {
+    label: 'Open',
+    attr: { data_ref: 'open[]' }
+  } %}
 {% endblock %}
 
 {% block close %}
   <div class="absolute top-0 right-0 m-2">
     {% include '@ui/atoms/Button/StyledButton.twig' with {
       label: 'Close',
-      attr: { data_ref: 'close' }
+      attr: { data_ref: 'close[]' }
     } %}
   </div>
 {% endblock %}

--- a/packages/ui/molecules/Panel/StyledPanel.twig
+++ b/packages/ui/molecules/Panel/StyledPanel.twig
@@ -12,17 +12,22 @@
 
 {% extends '@ui/molecules/Panel/Panel.twig' %}
 
-{% set container_attr = merge_html_attributes(container_attr ?? null, required={ class: 'bg-white' }) %}
+{% set container_attr =
+  merge_html_attributes(container_attr ?? null, required = { class: 'bg-white' })
+%}
 
 {% block open %}
-  {% include '@ui/atoms/Button/StyledButton.twig' with { label: 'Open', attr: { data_ref: 'open' } } %}
+  {% include '@ui/atoms/Button/StyledButton.twig' with {
+    label: 'Open',
+    attr: { data_ref: 'open[]' }
+  } %}
 {% endblock %}
 
 {% block close %}
   <div class="absolute top-0 right-0 m-2">
     {% include '@ui/atoms/Button/StyledButton.twig' with {
       label: 'Close',
-      attr: { data_ref: 'close' }
+      attr: { data_ref: 'close[]' }
     } %}
   </div>
 {% endblock %}


### PR DESCRIPTION
## Update
- Update `open` an `close` refs on Modal & Panel components to be `open[]` and `close[]`

see #45 

<a href="https://gitpod.io/#https://github.com/studiometa/ui/pull/49"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

