### PR TITLE
Fix the adding of the path in FigureTwicpics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix the adding of the path in FigureTwicpics ([#120](https://github.com/studiometa/ui/pull/120), [0821fee](https://github.com/studiometa/ui/commit/0821fee))
+
 ## [v0.2.28](https://github.com/studiometa/ui/compare/0.2.27..0.2.28) (2023-02-08)
 
 ### Added

--- a/packages/ui/atoms/Figure/FigureTwicpics.ts
+++ b/packages/ui/atoms/Figure/FigureTwicpics.ts
@@ -1,5 +1,9 @@
 import type { BaseConfig, BaseProps } from '@studiometa/js-toolkit';
-import { withoutLeadingSlash, withoutTrailingSlash } from '@studiometa/js-toolkit/utils';
+import {
+  withLeadingSlash,
+  withoutLeadingSlash,
+  withoutTrailingSlash,
+} from '@studiometa/js-toolkit/utils';
 import { Figure } from './Figure.js';
 
 export interface FigureTwicpicsProps extends BaseProps {
@@ -81,7 +85,7 @@ export class FigureTwicpics<T extends BaseProps = BaseProps> extends Figure<
     url.host = this.domain;
     url.port = '';
 
-    if (this.path) {
+    if (this.path && !url.pathname.startsWith(withLeadingSlash(this.path))) {
       url.pathname = `/${this.path}${url.pathname}`;
     }
 


### PR DESCRIPTION
### Fixed
- Fix the adding of the path in FigureTwicpics

<a href="https://gitpod.io/#https://github.com/studiometa/ui/pull/120"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

