### PR TITLE
[Feature] Add Emmet and autocompletion snippets to the playground

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+
+- **Playground:**
+  - add support for Twig and JS snippets autocompletion ([#114](https://github.com/studiometa/ui/pull/114), [54322cb](https://github.com/studiometa/ui/commit/54322cb))
+  - add support for Emmet in the HTML editor ([#114](https://github.com/studiometa/ui/pull/114), [883e039](https://github.com/studiometa/ui/commit/883e039))
+  - add support for import maps for the `@studiometa/` namespace ([#114](https://github.com/studiometa/ui/pull/114), [25052fd](https://github.com/studiometa/ui/commit/25052fd))
+
+### Fixed
+
+- **Playground:**
+  - fix Twig auto-indent not working for HTML elements ([#114](https://github.com/studiometa/ui/pull/114), [de6e560](https://github.com/studiometa/ui/commit/de6e560))
+  - fix a bug where HTML content was sometimes `undefined` ([#114](https://github.com/studiometa/ui/pull/114), [f542fb9](https://github.com/studiometa/ui/commit/f542fb9))
+  - improve layout on small screens ([#114](https://github.com/studiometa/ui/pull/114), [d178ce8](https://github.com/studiometa/ui/commit/d178ce8))
+
 ## [v0.2.27](https://github.com/studiometa/ui/compare/0.2.26..0.2.27) (2023-02-02)
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -2224,6 +2224,27 @@
         }
       }
     },
+    "node_modules/@emmetio/abbreviation": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@emmetio/abbreviation/-/abbreviation-2.2.3.tgz",
+      "integrity": "sha512-87pltuCPt99aL+y9xS6GPZ+Wmmyhll2WXH73gG/xpGcQ84DRnptBsI2r0BeIQ0EB/SQTOe2ANPqFqj3Rj5FOGA==",
+      "dependencies": {
+        "@emmetio/scanner": "^1.0.0"
+      }
+    },
+    "node_modules/@emmetio/css-abbreviation": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@emmetio/css-abbreviation/-/css-abbreviation-2.1.4.tgz",
+      "integrity": "sha512-qk9L60Y+uRtM5CPbB0y+QNl/1XKE09mSO+AhhSauIfr2YOx/ta3NJw2d8RtCFxgzHeRqFRr8jgyzThbu+MZ4Uw==",
+      "dependencies": {
+        "@emmetio/scanner": "^1.0.0"
+      }
+    },
+    "node_modules/@emmetio/scanner": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@emmetio/scanner/-/scanner-1.0.0.tgz",
+      "integrity": "sha512-8HqW8EVqjnCmWXVpqAOZf+EGESdkR27odcMMMGefgKXtar00SoYNSryGv//TELI4T3QFsECo78p+0lmalk/CFA=="
+    },
     "node_modules/@es-joy/jsdoccomment": {
       "version": "0.20.1",
       "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.20.1.tgz",
@@ -7925,6 +7946,26 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/emittery?sponsor=1"
+      }
+    },
+    "node_modules/emmet": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/emmet/-/emmet-2.3.6.tgz",
+      "integrity": "sha512-pLS4PBPDdxuUAmw7Me7+TcHbykTsBKN/S9XJbUOMFQrNv9MoshzyMFK/R57JBm94/6HSL4vHnDeEmxlC82NQ4A==",
+      "dependencies": {
+        "@emmetio/abbreviation": "^2.2.3",
+        "@emmetio/css-abbreviation": "^2.1.4"
+      }
+    },
+    "node_modules/emmet-monaco-es": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/emmet-monaco-es/-/emmet-monaco-es-5.1.2.tgz",
+      "integrity": "sha512-P+GwbRfzCAN9socNCLj7hdlmjV1J535wYZX9uoXERRGbbfkzcmfz4i43ClDecqCVt6IsbP0RK8AgX370ClMcJA==",
+      "dependencies": {
+        "emmet": "^2.3.6"
+      },
+      "peerDependencies": {
+        "monaco-editor": ">=0.22.0"
       }
     },
     "node_modules/emoji-regex": {
@@ -23342,6 +23383,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@studiometa/js-toolkit": "^2.9.0",
+        "emmet-monaco-es": "^5.1.2",
         "fflate": "^0.7.4",
         "monaco-editor": "^0.34.1"
       },
@@ -24876,6 +24918,27 @@
         "algoliasearch": "^4.0.0"
       }
     },
+    "@emmetio/abbreviation": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@emmetio/abbreviation/-/abbreviation-2.2.3.tgz",
+      "integrity": "sha512-87pltuCPt99aL+y9xS6GPZ+Wmmyhll2WXH73gG/xpGcQ84DRnptBsI2r0BeIQ0EB/SQTOe2ANPqFqj3Rj5FOGA==",
+      "requires": {
+        "@emmetio/scanner": "^1.0.0"
+      }
+    },
+    "@emmetio/css-abbreviation": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@emmetio/css-abbreviation/-/css-abbreviation-2.1.4.tgz",
+      "integrity": "sha512-qk9L60Y+uRtM5CPbB0y+QNl/1XKE09mSO+AhhSauIfr2YOx/ta3NJw2d8RtCFxgzHeRqFRr8jgyzThbu+MZ4Uw==",
+      "requires": {
+        "@emmetio/scanner": "^1.0.0"
+      }
+    },
+    "@emmetio/scanner": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@emmetio/scanner/-/scanner-1.0.0.tgz",
+      "integrity": "sha512-8HqW8EVqjnCmWXVpqAOZf+EGESdkR27odcMMMGefgKXtar00SoYNSryGv//TELI4T3QFsECo78p+0lmalk/CFA=="
+    },
     "@es-joy/jsdoccomment": {
       "version": "0.20.1",
       "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.20.1.tgz",
@@ -26019,6 +26082,7 @@
         "@netlify/functions": "^0.10.0",
         "@studiometa/js-toolkit": "^2.9.0",
         "@studiometa/webpack-config": "^4.2.0-alpha.3",
+        "emmet-monaco-es": "*",
         "fflate": "^0.7.4",
         "monaco-editor": "^0.34.1",
         "monaco-editor-webpack-plugin": "^7.0.1",
@@ -29138,6 +29202,23 @@
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz",
       "integrity": "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ=="
+    },
+    "emmet": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/emmet/-/emmet-2.3.6.tgz",
+      "integrity": "sha512-pLS4PBPDdxuUAmw7Me7+TcHbykTsBKN/S9XJbUOMFQrNv9MoshzyMFK/R57JBm94/6HSL4vHnDeEmxlC82NQ4A==",
+      "requires": {
+        "@emmetio/abbreviation": "^2.2.3",
+        "@emmetio/css-abbreviation": "^2.1.4"
+      }
+    },
+    "emmet-monaco-es": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/emmet-monaco-es/-/emmet-monaco-es-5.1.2.tgz",
+      "integrity": "sha512-P+GwbRfzCAN9socNCLj7hdlmjV1J535wYZX9uoXERRGbbfkzcmfz4i43ClDecqCVt6IsbP0RK8AgX370ClMcJA==",
+      "requires": {
+        "emmet": "^2.3.6"
+      }
     },
     "emoji-regex": {
       "version": "8.0.0",

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@studiometa/js-toolkit": "^2.9.0",
+    "emmet-monaco-es": "^5.1.2",
     "fflate": "^0.7.4",
     "monaco-editor": "^0.34.1"
   },

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -1,5 +1,7 @@
 {
   "name": "@studiometa/ui-playground",
+  "version": "0.2.27",
+  "private": true,
   "scripts": {
     "dev": "meta dev",
     "watch": "meta watch",
@@ -16,6 +18,5 @@
     "emmet-monaco-es": "^5.1.2",
     "fflate": "^0.7.4",
     "monaco-editor": "^0.34.1"
-  },
-  "version": "0.0.1"
+  }
 }

