### PR TITLE
[Feature] Add support for transition when using Figure with lazyload 

### DIFF
--- a/packages/docs/components/atoms/Figure/index.md
+++ b/packages/docs/components/atoms/Figure/index.md
@@ -1,4 +1,4 @@
-# Figure (todo) <Badges :texts="badges" />
+# Figure <Badges :texts="badges" />
 
 <script setup>
   import pkg from '@studiometa/ui/atoms/Figure/package.json';
@@ -9,4 +9,8 @@
 
 - [Examples](./examples.html)
 - [JS API](./js-api.html)
+- [FigureTwicPics JS API](./twicpics-js-api.html)
 - [Twig API](./twig-api.html)
+
+## Usage
+

--- a/packages/docs/components/atoms/Figure/index.md
+++ b/packages/docs/components/atoms/Figure/index.md
@@ -1,9 +1,15 @@
+---
+outline: deep
+---
+
 # Figure <Badges :texts="badges" />
 
 <script setup>
   import pkg from '@studiometa/ui/atoms/Figure/package.json';
   const badges = [`v${pkg.version}`, 'Twig', 'JS'];
 </script>
+
+Use the `Figure` component to display images.
 
 ## Table of content
 
@@ -14,3 +20,82 @@
 
 ## Usage
 
+Register the component in your JavaScript app and use the Twig template to display images.
+
+```js {2,8}
+import { Base, createApp } from '@studiometa/js-toolkit';
+import { Figure } from '@studiometa/ui';
+
+class App extends Base {
+  static config = {
+    name: 'Base',
+    components: {
+      Figure,
+    }
+  };
+}
+
+export default createApp(App);
+```
+```twig
+<div class="card">
+  {% include '@ui/atoms/Figure/Figure.twig' with {
+    src: 'https://picsum.photos/400/400',
+    width: 400,
+    height: 400,
+  } only %}
+</div>
+```
+
+### With or without lazy load
+
+The Twig component is lazy by default, so if you need to display images with an eager loading strategy, set the `lazy` parameter to `false`;
+
+```diff
+  <div class="card">
+    {% include '@ui/atoms/Figure/Figure.twig' with {
+      src: 'https://picsum.photos/400/400',
+      width: 400,
+      height: 400,
++     lazy: false
+    } only %}
+  </div>
+```
+
+### With TwicPics
+
+If your project uses TwicPics to optimize images, you can use the `FigureTwicPics` class instead of the `Figure` class. You will need to extend it in your project to configure the TwicPics' domain to use.
+
+```js
+import { FigureTwicPics } from '@studiometa/ui';
+
+export default class Figure extends FigureTwicPics {
+  static config = {
+    ...FigureTwicPics.config,
+    name: 'Figure',
+  };
+
+  get domain() {
+    return 'domain.twic.pics';
+  }
+}
+```
+
+And replace the import in your app to import your local class instead of the one from the package.
+
+```diff
+  import { Base, createApp } from '@studiometa/js-toolkit';
+- import { Figure } from '@studiometa/ui';
++ import { Figure } from './atoms/Figure.js';
+
+  class App extends Base {
+    static config = {
+      name: 'Base',
+      components: {
+        Figure,
+      }
+    };
+  }
+
+  export default createApp(App);
+```

--- a/packages/docs/components/atoms/Figure/js-api.md
+++ b/packages/docs/components/atoms/Figure/js-api.md
@@ -1,5 +1,26 @@
 ---
 title: Figure JS API
+outline: deep
 ---
 
