### PR TITLE
Feature/accessibility iconimginline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Changed
+- Update `IconImgInline` component to avoid accessibility issues ([#143](https://github.com/studiometa/ui/pull/143))
+
 ## [v0.2.35](https://github.com/studiometa/ui/compare/0.2.34..0.2.35) (2023-07-18)
 
 ### Fixed

--- a/packages/ui/atoms/Icon/IconInlineImg.twig
+++ b/packages/ui/atoms/Icon/IconInlineImg.twig
@@ -42,7 +42,7 @@
   {
     width: '',
     height: '',
-    alt: '',
+    alt: ' ',
   },
   {
     src: 'data:image/svg+xml,%s'|format(svg|url_encode),

--- a/packages/ui/atoms/Icon/IconInlineImg.twig
+++ b/packages/ui/atoms/Icon/IconInlineImg.twig
@@ -43,6 +43,7 @@
     width: '',
     height: '',
     alt: ' ',
+    aria_hidden: 'true'
   },
   {
     src: 'data:image/svg+xml,%s'|format(svg|url_encode),


### PR DESCRIPTION
## Edit IconImgInline component
**Goal: avoid accessibility issues while using the component**
- Edit IconImgInline to always have the alt attribute (empty string attributes are removed by the `merge_html_attributes` function)
- Edit IconImgInline to have aria-hidden=true, since this component is meant to be used for non informative content

Thanks @Guillaume-meta for noticing the issue

<a href="https://gitpod.io/#https://github.com/studiometa/ui/pull/143"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

