### PR TITLE
Terminate Figure component on image load

### DIFF
--- a/packages/ui/atoms/Figure/Figure.ts
+++ b/packages/ui/atoms/Figure/Figure.ts
@@ -79,6 +79,8 @@ export class Figure<T extends BaseProps = BaseProps> extends withMountWhenInView
         { once: true },
       );
       tempImg.src = src;
+
+      this.$terminate();
     }
   }
 }


### PR DESCRIPTION
Terminate the `Figure` component to avoid weird behaviors when scrolling up and down when the image has already been loaded.

Closes #64.

<a href="https://gitpod.io/#https://github.com/studiometa/ui/pull/89"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

## Changelog

### Fixed
- **Figure:** terminate component once the image is loaded (fix #64, #89)