### PR TITLE
[Hotfix] 0.2.19

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "studiometa/ui",
-  "version": "0.2.18",
+  "version": "0.2.19",
   "description": "A set of opiniated, unstyled and accessible components.",
   "license": "MIT",
   "require": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@studiometa/ui-workspace",
-  "version": "0.2.18",
+  "version": "0.2.19",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@studiometa/ui-workspace",
-      "version": "0.2.18",
+      "version": "0.2.19",
       "hasInstallScript": true,
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-workspace",
-  "version": "0.2.18",
+  "version": "0.2.19",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-docs",
-  "version": "0.2.18",
+  "version": "0.2.19",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-tests",
-  "version": "0.2.18",
+  "version": "0.2.19",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/ui/atoms/ScrollAnimation/AbstractScrollAnimation.ts
+++ b/packages/ui/atoms/ScrollAnimation/AbstractScrollAnimation.ts
@@ -82,8 +82,6 @@ export class AbstractScrollAnimation<T extends BaseProps = BaseProps> extends wi
       1,
     );
 
-    this.$options.playRange = [0, 0];
-
     this.render(progress);
   }
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui",
-  "version": "0.2.18",
+  "version": "0.2.19",
   "description": "A set of opiniated, unstyled and accessible components",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## FIx

- Fix `AbstractScrollAnimation` by removing `playRange` assignement
Component was throwing an error cause it has FreezedOptions: `Uncaught (in promise) TypeError: Cannot assign to read only property 'playRange' of object '#<Object>'` 

<a href="https://gitpod.io/#https://github.com/studiometa/ui/pull/92"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