--- a/packages/playground/src/js/components/Editor.ts
+++ b/packages/playground/src/js/components/Editor.ts
@@ -40,7 +40,12 @@ export default class Editor extends Base<EditorProps> {
   }
 
   async mounted() {
-    const monaco = await import('monaco-editor/esm/vs/editor/editor.api.js');
+    const [{ addTwigAutocompletion }, { addJsAutocompletion }, monaco] = await Promise.all([
+      import('../utils/twig/index.js'),
+      import('../utils/js/index.js'),
+      import('monaco-editor/esm/vs/editor/editor.api.js'),
+    ]);
+
     this.editor = monaco.editor.create(this.$el, {
       value: this.initialValue,
       language: this.language,
@@ -53,8 +58,10 @@ export default class Editor extends Base<EditorProps> {
       theme: themeIsDark() ? 'vs-dark' : 'vs',
     });
 
-    const disposeHTML = emmetHTML(monaco);
-    const disposeCSS = emmetCSS(monaco);
+    const disposeHTML = emmetHTML(monaco, ['html', 'twig']);
+    const disposeCSS = emmetCSS(monaco, ['css', 'html', 'twig']);
+    addTwigAutocompletion(monaco.languages);
+    addJsAutocompletion(monaco.languages);
 
     this.$on(
       'destroyed',

--- a/packages/playground/src/js/components/Editor.ts
+++ b/packages/playground/src/js/components/Editor.ts
@@ -2,6 +2,7 @@ import { Base } from '@studiometa/js-toolkit';
 import type { BaseConfig, BaseProps } from '@studiometa/js-toolkit';
 import { debounce, domScheduler } from '@studiometa/js-toolkit/utils';
 import type { editor } from 'monaco-editor/esm/vs/editor/editor.api.js';
+import { emmetHTML, emmetCSS } from 'emmet-monaco-es';
 import { themeIsDark, watchTheme } from '../store/index.js';
 
 export type EditorProps = BaseProps;
@@ -39,8 +40,8 @@ export default class Editor extends Base<EditorProps> {
   }
 
   async mounted() {
-    const { editor } = await import('monaco-editor/esm/vs/editor/editor.api.js');
-    this.editor = editor.create(this.$el, {
+    const monaco = await import('monaco-editor/esm/vs/editor/editor.api.js');
+    this.editor = monaco.editor.create(this.$el, {
       value: this.initialValue,
       language: this.language,
       minimap: { enabled: false },
@@ -51,6 +52,18 @@ export default class Editor extends Base<EditorProps> {
       tabSize: 2,
       theme: themeIsDark() ? 'vs-dark' : 'vs',
     });
+
+    const disposeHTML = emmetHTML(monaco);
+    const disposeCSS = emmetCSS(monaco);
+
+    this.$on(
+      'destroyed',
+      () => {
+        disposeHTML();
+        disposeCSS();
+      },
+      { once: true },
+    );
 
     watchTheme(() => {
       this.editor.updateOptions({

--- a/packages/playground/src/js/components/Iframe.ts
+++ b/packages/playground/src/js/components/Iframe.ts
@@ -43,6 +43,7 @@ export default class Iframe extends Base<IframeProps> {
 <body>
   ${rendered}
 </body>`;
+    await this.initImportMaps();
 
     // Add Tailwind CDN
     await this.initTailwind();
@@ -63,6 +64,17 @@ export default class Iframe extends Base<IframeProps> {
     await this.updateScript(false);
 
     this.$el.classList.remove('opacity-0');
+  }
+
+  initImportMaps() {
+    const importMap = this.doc.createElement('script');
+    importMap.type = 'importmap';
+    importMap.textContent = JSON.stringify({
+      imports: {
+        '@studiometa/': 'https://cdn.skypack.dev/@studiometa/',
+      },
+    });
+    this.doc.head.append(importMap);
   }
 
   initTailwind(): Promise<void> {

--- a/packages/playground/src/js/store/content.ts
+++ b/packages/playground/src/js/store/content.ts
@@ -18,8 +18,8 @@ const store = new URLSearchParams(location.search || location.hash.slice(1));
 const storeSetter = store.set.bind(store);
 const storeGetter = store.get.bind(store);
 
-store.get = (key) => {
-  return store.has(key) ? unzip(storeGetter(key)) : '';
+store.get = (key): string | null => {
+  return store.has(key) ? unzip(storeGetter(key)) : null;
 };
 
 store.set = (key, value) => {
@@ -29,7 +29,7 @@ store.set = (key, value) => {
 
 export function getScript() {
   return (
-    store.get('script') ||
+    store.get('script') ??
     `import { Base, createApp } from 'https://cdn.skypack.dev/@studiometa/js-toolkit';
 
 class App extends Base {
@@ -49,7 +49,7 @@ export function setScript(value) {
 
 export function getHtml() {
   return (
-    store.get('html') ||
+    store.get('html') ??
     `{% html_element 'div' with { class: 'p-10' } %}
 	Hello world!
 {% end_html_element %}`

--- a/packages/playground/src/js/store/content.ts
+++ b/packages/playground/src/js/store/content.ts
@@ -30,12 +30,13 @@ store.set = (key, value) => {
 export function getScript() {
   return (
     store.get('script') ??
-    `import { Base, createApp } from 'https://cdn.skypack.dev/@studiometa/js-toolkit';
+    `import { Base, createApp } from '@studiometa/js-toolkit';
+// import {  } from '@studiometa/ui';
 
 class App extends Base {
-	static config = {
-		name: 'App',
-	};
+  static config = {
+    name: 'App',
+  };
 }
 
 createApp(App)
@@ -51,7 +52,7 @@ export function getHtml() {
   return (
     store.get('html') ??
     `{% html_element 'div' with { class: 'p-10' } %}
-	Hello world!
+  Hello world!
 {% end_html_element %}`
   );
 }

--- a/packages/playground/src/js/utils/js/index.ts
+++ b/packages/playground/src/js/utils/js/index.ts
@@ -1,0 +1,37 @@
+import type { languages as Languages } from 'monaco-editor/esm/vs/editor/editor.api.js';
+import snippets from './snippets.json';
+
+interface Range {
+  startLineNumber: number;
+  endLineNumber: number;
+  startColumn: number;
+  endColumn: number;
+}
+
+function createDependencyProposals(range: Range, languages: typeof Languages) {
+  return Object.values(snippets).map((snippet) => ({
+    label: snippet.prefix,
+    kind: languages.CompletionItemKind.Function,
+    documentation: snippet.description,
+    insertText: snippet.body,
+    insertTextRules: languages.CompletionItemInsertTextRule.InsertAsSnippet,
+    range,
+  }));
+}
+
+export function addJsAutocompletion(languages: typeof Languages) {
+  languages.registerCompletionItemProvider('javascript', {
+    provideCompletionItems(model, position) {
+      const word = model.getWordUntilPosition(position);
+      const range: Range = {
+        startLineNumber: position.lineNumber,
+        endLineNumber: position.lineNumber,
+        startColumn: word.startColumn,
+        endColumn: word.endColumn,
+      };
+      return {
+        suggestions: createDependencyProposals(range, languages),
+      };
+    },
+  });
+}

--- a/packages/playground/src/js/utils/js/snippets.json
+++ b/packages/playground/src/js/utils/js/snippets.json
@@ -1,0 +1,8 @@
+{
+  "base": {
+    "prefix": "base.",
+    "body": "class ${1:Component} extends Base {\n\tstatic config = {\n\t\tname: '${1:Component}',${2}\n\t};\n}\n",
+    "description": "Base class",
+    "scope": "source.js"
+  }
+}

--- a/packages/playground/src/js/utils/twig/index.ts
+++ b/packages/playground/src/js/utils/twig/index.ts
@@ -1,0 +1,37 @@
+import type { languages as Languages } from 'monaco-editor/esm/vs/editor/editor.api.js';
+import snippets from './snippets.json';
+
+interface Range {
+  startLineNumber: number;
+  endLineNumber: number;
+  startColumn: number;
+  endColumn: number;
+}
+
+function createDependencyProposals(range: Range, languages: typeof Languages) {
+  return Object.values(snippets).map((snippet) => ({
+    label: snippet.prefix,
+    kind: languages.CompletionItemKind.Function,
+    documentation: snippet.description,
+    insertText: snippet.body,
+    insertTextRules: languages.CompletionItemInsertTextRule.InsertAsSnippet,
+    range,
+  }));
+}
+
+export function addTwigAutocompletion(languages: typeof Languages) {
+  languages.registerCompletionItemProvider('twig', {
+    provideCompletionItems(model, position) {
+      const word = model.getWordUntilPosition(position);
+      const range: Range = {
+        startLineNumber: position.lineNumber,
+        endLineNumber: position.lineNumber,
+        startColumn: word.startColumn,
+        endColumn: word.endColumn,
+      };
+      return {
+        suggestions: createDependencyProposals(range, languages),
+      };
+    },
+  });
+}

--- a/packages/playground/src/js/utils/twig/snippets.json
+++ b/packages/playground/src/js/utils/twig/snippets.json
@@ -1,7 +1,13 @@
 {
   "html_element": {
-    "prefix": "el",
+    "prefix": "html_element",
     "body": "{% html_element '${1:tag}' %}\n\t$0\n{% end_html_element %}",
+    "description": "html_element",
+    "scope": "text.html.twig"
+  },
+  "html_elementw": {
+    "prefix": "html_elementw",
+    "body": "{% html_element '${1:tag}' with ${2:{\\}} %}\n\t$0\n{% end_html_element %}",
     "description": "html_element",
     "scope": "text.html.twig"
   },

--- a/packages/playground/src/js/utils/twig/snippets.json
+++ b/packages/playground/src/js/utils/twig/snippets.json
@@ -1,0 +1,311 @@
+{
+  "html_element": {
+    "prefix": "el",
+    "body": "{% html_element '${1:tag}' %}\n\t$0\n{% end_html_element %}",
+    "description": "html_element",
+    "scope": "text.html.twig"
+  },
+  "autoescape": {
+    "prefix": "autoescape",
+    "body": "{% autoescape '${1:type}' %}\n\t$0\n{% endautoescape %}",
+    "description": "autoescape",
+    "scope": "text.html.twig"
+  },
+  "blockb": {
+    "prefix": "blockb",
+    "body": "{% block ${1:name} %}\n\t$0\n{% endblock %}",
+    "description": "block (block)",
+    "scope": "text.html.twig"
+  },
+  "block": {
+    "prefix": "block",
+    "body": "{% block ${1:name} %}$0{% endblock %}",
+    "description": "block",
+    "scope": "text.html.twig"
+  },
+  "blockf": {
+    "prefix": "blockf",
+    "body": "{{ block('${1:name}') }}$0",
+    "description": "blockf",
+    "scope": "text.html.twig"
+  },
+  "case": {
+    "prefix": "case",
+    "body": "{% case '${1:value}' %}\n\t$0",
+    "description": "case",
+    "scope": "text.html.twig"
+  },
+  "replace": {
+    "prefix": "replace",
+    "body": "{{ ${1:$TM_SELECTED_TEXT} | replace('search', 'replace') }}$0",
+    "description": "replace with | replace('search', 'replace')"
+  },
+  "replacex": {
+    "prefix": "replacex",
+    "body": "{{ ${1:$TM_SELECTED_TEXT} | replace('/(search)/i', 'replace') }}$0",
+    "description": "replace regex with | replace('/(search)/i', 'replace')"
+  },
+  "split": {
+    "prefix": "split",
+    "body": "{{ ${1:$TM_SELECTED_TEXT} | split('\\n') }}$0",
+    "description": "split on | split ('\\n')"
+  },
+  "dd": {
+    "prefix": "dd",
+    "body": "<pre>\n\t{{ dump($1) }}\n</pre>\n{% exit %}$0",
+    "description": "dump and die",
+    "scope": "text.html.twig"
+  },
+  "do": {
+    "prefix": "do",
+    "body": "{% do $1 %}$0",
+    "description": "do",
+    "scope": "text.html.twig"
+  },
+  "dump": {
+    "prefix": "dump",
+    "body": "<pre>\n\t{{ dump($1) }}\n</pre>",
+    "description": "dump",
+    "scope": "text.html.twig"
+  },
+  "else": {
+    "prefix": "else",
+    "body": "{% else %}\n\t$0",
+    "description": "else",
+    "scope": "text.html.twig"
+  },
+  "embed": {
+    "prefix": "embed",
+    "body": "{% embed '${1:template}' %}\n\t$0\n{% endembed %}",
+    "description": "embed",
+    "scope": "text.html.twig"
+  },
+  "endautoescape": {
+    "prefix": "endautoescape",
+    "body": "{% endautoescape %}$0",
+    "description": "endautoescape",
+    "scope": "text.html.twig"
+  },
+  "endblock": {
+    "prefix": "endblock",
+    "body": "{% endblock %}$0",
+    "description": "endblock",
+    "scope": "text.html.twig"
+  },
+  "endembed": {
+    "prefix": "endembed",
+    "body": "{% endembed %}$0",
+    "description": "endembed",
+    "scope": "text.html.twig"
+  },
+  "endfilter": {
+    "prefix": "endfilter",
+    "body": "{% endfilter %}$0",
+    "description": "endfilter",
+    "scope": "text.html.twig"
+  },
+  "endfor": {
+    "prefix": "endfor",
+    "body": "{% endfor %}$0",
+    "description": "endfor",
+    "scope": "text.html.twig"
+  },
+  "endif": {
+    "prefix": "endif",
+    "body": "{% endif %}$0",
+    "description": "endif",
+    "scope": "text.html.twig"
+  },
+  "endmacro": {
+    "prefix": "endmacro",
+    "body": "{% endmacro %}$0",
+    "description": "endmacro",
+    "scope": "text.html.twig"
+  },
+  "endset": {
+    "prefix": "endset",
+    "body": "{% endset %}$0",
+    "description": "endset",
+    "scope": "text.html.twig"
+  },
+  "endspaceless": {
+    "prefix": "endspaceless",
+    "body": "{% endspaceless %}$0",
+    "description": "endspaceless",
+    "scope": "text.html.twig"
+  },
+  "endswitch": {
+    "prefix": "endswitch",
+    "body": "{% endswitch %}$0",
+    "description": "endswitch",
+    "scope": "text.html.twig"
+  },
+  "endverbatim": {
+    "prefix": "endverbatim",
+    "body": "{% endverbatim %}$0",
+    "description": "endverbatim",
+    "scope": "text.html.twig"
+  },
+  "extends": {
+    "prefix": "extends",
+    "body": "{% extends '${1:template}' %}$0",
+    "description": "extends",
+    "scope": "text.html.twig"
+  },
+  "fore": {
+    "prefix": "fore",
+    "body": "{% for ${1:item} in ${2:items} %}\n\t$3\n{% else %}\n\t$0\n{% endfor %}",
+    "description": "for ... else",
+    "scope": "text.html.twig"
+  },
+  "for": {
+    "prefix": "for",
+    "body": "{% for ${1:item} in ${2:items} %}\n\t$0\n{% endfor %}",
+    "description": "for",
+    "scope": "text.html.twig"
+  },
+  "from": {
+    "prefix": "from",
+    "body": "{% from '${1:template}' import '${2:macro}' %}$0",
+    "description": "from",
+    "scope": "text.html.twig"
+  },
+  "endbody": {
+    "prefix": "endbody",
+    "body": "{{ endBody() }}\n$0",
+    "description": "endBody",
+    "scope": "text.html.twig"
+  },
+  "if": {
+    "prefix": "if",
+    "body": "{% if ${1:condition} %}$2{% endif %}\n$0",
+    "description": "if",
+    "scope": "text.html.twig"
+  },
+  "ifb": {
+    "prefix": "ifb",
+    "body": "{% if ${1:condition} %}\n\t$0\n{% endif %}",
+    "description": "if (block)",
+    "scope": "text.html.twig"
+  },
+  "ife": {
+    "prefix": "ife",
+    "body": "{% if ${1:condition} %}\n\t$2\n{% else %}\n\t$0\n{% endif %}",
+    "description": "if ... else",
+    "scope": "text.html.twig"
+  },
+  "if1": {
+    "prefix": "if",
+    "body": "{% if ${1:condition} %}$0{% endif %}",
+    "description": "if",
+    "scope": "text.html.twig"
+  },
+  "import": {
+    "prefix": "import",
+    "body": "{% import '${1:template}' as ${2:name} %}$0",
+    "description": "import",
+    "scope": "text.html.twig"
+  },
+  "importself": {
+    "prefix": "importself",
+    "body": "{% import _self as ${1:name} %}$0",
+    "description": "importself",
+    "scope": "text.html.twig"
+  },
+  "inckv": {
+    "prefix": "inckv",
+    "body": "{% include '${1:template}' with {\n\t${2:key}: ${3:'${4:value}'}\n} %}\n$0",
+    "description": "include w/ key/value",
+    "scope": "text.html.twig"
+  },
+  "include": {
+    "prefix": "include",
+    "body": "{% include '${1:template}' %}$0",
+    "description": "include",
+    "scope": "text.html.twig"
+  },
+  "inc": {
+    "prefix": "inc",
+    "body": "{% include '${1:template}' %}$0",
+    "description": "inc",
+    "scope": "text.html.twig"
+  },
+  "incp": {
+    "prefix": "incp",
+    "body": "{% include '${1:template}'${2: with ${3:params} }%}$0",
+    "description": "include w/ params",
+    "scope": "text.html.twig"
+  },
+  "macro": {
+    "prefix": "macro",
+    "body": "{% macro ${1:name}(${2:params}) %}\n\t$0\n{% endmacro %}",
+    "description": "macro",
+    "scope": "text.html.twig"
+  },
+  "max": {
+    "prefix": "max",
+    "body": "max(${1:$2, $3})$0",
+    "description": "max",
+    "scope": "text.html.twig"
+  },
+  "min": {
+    "prefix": "min",
+    "body": "min(${1:$2, $3})$0",
+    "description": "min",
+    "scope": "text.html.twig"
+  },
+  "round": {
+    "prefix": "round",
+    "body": "{{ $1 | round(1, 'floor') }}$0",
+    "description": "round",
+    "scope": "text.html.twig"
+  },
+  "setb": {
+    "prefix": "setb",
+    "body": "{% set ${1:var} %}\n\t$0\n{% endset %}",
+    "description": "set (block)",
+    "scope": "text.html.twig"
+  },
+  "set": {
+    "prefix": "set",
+    "body": "{% set ${1:var} = ${2:value} %}$0",
+    "description": "set",
+    "scope": "text.html.twig"
+  },
+  "shuffle": {
+    "prefix": "shuffle",
+    "body": "shuffle($1)$0",
+    "description": "shuffle",
+    "scope": "text.html.twig"
+  },
+  "random": {
+    "prefix": "random",
+    "body": "random($1)$0",
+    "description": "random",
+    "scope": "text.html.twig"
+  },
+  "spaceless": {
+    "prefix": "spaceless",
+    "body": "{% spaceless %}\n\t$0\n{% endspaceless %}",
+    "description": "spaceless",
+    "scope": "text.html.twig"
+  },
+  "switch": {
+    "prefix": "switch",
+    "body": "{% switch ${1:variable} %}\n\n\t{% case '${2:value1}' %}\n\t\n\n\t{% case '${3:value2}' %}\n\t\n\n\t{% default %}\n\t\n\n{% endswitch %}\n$0",
+    "description": "switch",
+    "scope": "text.html.twig"
+  },
+  "use": {
+    "prefix": "use",
+    "body": "{% use '${1:template}' %}$0",
+    "description": "use",
+    "scope": "text.html.twig"
+  },
+  "verbatim": {
+    "prefix": "verbatim",
+    "body": "{% verbatim %}\n\t$0\n{% endverbatim %}",
+    "description": "verbatim",
+    "scope": "text.html.twig"
+  }
+}

--- a/packages/playground/src/js/utils/twigRender.ts
+++ b/packages/playground/src/js/utils/twigRender.ts
@@ -15,7 +15,7 @@ export async function twigRender(content: string) {
 
   // Return cached response early
   if (cache.has(content)) {
-    return cache.get(content);
+    return cache.get(content) ?? 'Failed to get cached response.';
   }
 
   controller = new AbortController();

--- a/packages/playground/src/templates/pages/index.ts
+++ b/packages/playground/src/templates/pages/index.ts
@@ -1,0 +1,5 @@
+export async function data() {
+  return {
+    version: process.env.npm_package_version,
+  };
+}

--- a/packages/playground/src/templates/pages/index.twig
+++ b/packages/playground/src/templates/pages/index.twig
@@ -36,8 +36,12 @@
   <body class="fixed inset-0 group dark:bg-zinc-900 dark:text-white">
     <main class="fixed top-0 left-0 w-full h-full">
       <div class="z-10 absolute top-0 flex items-center gap-8 w-full p-4 leading-4 bg-zinc-100 dark:bg-zinc-800 text-sm dark:text-zinc-100 dark:border-b-zinc-700">
-        <span class="font-bold">UI Playground</span>
-
+        <div class="flex items-center gap-4">
+          <span class="font-bold">UI Playground</span>
+          <span class="py-1 px-2 rounded bg-zinc-200 dark:bg-zinc-900 dark:bg-opacity-50">
+            <span class="text-xs">v{{ version }}</span>
+          </span>
+        </div>
         <div class="flex items-center gap-4">
           {% include '@components/Checkbox.twig' with {
             label: 'HTML',

--- a/packages/playground/src/templates/pages/index.twig
+++ b/packages/playground/src/templates/pages/index.twig
@@ -35,14 +35,17 @@
   </head>
   <body class="fixed inset-0 group dark:bg-zinc-900 dark:text-white">
     <main class="fixed top-0 left-0 w-full h-full">
-      <div class="z-10 absolute top-0 flex items-center gap-8 w-full p-4 leading-4 bg-zinc-100 dark:bg-zinc-800 text-sm dark:text-zinc-100 dark:border-b-zinc-700">
-        <div class="flex items-center gap-4">
-          <span class="font-bold">UI Playground</span>
+      <div class="z-10 absolute top-0 flex items-center gap-4 sm:gap-8 w-full h-12 p-4  leading-4 bg-zinc-100 dark:bg-zinc-800 text-sm dark:text-zinc-100 dark:border-b-zinc-700">
+        <div class="flex items-center gap-2 sm:gap-4">
+          <span class="font-bold">
+            UI
+            <span class="hidden md:inline">Playground</span>
+          </span>
           <span class="py-1 px-2 rounded bg-zinc-200 dark:bg-zinc-900 dark:bg-opacity-50">
             <span class="text-xs">v{{ version }}</span>
           </span>
         </div>
-        <div class="flex items-center gap-4">
+        <div class="flex items-center gap-3 sm:gap-4">
           {% include '@components/Checkbox.twig' with {
             label: 'HTML',
             attr: {
@@ -69,8 +72,8 @@
           } %}
         </div>
 
-        <div data-component="LayoutSwitcher" class="flex items-center gap-4">
-          Layout
+        <div data-component="LayoutSwitcher" class="flex items-center gap-2 sm:gap-4">
+          <div class="hidden md:block">Layout</div>
           {% include '@components/RadioGroup.twig' with {
             items: [
               {
@@ -101,8 +104,8 @@
           } %}
         </div>
 
-        <div data-component="ThemeSwitcher" class="flex gap-4">
-          Theme
+        <div data-component="ThemeSwitcher" class="flex gap-2 sm:gap-4">
+          <div class="hidden md:block">Theme</div>
           {% include '@components/RadioGroup.twig' with {
             items: [
               {

--- a/packages/playground/tailwind.config.cjs
+++ b/packages/playground/tailwind.config.cjs
@@ -1,25 +1,25 @@
 module.exports = {
-	darkMode: 'class',
-	content: [
-		'./src/js/**/*.ts',
-		'./src/js/**/*.vue',
-		'./src/templates/**/*.twig',
-		'./src/templates/**/*.yml',
-		'./node_modules/@studiometa/ui/**/*.twig',
-		'./node_modules/@studiometa/ui/**/*.js',
-		'tailwind.safelist.txt',
-	],
-	theme: {
-		extend: {
-			keyframes: {
-				loader: {
-					'0%': { transform: 'rotate(0)' },
-					'100%': { transform: 'rotate(720deg)' },
-				},
-			},
-			animation: {
-				loader: 'loader 1s ease-in-out infinite',
-			}
-		},
-	},
+  darkMode: 'class',
+  content: [
+    './src/js/**/*.ts',
+    './src/js/**/*.vue',
+    './src/templates/**/*.twig',
+    './src/templates/**/*.yml',
+    './node_modules/@studiometa/ui/**/*.twig',
+    './node_modules/@studiometa/ui/**/*.js',
+    'tailwind.safelist.txt',
+  ],
+  theme: {
+    extend: {
+      keyframes: {
+        loader: {
+          '0%': { transform: 'rotate(0)' },
+          '100%': { transform: 'rotate(720deg)' },
+        },
+      },
+      animation: {
+        loader: 'loader 1s ease-in-out infinite',
+      }
+    },
+  },
 };

--- a/packages/playground/tsconfig.json
+++ b/packages/playground/tsconfig.json
@@ -16,7 +16,8 @@
     "noEmit": true,
     "noImplicitThis": true,
     "esModuleInterop": true,
-    "moduleResolution": "node"
+    "moduleResolution": "node",
+    "resolveJsonModule": true
   },
   "include": [
     "src/js/**/*.ts"

--- a/patches/monaco-editor+0.34.1.patch
+++ b/patches/monaco-editor+0.34.1.patch
@@ -1,0 +1,587 @@
+diff --git a/node_modules/monaco-editor/esm/vs/basic-languages/twig/twig.js b/node_modules/monaco-editor/esm/vs/basic-languages/twig/twig.js
+index c57d900..1ec068b 100644
+--- a/node_modules/monaco-editor/esm/vs/basic-languages/twig/twig.js
++++ b/node_modules/monaco-editor/esm/vs/basic-languages/twig/twig.js
+@@ -5,322 +5,392 @@
+  * https://github.com/microsoft/monaco-editor/blob/main/LICENSE.txt
+  *-----------------------------------------------------------------------------*/
+ 
++import * as monaco_editor_core_star from '../../editor/editor.api.js';
++
++const __defProp = Object.defineProperty;
++const __getOwnPropDesc = Object.getOwnPropertyDescriptor;
++const __getOwnPropNames = Object.getOwnPropertyNames;
++const __hasOwnProp = Object.prototype.hasOwnProperty;
++const __copyProps = (to, from, except, desc) => {
++  if ((from && typeof from === 'object') || typeof from === 'function') {
++    for (const key of __getOwnPropNames(from))
++      if (!__hasOwnProp.call(to, key) && key !== except)
++        __defProp(to, key, {
++          get: () => from[key],
++          enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable,
++        });
++  }
++  return to;
++};
++const __reExport = (target, mod, secondTarget) => (
++  __copyProps(target, mod, 'default'), secondTarget && __copyProps(secondTarget, mod, 'default')
++);
++
++// src/fillers/monaco-editor-core.ts
++const monaco_editor_core_exports = {};
++__reExport(monaco_editor_core_exports, monaco_editor_core_star);
++
++const EMPTY_ELEMENTS = [
++  'area',
++  'base',
++  'br',
++  'col',
++  'embed',
++  'hr',
++  'img',
++  'input',
++  'keygen',
++  'link',
++  'menuitem',
++  'meta',
++  'param',
++  'source',
++  'track',
++  'wbr',
++];
++
+ // src/basic-languages/twig/twig.ts
+-var conf = {
++const conf = {
+   wordPattern: /(-?\d*\.\d\w*)|([^\`\~\!\@\$\^\&\*\(\)\=\+\[\{\]\}\\\|\;\:\'\"\,\.\<\>\/\s]+)/g,
+   comments: {
+-    blockComment: ["{#", "#}"]
++    blockComment: ['{#', '#}'],
+   },
+   brackets: [
+-    ["{#", "#}"],
+-    ["{%", "%}"],
+-    ["{{", "}}"],
+-    ["(", ")"],
+-    ["[", "]"],
+-    ["<!--", "-->"],
+-    ["<", ">"]
++    ['{#', '#}'],
++    ['{%', '%}'],
++    ['{{', '}}'],
++    ['(', ')'],
++    ['[', ']'],
++    ['<!--', '-->'],
++    ['<', '>'],
+   ],
+   autoClosingPairs: [
+-    { open: "{# ", close: " #}" },
+-    { open: "{% ", close: " %}" },
+-    { open: "{{ ", close: " }}" },
+-    { open: "[", close: "]" },
+-    { open: "(", close: ")" },
++    { open: '{# ', close: ' #}' },
++    { open: '{% ', close: ' %}' },
++    { open: '{{ ', close: ' }}' },
++    { open: '[', close: ']' },
++    { open: '(', close: ')' },
+     { open: '"', close: '"' },
+-    { open: "'", close: "'" }
++    { open: "'", close: "'" },
+   ],
+   surroundingPairs: [
+     { open: '"', close: '"' },
+     { open: "'", close: "'" },
+-    { open: "<", close: ">" }
+-  ]
++    { open: '<', close: '>' },
++  ],
++  onEnterRules: [
++    {
++      beforeText: /\s%}[^{%]*$/,
++      afterText: /^{%\s/,
++      action: {
++        indentAction: monaco_editor_core_exports.languages.IndentAction.IndentOutdent,
++      },
++    },
++    {
++      beforeText: /\s%}[^{%]*$/,
++      action: {
++        indentAction: monaco_editor_core_exports.languages.IndentAction.Indent,
++      },
++    },
++    {
++      beforeText: new RegExp(
++        `<(?!(?:${EMPTY_ELEMENTS.join('|')}))([_:\\w][_:\\w-.\\d]*)([^/>]*(?!/)>)[^<]*$`,
++        'i',
++      ),
++      afterText: /^<\/([_:\w][_:\w-.\d]*)\s*>$/i,
++      action: {
++        indentAction: monaco_editor_core_exports.languages.IndentAction.IndentOutdent,
++      },
++    },
++    {
++      beforeText: new RegExp(
++        `<(?!(?:${EMPTY_ELEMENTS.join('|')}))(\\w[\\w\\d]*)([^/>]*(?!/)>)[^<]*$`,
++        'i',
++      ),
++      action: { indentAction: monaco_editor_core_exports.languages.IndentAction.Indent },
++    },
++  ],
+ };
+-var language = {
+-  defaultToken: "",
+-  tokenPostfix: "",
++const language = {
++  defaultToken: '',
++  tokenPostfix: '',
+   ignoreCase: true,
+   keywords: [
+-    "apply",
+-    "autoescape",
+-    "block",
+-    "deprecated",
+-    "do",
+-    "embed",
+-    "extends",
+-    "flush",
+-    "for",
+-    "from",
+-    "if",
+-    "import",
+-    "include",
+-    "macro",
+-    "sandbox",
+-    "set",
+-    "use",
+-    "verbatim",
+-    "with",
+-    "endapply",
+-    "endautoescape",
+-    "endblock",
+-    "endembed",
+-    "endfor",
+-    "endif",
+-    "endmacro",
+-    "endsandbox",
+-    "endset",
+-    "endwith",
+-    "true",
+-    "false"
++    'apply',
++    'autoescape',
++    'block',
++    'deprecated',
++    'do',
++    'embed',
++    'extends',
++    'flush',
++    'for',
++    'from',
++    'if',
++    'import',
++    'include',
++    'macro',
++    'sandbox',
++    'set',
++    'use',
++    'verbatim',
++    'with',
++    'endapply',
++    'endautoescape',
++    'endblock',
++    'endembed',
++    'endfor',
++    'endif',
++    'endmacro',
++    'endsandbox',
++    'endset',
++    'endwith',
++    'true',
++    'false',
+   ],
+   tokenizer: {
+     root: [
+       [/\s+/],
+-      [/{#/, "comment.twig", "@commentState"],
+-      [/{%[-~]?/, "delimiter.twig", "@blockState"],
+-      [/{{[-~]?/, "delimiter.twig", "@variableState"],
+-      [/<!DOCTYPE/, "metatag.html", "@doctype"],
+-      [/<!--/, "comment.html", "@comment"],
+-      [/(<)((?:[\w\-]+:)?[\w\-]+)(\s*)(\/>)/, ["delimiter.html", "tag.html", "", "delimiter.html"]],
+-      [/(<)(script)/, ["delimiter.html", { token: "tag.html", next: "@script" }]],
+-      [/(<)(style)/, ["delimiter.html", { token: "tag.html", next: "@style" }]],
+-      [/(<)((?:[\w\-]+:)?[\w\-]+)/, ["delimiter.html", { token: "tag.html", next: "@otherTag" }]],
+-      [/(<\/)((?:[\w\-]+:)?[\w\-]+)/, ["delimiter.html", { token: "tag.html", next: "@otherTag" }]],
+-      [/</, "delimiter.html"],
+-      [/[^<]+/]
++      [/{#/, 'comment.twig', '@commentState'],
++      [/{%[-~]?/, 'delimiter.twig', '@blockState'],
++      [/{{[-~]?/, 'delimiter.twig', '@variableState'],
++      [/<!DOCTYPE/, 'metatag.html', '@doctype'],
++      [/<!--/, 'comment.html', '@comment'],
++      [/(<)((?:[\w\-]+:)?[\w\-]+)(\s*)(\/>)/, ['delimiter.html', 'tag.html', '', 'delimiter.html']],
++      [/(<)(script)/, ['delimiter.html', { token: 'tag.html', next: '@script' }]],
++      [/(<)(style)/, ['delimiter.html', { token: 'tag.html', next: '@style' }]],
++      [/(<)((?:[\w\-]+:)?[\w\-]+)/, ['delimiter.html', { token: 'tag.html', next: '@otherTag' }]],
++      [/(<\/)((?:[\w\-]+:)?[\w\-]+)/, ['delimiter.html', { token: 'tag.html', next: '@otherTag' }]],
++      [/</, 'delimiter.html'],
++      [/[^<]+/],
+     ],
+     commentState: [
+-      [/#}/, "comment.twig", "@pop"],
+-      [/./, "comment.twig"]
++      [/#}/, 'comment.twig', '@pop'],
++      [/./, 'comment.twig'],
+     ],
+     blockState: [
+-      [/[-~]?%}/, "delimiter.twig", "@pop"],
++      [/[-~]?%}/, 'delimiter.twig', '@pop'],
+       [/\s+/],
+       [
+         /(verbatim)(\s*)([-~]?%})/,
+-        ["keyword.twig", "", { token: "delimiter.twig", next: "@rawDataState" }]
++        ['keyword.twig', '', { token: 'delimiter.twig', next: '@rawDataState' }],
+       ],
+-      { include: "expression" }
++      { include: 'expression' },
+     ],
+     rawDataState: [
+       [
+         /({%[-~]?)(\s*)(endverbatim)(\s*)([-~]?%})/,
+-        ["delimiter.twig", "", "keyword.twig", "", { token: "delimiter.twig", next: "@popall" }]
++        ['delimiter.twig', '', 'keyword.twig', '', { token: 'delimiter.twig', next: '@popall' }],
+       ],
+-      [/./, "string.twig"]
++      [/./, 'string.twig'],
+     ],
+-    variableState: [[/[-~]?}}/, "delimiter.twig", "@pop"], { include: "expression" }],
++    variableState: [[/[-~]?}}/, 'delimiter.twig', '@pop'], { include: 'expression' }],
+     stringState: [
+-      [/"/, "string.twig", "@pop"],
+-      [/#{\s*/, "string.twig", "@interpolationState"],
+-      [/[^#"\\]*(?:(?:\\.|#(?!\{))[^#"\\]*)*/, "string.twig"]
+-    ],
+-    interpolationState: [
+-      [/}/, "string.twig", "@pop"],
+-      { include: "expression" }
++      [/"/, 'string.twig', '@pop'],
++      [/#{\s*/, 'string.twig', '@interpolationState'],
++      [/[^#"\\]*(?:(?:\\.|#(?!\{))[^#"\\]*)*/, 'string.twig'],
+     ],
++    interpolationState: [[/}/, 'string.twig', '@pop'], { include: 'expression' }],
+     expression: [
+       [/\s+/],
+-      [/\+|-|\/{1,2}|%|\*{1,2}/, "operators.twig"],
+-      [/(and|or|not|b-and|b-xor|b-or)(\s+)/, ["operators.twig", ""]],
+-      [/==|!=|<|>|>=|<=/, "operators.twig"],
+-      [/(starts with|ends with|matches)(\s+)/, ["operators.twig", ""]],
+-      [/(in)(\s+)/, ["operators.twig", ""]],
+-      [/(is)(\s+)/, ["operators.twig", ""]],
+-      [/\||~|:|\.{1,2}|\?{1,2}/, "operators.twig"],
++      [/\+|-|\/{1,2}|%|\*{1,2}/, 'operators.twig'],
++      [/(and|or|not|b-and|b-xor|b-or)(\s+)/, ['operators.twig', '']],
++      [/==|!=|<|>|>=|<=/, 'operators.twig'],
++      [/(starts with|ends with|matches)(\s+)/, ['operators.twig', '']],
++      [/(in)(\s+)/, ['operators.twig', '']],
++      [/(is)(\s+)/, ['operators.twig', '']],
++      [/\||~|:|\.{1,2}|\?{1,2}/, 'operators.twig'],
+       [
+         /[^\W\d][\w]*/,
+         {
+           cases: {
+-            "@keywords": "keyword.twig",
+-            "@default": "variable.twig"
+-          }
+-        }
++            '@keywords': 'keyword.twig',
++            '@default': 'variable.twig',
++          },
++        },
+       ],
+-      [/\d+(\.\d+)?/, "number.twig"],
+-      [/\(|\)|\[|\]|{|}|,/, "delimiter.twig"],
+-      [/"([^#"\\]*(?:\\.[^#"\\]*)*)"|\'([^\'\\]*(?:\\.[^\'\\]*)*)\'/, "string.twig"],
+-      [/"/, "string.twig", "@stringState"],
+-      [/=>/, "operators.twig"],
+-      [/=/, "operators.twig"]
++      [/\d+(\.\d+)?/, 'number.twig'],
++      [/\(|\)|\[|\]|{|}|,/, 'delimiter.twig'],
++      [/"([^#"\\]*(?:\\.[^#"\\]*)*)"|\'([^\'\\]*(?:\\.[^\'\\]*)*)\'/, 'string.twig'],
++      [/"/, 'string.twig', '@stringState'],
++      [/=>/, 'operators.twig'],
++      [/=/, 'operators.twig'],
+     ],
+     doctype: [
+-      [/[^>]+/, "metatag.content.html"],
+-      [/>/, "metatag.html", "@pop"]
++      [/[^>]+/, 'metatag.content.html'],
++      [/>/, 'metatag.html', '@pop'],
+     ],
+     comment: [
+-      [/-->/, "comment.html", "@pop"],
+-      [/[^-]+/, "comment.content.html"],
+-      [/./, "comment.content.html"]
++      [/-->/, 'comment.html', '@pop'],
++      [/[^-]+/, 'comment.content.html'],
++      [/./, 'comment.content.html'],
+     ],
+     otherTag: [
+-      [/\/?>/, "delimiter.html", "@pop"],
+-      [/"([^"]*)"/, "attribute.value.html"],
+-      [/'([^']*)'/, "attribute.value.html"],
+-      [/[\w\-]+/, "attribute.name.html"],
+-      [/=/, "delimiter.html"],
+-      [/[ \t\r\n]+/]
++      [/\/?>/, 'delimiter.html', '@pop'],
++      [/"([^"]*)"/, 'attribute.value.html'],
++      [/'([^']*)'/, 'attribute.value.html'],
++      [/[\w\-]+/, 'attribute.name.html'],
++      [/=/, 'delimiter.html'],
++      [/[ \t\r\n]+/],
+     ],
+     script: [
+-      [/type/, "attribute.name.html", "@scriptAfterType"],
+-      [/"([^"]*)"/, "attribute.value.html"],
+-      [/'([^']*)'/, "attribute.value.html"],
+-      [/[\w\-]+/, "attribute.name.html"],
+-      [/=/, "delimiter.html"],
++      [/type/, 'attribute.name.html', '@scriptAfterType'],
++      [/"([^"]*)"/, 'attribute.value.html'],
++      [/'([^']*)'/, 'attribute.value.html'],
++      [/[\w\-]+/, 'attribute.name.html'],
++      [/=/, 'delimiter.html'],
+       [
+         />/,
+         {
+-          token: "delimiter.html",
+-          next: "@scriptEmbedded",
+-          nextEmbedded: "text/javascript"
+-        }
++          token: 'delimiter.html',
++          next: '@scriptEmbedded',
++          nextEmbedded: 'text/javascript',
++        },
+       ],
+       [/[ \t\r\n]+/],
+       [
+         /(<\/)(script\s*)(>)/,
+-        ["delimiter.html", "tag.html", { token: "delimiter.html", next: "@pop" }]
+-      ]
++        ['delimiter.html', 'tag.html', { token: 'delimiter.html', next: '@pop' }],
++      ],
+     ],
+     scriptAfterType: [
+-      [/=/, "delimiter.html", "@scriptAfterTypeEquals"],
++      [/=/, 'delimiter.html', '@scriptAfterTypeEquals'],
+       [
+         />/,
+         {
+-          token: "delimiter.html",
+-          next: "@scriptEmbedded",
+-          nextEmbedded: "text/javascript"
+-        }
++          token: 'delimiter.html',
++          next: '@scriptEmbedded',
++          nextEmbedded: 'text/javascript',
++        },
+       ],
+       [/[ \t\r\n]+/],
+-      [/<\/script\s*>/, { token: "@rematch", next: "@pop" }]
++      [/<\/script\s*>/, { token: '@rematch', next: '@pop' }],
+     ],
+     scriptAfterTypeEquals: [
+       [
+         /"([^"]*)"/,
+         {
+-          token: "attribute.value.html",
+-          switchTo: "@scriptWithCustomType.$1"
+-        }
++          token: 'attribute.value.html',
++          switchTo: '@scriptWithCustomType.$1',
++        },
+       ],
+       [
+         /'([^']*)'/,
+         {
+-          token: "attribute.value.html",
+-          switchTo: "@scriptWithCustomType.$1"
+-        }
++          token: 'attribute.value.html',
++          switchTo: '@scriptWithCustomType.$1',
++        },
+       ],
+       [
+         />/,
+         {
+-          token: "delimiter.html",
+-          next: "@scriptEmbedded",
+-          nextEmbedded: "text/javascript"
+-        }
++          token: 'delimiter.html',
++          next: '@scriptEmbedded',
++          nextEmbedded: 'text/javascript',
++        },
+       ],
+       [/[ \t\r\n]+/],
+-      [/<\/script\s*>/, { token: "@rematch", next: "@pop" }]
++      [/<\/script\s*>/, { token: '@rematch', next: '@pop' }],
+     ],
+     scriptWithCustomType: [
+       [
+         />/,
+         {
+-          token: "delimiter.html",
+-          next: "@scriptEmbedded.$S2",
+-          nextEmbedded: "$S2"
+-        }
++          token: 'delimiter.html',
++          next: '@scriptEmbedded.$S2',
++          nextEmbedded: '$S2',
++        },
+       ],
+-      [/"([^"]*)"/, "attribute.value.html"],
+-      [/'([^']*)'/, "attribute.value.html"],
+-      [/[\w\-]+/, "attribute.name.html"],
+-      [/=/, "delimiter.html"],
++      [/"([^"]*)"/, 'attribute.value.html'],
++      [/'([^']*)'/, 'attribute.value.html'],
++      [/[\w\-]+/, 'attribute.name.html'],
++      [/=/, 'delimiter.html'],
+       [/[ \t\r\n]+/],
+-      [/<\/script\s*>/, { token: "@rematch", next: "@pop" }]
++      [/<\/script\s*>/, { token: '@rematch', next: '@pop' }],
+     ],
+     scriptEmbedded: [
+-      [/<\/script/, { token: "@rematch", next: "@pop", nextEmbedded: "@pop" }],
+-      [/[^<]+/, ""]
++      [/<\/script/, { token: '@rematch', next: '@pop', nextEmbedded: '@pop' }],
++      [/[^<]+/, ''],
+     ],
+     style: [
+-      [/type/, "attribute.name.html", "@styleAfterType"],
+-      [/"([^"]*)"/, "attribute.value.html"],
+-      [/'([^']*)'/, "attribute.value.html"],
+-      [/[\w\-]+/, "attribute.name.html"],
+-      [/=/, "delimiter.html"],
++      [/type/, 'attribute.name.html', '@styleAfterType'],
++      [/"([^"]*)"/, 'attribute.value.html'],
++      [/'([^']*)'/, 'attribute.value.html'],
++      [/[\w\-]+/, 'attribute.name.html'],
++      [/=/, 'delimiter.html'],
+       [
+         />/,
+         {
+-          token: "delimiter.html",
+-          next: "@styleEmbedded",
+-          nextEmbedded: "text/css"
+-        }
++          token: 'delimiter.html',
++          next: '@styleEmbedded',
++          nextEmbedded: 'text/css',
++        },
+       ],
+       [/[ \t\r\n]+/],
+       [
+         /(<\/)(style\s*)(>)/,
+-        ["delimiter.html", "tag.html", { token: "delimiter.html", next: "@pop" }]
+-      ]
++        ['delimiter.html', 'tag.html', { token: 'delimiter.html', next: '@pop' }],
++      ],
+     ],
+     styleAfterType: [
+-      [/=/, "delimiter.html", "@styleAfterTypeEquals"],
++      [/=/, 'delimiter.html', '@styleAfterTypeEquals'],
+       [
+         />/,
+         {
+-          token: "delimiter.html",
+-          next: "@styleEmbedded",
+-          nextEmbedded: "text/css"
+-        }
++          token: 'delimiter.html',
++          next: '@styleEmbedded',
++          nextEmbedded: 'text/css',
++        },
+       ],
+       [/[ \t\r\n]+/],
+-      [/<\/style\s*>/, { token: "@rematch", next: "@pop" }]
++      [/<\/style\s*>/, { token: '@rematch', next: '@pop' }],
+     ],
+     styleAfterTypeEquals: [
+       [
+         /"([^"]*)"/,
+         {
+-          token: "attribute.value.html",
+-          switchTo: "@styleWithCustomType.$1"
+-        }
++          token: 'attribute.value.html',
++          switchTo: '@styleWithCustomType.$1',
++        },
+       ],
+       [
+         /'([^']*)'/,
+         {
+-          token: "attribute.value.html",
+-          switchTo: "@styleWithCustomType.$1"
+-        }
++          token: 'attribute.value.html',
++          switchTo: '@styleWithCustomType.$1',
++        },
+       ],
+       [
+         />/,
+         {
+-          token: "delimiter.html",
+-          next: "@styleEmbedded",
+-          nextEmbedded: "text/css"
+-        }
++          token: 'delimiter.html',
++          next: '@styleEmbedded',
++          nextEmbedded: 'text/css',
++        },
+       ],
+       [/[ \t\r\n]+/],
+-      [/<\/style\s*>/, { token: "@rematch", next: "@pop" }]
++      [/<\/style\s*>/, { token: '@rematch', next: '@pop' }],
+     ],
+     styleWithCustomType: [
+       [
+         />/,
+         {
+-          token: "delimiter.html",
+-          next: "@styleEmbedded.$S2",
+-          nextEmbedded: "$S2"
+-        }
++          token: 'delimiter.html',
++          next: '@styleEmbedded.$S2',
++          nextEmbedded: '$S2',
++        },
+       ],
+-      [/"([^"]*)"/, "attribute.value.html"],
+-      [/'([^']*)'/, "attribute.value.html"],
+-      [/[\w\-]+/, "attribute.name.html"],
+-      [/=/, "delimiter.html"],
++      [/"([^"]*)"/, 'attribute.value.html'],
++      [/'([^']*)'/, 'attribute.value.html'],
++      [/[\w\-]+/, 'attribute.name.html'],
++      [/=/, 'delimiter.html'],
+       [/[ \t\r\n]+/],
+-      [/<\/style\s*>/, { token: "@rematch", next: "@pop" }]
++      [/<\/style\s*>/, { token: '@rematch', next: '@pop' }],
+     ],
+     styleEmbedded: [
+-      [/<\/style/, { token: "@rematch", next: "@pop", nextEmbedded: "@pop" }],
+-      [/[^<]+/, ""]
+-    ]
+-  }
+-};
+-export {
+-  conf,
+-  language
++      [/<\/style/, { token: '@rematch', next: '@pop', nextEmbedded: '@pop' }],
++      [/[^<]+/, ''],
++    ],
++  },
+ };
++export { conf, language };


### PR DESCRIPTION
## Changelog

### Added

- **Playground:**
  - add support for Twig and JS snippets autocompletion ([#114](https://github.com/studiometa/ui/pull/114), [54322cb](https://github.com/studiometa/ui/commit/54322cb))
  - add support for Emmet in the HTML editor ([#114](https://github.com/studiometa/ui/pull/114), [883e039](https://github.com/studiometa/ui/commit/883e039))
  - add support for import maps for the `@studiometa/` namespace ([#114](https://github.com/studiometa/ui/pull/114), [25052fd](https://github.com/studiometa/ui/commit/25052fd))

### Fixed

- **Playground:**
  - fix Twig auto-indent not working for HTML elements ([#114](https://github.com/studiometa/ui/pull/114), [de6e560](https://github.com/studiometa/ui/commit/de6e560))
  - fix a bug where HTML content was sometimes `undefined` ([#114](https://github.com/studiometa/ui/pull/114), [f542fb9](https://github.com/studiometa/ui/commit/f542fb9))
  - improve layout on small screens ([#114](https://github.com/studiometa/ui/pull/114), [d178ce8](https://github.com/studiometa/ui/commit/d178ce8))

## To do

- [ ] ~~Add a changelog dedicated to the playground package~~
- [ ] ~~Add a release creation workflow per package~~

<a href="https://gitpod.io/#https://github.com/studiometa/ui/pull/114"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

