### PR TITLE
[Feature] SliderBtn `contain` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- **Slider:**
+  - Add the `contain` option to SliderBtn ([8407de8](https://github.com/studiometa/ui/commit/8407de8), [#101](https://github.com/studiometa/ui/issues/101))
 
 ## v0.2.23 (2022-11-17)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 ### Added
 - **Slider:**
-  - Add the `contain` option to SliderBtn ([8407de8](https://github.com/studiometa/ui/commit/8407de8), [#101](https://github.com/studiometa/ui/issues/101))
+  - Add the `contain` option to SliderBtn ([#105](https://github.com/studiometa/ui/pull/105), [#101](https://github.com/studiometa/ui/issues/101))
 
 ## v0.2.23 (2022-11-17)
 

--- a/packages/ui/molecules/Slider/Slider.ts
+++ b/packages/ui/molecules/Slider/Slider.ts
@@ -19,6 +19,7 @@ export interface SliderProps extends BaseProps {
   $options: {
     mode: SliderModes;
     fitBounds: boolean;
+    contain: boolean;
     sensitivity: number;
     dropSensitivity: number;
   }

--- a/packages/ui/molecules/Slider/SliderBtn.ts
+++ b/packages/ui/molecules/Slider/SliderBtn.ts
@@ -1,3 +1,4 @@
+import { isDev } from '@studiometa/js-toolkit/utils';
 import type { BaseProps, BaseConfig } from '@studiometa/js-toolkit';
 import { AbstractSliderChild } from './AbstractSliderChild.js';
 
@@ -5,6 +6,7 @@ export interface SliderBtnProps extends BaseProps {
   $options: {
     prev: boolean;
     next: boolean;
+    contain: boolean;
   };
 }
 
@@ -20,6 +22,7 @@ export class SliderBtn<T extends BaseProps = BaseProps> extends AbstractSliderCh
     options: {
       prev: Boolean,
       next: Boolean,
+      contain: Boolean,
     },
   };
 
@@ -29,9 +32,17 @@ export class SliderBtn<T extends BaseProps = BaseProps> extends AbstractSliderCh
    * @returns {void}
    */
   update(index: number) {
+    if (isDev && this.$options.contain && !this.$parent.$options.contain) {
+      console.warn(`[${this.$id}] The contain option will only works if the parent Slider also has the contain option.`);
+    }
+
+    const isContainMaxState =
+      this.$options.contain && this.$parent.$options.contain && this.$parent.containMaxState ===
+          this.$parent.getStates()[index].x[this.$parent.$options.mode];
+
     if (
       (index === 0 && this.$options.prev) ||
-      (index === this.$parent.indexMax && this.$options.next)
+      ((index === this.$parent.indexMax || isContainMaxState) && this.$options.next)
     ) {
       this.$el.setAttribute('disabled', '');
     } else {


### PR DESCRIPTION
## Added
- Add the `contain` option to SliderBtn ([8407de8](https://github.com/studiometa/ui/commit/8407de8), [#101](https://github.com/studiometa/ui/issues/101))

<a href="https://gitpod.io/#https://github.com/studiometa/ui/pull/105"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