-# JS API (todo)
+# JS API
+
+The `Figure` component extends the [`Transition` primitive](/components/primitives/Transition/) and implements the [`withMountWhenInView` decorator](https://js-toolkit.studiometa.dev/api/decorators/withMountWhenInView.html). It inherits their respective APIs, so make sur have a look at them.
+
+## Options
+
+### `lazy`
+
+- Type: `boolean`
+- Default: `false`
+
+Use this options to enable lazy loading while reading the source from the `data-src` attribute of the [`img` ref](#img).
+
+
+## Refs
+
+### `img`
+
+- Type: `HTMLImageElement`
+
+The `Figure` component should have a ref corresponding to its inner `<img />` element.

--- a/packages/docs/components/atoms/Figure/stories/lazyload/app.twig
+++ b/packages/docs/components/atoms/Figure/stories/lazyload/app.twig
@@ -1,13 +1,15 @@
 <div class="max-w-lg mx-auto p-10 space-y-10">
-  {% include '@ui/atoms/Figure/Figure.twig' with {
-    src: 'https://picsum.photos/500/400',
-    width: '500',
-    height: '400',
-    lazy: false
-  } %}
-  {% include '@ui/atoms/Figure/Figure.twig' with {
-    src: 'https://picsum.photos/500/400',
-    width: '500',
-    height: '400'
-  } %}
+  {% for i in 1..10 %}
+    {% include '@ui/atoms/Figure/Figure.twig' with {
+      src: 'https://picsum.photos/500/400',
+      width: '500',
+      height: '400',
+      attr: {
+        data_option_enter_from: 'opacity-0',
+        data_option_enter_active: 'transition duration-500'
+      },
+      inner_attr: { class: 'bg-vp-bg' },
+      img_attr: { class: 'opacity-0' }
+    } %}
+  {% endfor %}
 </div>

--- a/packages/docs/components/atoms/Figure/stories/lazyload/app.twig
+++ b/packages/docs/components/atoms/Figure/stories/lazyload/app.twig
@@ -1,7 +1,7 @@
 <div class="max-w-lg mx-auto p-10 space-y-10">
   {% for i in 1..10 %}
     {% include '@ui/atoms/Figure/Figure.twig' with {
-      src: 'https://picsum.photos/500/400',
+      src: 'https://picsum.photos/500/400?rand=' ~ i,
       width: '500',
       height: '400',
       attr: {

--- a/packages/docs/components/atoms/Figure/stories/twicpics/app.twig
+++ b/packages/docs/components/atoms/Figure/stories/twicpics/app.twig
@@ -1,24 +1,24 @@
 <div class="max-w-lg mx-auto p-10 space-y-10">
   {% include '@ui/atoms/Figure/Figure.twig' with {
-    src: 'https://picsum.photos/500/400',
+    src: 'https://picsum.photos/500/400?rand=1',
     width: '500',
     height: '400',
     lazy: false,
     attr: {
-      data_option_transform: 'focus=auto/crop=300x300'
+      data_option_transform: 'focus=auto/crop=300x300/placeholder:auto'
     }
   } %}
   {% include '@ui/atoms/Figure/Figure.twig' with {
-    src: 'https://picsum.photos/500/400',
+    src: 'https://picsum.photos/500/400?rand=2',
     width: '500',
     height: '400',
   } %}
   {% include '@ui/atoms/Figure/Figure.twig' with {
-    src: 'https://picsum.photos/500/400',
+    src: 'https://picsum.photos/500/400?rand=3',
     width: '500',
     height: '400',
     attr: {
-      data_option_transform: 'focus=auto/crop=300x300'
+      data_option_transform: 'focus=auto/crop=300x300/placeholder:auto'
     }
   } %}
 </div>

--- a/packages/docs/components/atoms/Figure/twicpics-js-api.md
+++ b/packages/docs/components/atoms/Figure/twicpics-js-api.md
@@ -1,0 +1,38 @@
+---
+outline: deep
+---
+
+# FigureTwicpics JS API
+
+The `FigureTwicpics` class extends the `Figure` class and adds support for TwicPics API support.
+
+## Options
+
+### `transform`
+
+- Type: `string`
+- Default: `''`
+
+Use this option to add transforms to the image with [TwicPics URL API](https://www.twicpics.com/docs/api/basics).
+
+### `step`
+
+- Type: `number`
+- Default: `50`
+
+The step used to round up image size calculation. Default to `50`, which means that a size of `320×380` will be rounded to `350×400`.
+
+### `mode`
+
+- Type: `string`
+- Default: `'cover'`
+
+The mode used to resize and crop the image. It can be any key of the [transformations API](https://www.twicpics.com/docs/api/transformations) of TwicPics which accepts a size as value.
+
+## Getter
+
+### `domain`
+
+- Return: `string`
+
+A getter to override in a child class in order to define the main host on which the image should be server by Twicpics. It will be used to replace the host of the image source.

--- a/packages/docs/components/atoms/Figure/twig-api.md
+++ b/packages/docs/components/atoms/Figure/twig-api.md
@@ -7,33 +7,56 @@ outline: deep
 
 ## Parameters
 
+:::tip Required parameters
+The  [`src`](#src), [`width`](#width) and [`height`](#height) parameters are required.
+:::
+
 ### `src`
 
 - Type: `string`
 
-### `srcset`
-
-- Type: `string`
-
-### `sizes`
-
-- Type: `string`
+Configure the `src` attribute of the image.
 
 ### `width`
 
 - Type: `number`
 
+Configure the `width` attribute of the image and the components sizing.
+
 ### `height`
 
 - Type: `number`
+
+Configure the `height` attribute of the image and the components sizing.
+
+### `srcset`
+
+- Type: `string`
+
+Configure the `srcset` attribute of the image.
+
+### `sizes`
+
+- Type: `string`
+
+Configure the `sizes` attribute of the image.
 
 ### `alt`
 
 - Type: `string`
 
+### `lazy`
+
+- Type: `boolean`
+- Default: `true`
+
+Configure the type of loading for the image. Defaults to `true` which requires the `Figure` JavaScript component to be loaded in your project.
+
 ### `caption`
 
 - Type: `string`
+
+The caption of the image.
 
 ### `fit`
 

--- a/packages/ui/atoms/Figure/Figure.js
+++ b/packages/ui/atoms/Figure/Figure.js
@@ -1,14 +1,15 @@
 import { withMountWhenInView } from '@studiometa/js-toolkit';
-import Transition from '../../primitives/Transition/Transition.js';
+import { Transition } from '../../primitives/index.js';
 
 /**
- * @typedef {Object} FigureRefs
- * @property {HTMLImageElement} img
- */
-
-/**
- * @typedef {Object} FigureInterface
- * @property {FigureRefs} $refs
+ * @typedef {Figure & {
+ *   $refs: {
+ *     img: HTMLImageElement
+ *   },
+ *   $options: {
+ *     lazy: boolean
+ *   }
+ * }} FigureInterface
  */
 
 /**
@@ -32,6 +33,8 @@ export default class Figure extends withMountWhenInView(Transition, { threshold:
 
   /**
    * Get the transition target.
+   *
+   * @this {FigureInterface}
    * @returns {HTMLImageElement}
    */
   get target() {
@@ -41,7 +44,7 @@ export default class Figure extends withMountWhenInView(Transition, { threshold:
   /**
    * Get the image source.
    *
-   * @this {Figure & FigureInterface}
+   * @this {FigureInterface}
    * @returns {string}
    */
   get src() {
@@ -51,7 +54,7 @@ export default class Figure extends withMountWhenInView(Transition, { threshold:
   /**
    * Set the image source.
    *
-   * @this {Figure & FigureInterface}
+   * @this {FigureInterface}
    * @param   {string} value
    * @returns {void}
    */
@@ -61,7 +64,7 @@ export default class Figure extends withMountWhenInView(Transition, { threshold:
 
   /**
    * Load on mount.
-   * @this {Figure & FigureInterface}
+   * @this {FigureInterface}
    */
   mounted() {
     const { img } = this.$refs;
@@ -74,15 +77,16 @@ export default class Figure extends withMountWhenInView(Transition, { threshold:
       throw new Error('[Figure] The `img` ref must be an `<img>` element.');
     }
 
-    if (
-      this.$options.lazy &&
-      img.hasAttribute('data-src') &&
-      img.getAttribute('data-src') !== this.src
-    ) {
-      img.onload = () => {
+    const src = img.getAttribute('data-src');
+
+    if (this.$options.lazy && src && src !== this.src) {
+      let tempImg = new Image();
+      tempImg.onload = () => {
         this.enter();
+        this.src = src;
+        tempImg = null;
       };
-      this.src = img.getAttribute('data-src');
+      tempImg.src = src;
     }
   }
 }

--- a/packages/ui/atoms/Figure/Figure.js
+++ b/packages/ui/atoms/Figure/Figure.js
@@ -1,4 +1,5 @@
-import { Base, withMountWhenInView } from '@studiometa/js-toolkit';
+import { withMountWhenInView } from '@studiometa/js-toolkit';
+import Transition from '../../primitives/Transition/Transition.js';
 
 /**
  * @typedef {Object} FigureRefs
@@ -15,14 +16,27 @@ import { Base, withMountWhenInView } from '@studiometa/js-toolkit';
  *
  * Manager lazyloading image sources.
  */
-export default class Figure extends withMountWhenInView(Base, { threshold: [0, 1] }) {
+export default class Figure extends withMountWhenInView(Transition, { threshold: [0, 1] }) {
+  /**
+   * Config.
+   */
   static config = {
+    ...Transition.config,
     name: 'Figure',
     refs: ['img'],
     options: {
+      ...Transition.config.options,
       lazy: Boolean,
     },
   };
+
+  /**
+   * Get the transition target.
+   * @returns {HTMLImageElement}
+   */
+  get target() {
+    return this.$refs.img;
+  }
 
   /**
    * Get the image source.
@@ -50,20 +64,25 @@ export default class Figure extends withMountWhenInView(Base, { threshold: [0, 1
    * @this {Figure & FigureInterface}
    */
   mounted() {
-    if (!this.$refs.img) {
+    const { img } = this.$refs;
+
+    if (!img) {
       throw new Error('[Figure] The `img` ref is required.');
     }
 
-    if (!(this.$refs.img instanceof HTMLImageElement)) {
+    if (!(img instanceof HTMLImageElement)) {
       throw new Error('[Figure] The `img` ref must be an `<img>` element.');
     }
 
     if (
       this.$options.lazy &&
-      this.$refs.img.hasAttribute('data-src') &&
-      this.$refs.img.getAttribute('data-src') !== this.src
+      img.hasAttribute('data-src') &&
+      img.getAttribute('data-src') !== this.src
     ) {
-      this.src = this.$refs.img.getAttribute('data-src');
+      img.onload = () => {
+        this.enter();
+      };
+      this.src = img.getAttribute('data-src');
     }
   }
 }

--- a/packages/ui/atoms/Figure/FigureTwicPics.js
+++ b/packages/ui/atoms/Figure/FigureTwicPics.js
@@ -69,7 +69,7 @@ export default class FigureTwicPics extends Figure {
    * @returns {void}
    */
   set src(value) {
-    const url = new URL(value);
+    const url = new URL(value, window.location.origin);
     url.host = this.domain;
 
     const width = normalizeSize(this, 'offsetWidth');

--- a/packages/ui/atoms/Figure/FigureTwicPics.js
+++ b/packages/ui/atoms/Figure/FigureTwicPics.js
@@ -9,6 +9,7 @@ import Figure from './Figure.js';
  *   $options: {
  *     transform: string,
  *     step: number,
+ *     mode: string,
  *   }
  * }} FigureTwicPicsInterface
  */


### PR DESCRIPTION
## Changelog

### Added
- **Figure:** Add support for transition when using Figure with lazyload (#55)

## To-do
- [ ] Update JS API doc


<a href="https://gitpod.io/#https://github.com/studiometa/ui/pull/55"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

