### PR TITLE
[Feature] Device Pixel Ratio support for `FigureTwicpics` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Add the **Action** atom ([#161](https://github.com/studiometa/ui/issues/161), [#165](https://github.com/studiometa/ui/pull/165))
 - Add the **CircularMarquee** atom ([#171](https://github.com/studiometa/ui/pull/171))
+- Add the device pixel ratio support for **FigureTwicpics** atom ([#173](https://github.com/studiometa/ui/pull/173))
 
 ## [v0.2.43](https://github.com/studiometa/ui/compare/0.2.42..0.2.43) (2024-02-14)
 

--- a/packages/docs/components/atoms/FigureTwicpics/js-api.md
+++ b/packages/docs/components/atoms/FigureTwicpics/js-api.md
@@ -44,6 +44,13 @@ The step used to round up image size calculation. Default to `50`, which means t
 
 The mode used to resize and crop the image. It can be any key of the [transformations API](https://www.twicpics.com/docs/api/transformations) of TwicPics which accepts a size as value.
 
+### `dpr`
+
+- Type: `boolean`
+- Default: `true`
+
+Use this option to disable the support of the Device Pixel Ratio (DPR) with `data-option-no-dpr` attribute.
+
 ## Getter
 
 ### `domain`

--- a/packages/ui/atoms/Figure/FigureTwicpics.ts
+++ b/packages/ui/atoms/Figure/FigureTwicpics.ts
@@ -27,6 +27,11 @@ function normalizeSize(that: FigureTwicpics, prop: string): number {
 }
 
 /**
+ * Determine if the user agent is a bot or not.
+ */
+const isBot = /bot|crawl|slurp|spider/i.test(navigator.userAgent);
+
+/**
  * Figure class.
  *
  * Manager lazyloading image sources.
@@ -60,17 +65,6 @@ export class FigureTwicpics<T extends BaseProps = BaseProps> extends Figure<
     },
   };
 
-  devicePixelRatio = window.devicePixelRatio;
-
-  constructor() {
-    super();
-
-    // Disable Device Pixel Ratio
-    if (!this.$options.dpr) {
-      this.devicePixelRatio = 1;
-    }
-  }
-
   /**
    * Get the Twicpics path.
    */
@@ -94,6 +88,18 @@ export class FigureTwicpics<T extends BaseProps = BaseProps> extends Figure<
   }
 
   /**
+   * Get the current device pixel ratio
+   * Returns 1 if user agent is considered as a bot.
+   */
+  get devicePixelRatio() {
+    if (!this.$options.dpr) {
+      return 1;
+    }
+
+    return window.devicePixelRatio;
+  }
+
+  /**
    * Format the source for Twicpics.
    */
   formatSrc(src: string): string {
@@ -108,9 +114,9 @@ export class FigureTwicpics<T extends BaseProps = BaseProps> extends Figure<
     let width = normalizeSize(this, 'offsetWidth');
     let height = normalizeSize(this, 'offsetHeight');
 
-    if (!this.isBot) {
-      width *= devicePixelRatio;
-      height *= devicePixelRatio;
+    if (!isBot) {
+      width *= this.devicePixelRatio;
+      height *= this.devicePixelRatio;
     }
 
     url.searchParams.set(
@@ -138,12 +144,5 @@ export class FigureTwicpics<T extends BaseProps = BaseProps> extends Figure<
    */
   onLoad() {
     // Do not terminate on image load as we need.
-  }
-
-  /**
-   * Determine if the user agent is a bot or not.
-   */
-  isBot() {
-    return /bot|crawl|slurp|spider/i.test(navigator.userAgent);
   }
 }

--- a/packages/ui/atoms/Figure/FigureTwicpics.ts
+++ b/packages/ui/atoms/Figure/FigureTwicpics.ts
@@ -90,9 +90,10 @@ export class FigureTwicpics<T extends BaseProps = BaseProps> extends Figure<
   /**
    * Get the current device pixel ratio
    * Returns 1 if user agent is considered as a bot.
+   * Returns 1 if disabled by the `data-option-no-dpr` attribute.
    */
   get devicePixelRatio() {
-    if (!this.$options.dpr) {
+    if (!this.$options.dpr || isBot) {
       return 1;
     }
 
@@ -111,13 +112,8 @@ export class FigureTwicpics<T extends BaseProps = BaseProps> extends Figure<
       url.pathname = `/${this.path}${url.pathname}`;
     }
 
-    let width = normalizeSize(this, 'offsetWidth');
-    let height = normalizeSize(this, 'offsetHeight');
-
-    if (!isBot) {
-      width *= this.devicePixelRatio;
-      height *= this.devicePixelRatio;
-    }
+    const width = normalizeSize(this, 'offsetWidth') * this.devicePixelRatio;
+    const height = normalizeSize(this, 'offsetHeight') * this.devicePixelRatio;
 
     url.searchParams.set(
       'twic',

--- a/packages/ui/atoms/Figure/FigureTwicpics.ts
+++ b/packages/ui/atoms/Figure/FigureTwicpics.ts
@@ -13,6 +13,7 @@ export interface FigureTwicpicsProps extends BaseProps {
     path: string;
     step: number;
     mode: string;
+    dpr: boolean;
   };
 }
 
@@ -52,8 +53,23 @@ export class FigureTwicpics<T extends BaseProps = BaseProps> extends Figure<
         type: String,
         default: 'cover',
       },
+      dpr: {
+        type: Boolean,
+        default: true,
+      },
     },
   };
+
+  devicePixelRatio = window.devicePixelRatio;
+
+  constructor() {
+    super();
+
+    // Disable Device Pixel Ratio
+    if (!this.$options.dpr) {
+      this.devicePixelRatio = 1;
+    }
+  }
 
   /**
    * Get the Twicpics path.
@@ -89,8 +105,13 @@ export class FigureTwicpics<T extends BaseProps = BaseProps> extends Figure<
       url.pathname = `/${this.path}${url.pathname}`;
     }
 
-    const width = normalizeSize(this, 'offsetWidth');
-    const height = normalizeSize(this, 'offsetHeight');
+    let width = normalizeSize(this, 'offsetWidth');
+    let height = normalizeSize(this, 'offsetHeight');
+
+    if (!this.isBot) {
+      width *= devicePixelRatio;
+      height *= devicePixelRatio;
+    }
 
     url.searchParams.set(
       'twic',
@@ -117,5 +138,12 @@ export class FigureTwicpics<T extends BaseProps = BaseProps> extends Figure<
    */
   onLoad() {
     // Do not terminate on image load as we need.
+  }
+
+  /**
+   * Determine if the user agent is a bot or not.
+   */
+  isBot() {
+    return /bot|crawl|slurp|spider/i.test(navigator.userAgent);
   }
 }


### PR DESCRIPTION
### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR adds the support of the device pixel ratio, it will ensure TwicPics is returning a better image resolution for this device thus improving overall user experience.

The device pixel ratio isn't applied if the user agent is considered a bot/crawler to save bandwidth and resources.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [x] I have updated the documentation accordingly.
- [x] I have updated the changelog.
