### PR TITLE
[Feature] AnchroScrollTo: add support for updating the URL hash 

### DIFF
--- a/packages/ui/atoms/AnchorScrollTo/AnchorScrollTo.ts
+++ b/packages/ui/atoms/AnchorScrollTo/AnchorScrollTo.ts
@@ -12,6 +12,9 @@ export interface AnchorScrollToProps extends BaseProps {
 export class AnchorScrollTo<T extends BaseProps = BaseProps> extends Base<AnchorScrollToProps & T> {
   static config: BaseConfig = {
     name: 'AnchorScrollTo',
+    options: {
+      hashCloak: Boolean,
+    },
   };
 
   /**
@@ -27,10 +30,21 @@ export class AnchorScrollTo<T extends BaseProps = BaseProps> extends Base<Anchor
    * @param   {MouseEvent} event
    * @returns {void}
    */
-  onClick(event) {
+  async onClick(event) {
+    const target = document.querySelector(this.targetSelector) as HTMLElement;
+    if (!target) {
+      return;
+    }
+
     try {
-      scrollTo(this.targetSelector);
       event.preventDefault();
+      await scrollTo(target);
+
+      if (this.$options.hashCloak) {
+        return;
+      }
+
+      window.location.hash = this.targetSelector;
     } catch {
       // Silence is golden.
     }


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Add the update of the hash in the url after animation complete and add an option to disable it.

### 📝 Checklist

### Feature todos

- [ ] Use the new Tween api via the [@studiometa/js-toolkit ScrollTo refactor](https://github.com/studiometa/js-toolkit/pull/418) (Waiting for the v3 of the js-toolkit)

### PR todos

- [ ] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the changelog.
