### PR TITLE
[Bugfix] Always use https for TwicPics URLs

### DIFF
--- a/packages/ui/atoms/Figure/FigureTwicpics.twig
+++ b/packages/ui/atoms/Figure/FigureTwicpics.twig
@@ -28,7 +28,7 @@
   {% set attr = (attr ?? {})|merge({ data_option_transform: formatted_transform }) %}
 {% endif %}
 
-{% set src = twig_toolkit_url(src).withQueryParameter('twic', twic_param) %}
+{% set src = twig_toolkit_url(src).withQueryParameter('twic', twic_param).withScheme('https') %}
 
 {% if twic_domain is defined %}
   {% set src = src.withHost(twic_domain) %}


### PR DESCRIPTION
URLs for TwicPics should always have the `https` scheme. 