### PR TITLE
Add disable option for FigureTwicPics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 
 - Add the **MapboxStaticMap** molecule ([#175](https://github.com/studiometa/ui/pull/175))
+- **FigureTwicpics:** add `disable` option ([#176](https://github.com/studiometa/ui/pull/176))
 
 ## [v0.2.44](https://github.com/studiometa/ui/compare/0.2.43..0.2.44) (2024-02-29)
 

--- a/packages/docs/components/atoms/FigureTwicpics/js-api.md
+++ b/packages/docs/components/atoms/FigureTwicpics/js-api.md
@@ -51,6 +51,13 @@ The mode used to resize and crop the image. It can be any key of the [transforma
 
 Use this option to disable the support of the Device Pixel Ratio (DPR) with `data-option-no-dpr` attribute.
 
+### `disable`
+
+- Type: `boolean`
+- Default: `false`
+
+Use this option to return the original src instead of the TwicPics src. Useful when testing in local or preproductions that does not have a TwicPics path configured.
+
 ## Getter
 
 ### `domain`

--- a/packages/ui/atoms/Figure/FigureTwicpics.ts
+++ b/packages/ui/atoms/Figure/FigureTwicpics.ts
@@ -50,6 +50,7 @@ export class FigureTwicpics<T extends BaseProps = BaseProps> extends Figure<
       transform: String,
       domain: String,
       path: String,
+      disable: Boolean,
       step: {
         type: Number,
         default: 50,
@@ -81,10 +82,11 @@ export class FigureTwicpics<T extends BaseProps = BaseProps> extends Figure<
   }
 
   /**
-   * Get formattted original source.
+   * Get formatted original source.
+   * If `disable` option is `true` returns the original src.
    */
   get original() {
-    return this.formatSrc(super.original);
+    return this.$options.disable ? super.original : this.formatSrc(super.original);
   }
 
   /**


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

Closes #125 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Add `disable` option that returns the original src instead of TwicPics's

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [x] I have updated the documentation accordingly.
- [x] I have updated the changelog.
