### PR TITLE
[Feature] Add support for `Action` self reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+
+- Add support for targeting self by default ([#290](https://github.com/studiometa/ui/issues/290), [#291](https://github.com/studiometa/ui/pull/291), [2951299](https://github.com/studiometa/ui/commit/2951299))
+- Add support for self reference in the effect ([#290](https://github.com/studiometa/ui/issues/290), [#291](https://github.com/studiometa/ui/pull/291), [0eac076](https://github.com/studiometa/ui/commit/0eac076))
+
 ## [v1.0.0-alpha.5](https://github.com/studiometa/ui/compare/1.0.0-alpha.4..1.0.0-alpha.5) (2024-08-06)
 
 ### Fixed

--- a/packages/docs/.vitepress/config.ts
+++ b/packages/docs/.vitepress/config.ts
@@ -80,7 +80,7 @@ export default defineConfig({
         target: '_blank',
       },
       {
-        text: `v${pkg.version}`,
+        text: `<span class="VPBadge font-bold bg-[var(--vp-button-brand-bg)] text-[var(--vp-button-brand-text)]">v${pkg.version}</span>`,
         items: [{ text: 'Release Notes', link: 'https://github.com/studiometa/ui/releases' }],
       },
     ],

--- a/packages/docs/components/atoms/Action/index.md
+++ b/packages/docs/components/atoms/Action/index.md
@@ -1,14 +1,8 @@
 ---
-outline: deep
+badges: [JS]
 ---
 
-# Action <Badges :texts="badges" />
-
-<script setup>
-  import pkg from '@studiometa/ui/atoms/Action/package.json';
-
-  const badges = [`v${pkg.version}`, 'JS'];
-</script>
+# Action <Badges :texts="$frontmatter.badges" />
 
 The `Action` atom is a component who trigger an action on other components.
 

--- a/packages/docs/components/atoms/Action/js-api.md
+++ b/packages/docs/components/atoms/Action/js-api.md
@@ -33,7 +33,6 @@ Modifiers can be chained with a `.` as separator:
 ### `target`
 
 - Type: `string`
-- Required
 - Available formats:
   - `Name`
   - `Name OtherName`
@@ -53,6 +52,19 @@ class Foo extends Base {
 }
 ```
 :::
+
+#### No target
+
+By not defining the `target` option, the default target will be the current `Action` instance. The following will toggle the `clicked` class on the `<button>` element:
+
+```html
+<button
+  data-component="Action"
+  data-option-effect="target.classList.toggle('clicked')"
+  class="clicked">
+  Click me
+</button>
+```
 
 #### Single target
 
@@ -111,6 +123,7 @@ The `effect` option must be used to define a small piece of JavaScript that will
 - `ctx` (`Record<name, Base>`): the current targeted component in an object with a uniq key being its name set in the static `config.name` property and the value being the component instance
 - `event` (`Event`): the event that triggered the action
 - `target` (`Base`): a direct reference to the current targeted component
+- `action` (`Base`): a direct reference to the current action component
 
 #### Simple effect vs callback effect
 

--- a/packages/docs/tailwind.config.cjs
+++ b/packages/docs/tailwind.config.cjs
@@ -12,7 +12,6 @@ const folders = fs
   .map((item) => path.resolve(ui, item.name));
 
 module.exports = {
-  important: '.story',
   presets: [defaultConfig, tailwindConfig],
   content: [
     ...folders.map((folder) => path.relative(__dirname, path.resolve(folder, '**/*.js'))),

--- a/packages/tests/atoms/Action.spec.ts
+++ b/packages/tests/atoms/Action.spec.ts
@@ -82,6 +82,14 @@ describe('The Action component', () => {
     await reset();
   });
 
+  it('should resolve targets to self if option is not set', async () => {
+    const { action, reset } = await getContext({
+      target: '',
+    });
+    expect(action.targets).toEqual([{ Action: action }]);
+    await reset();
+  })
+
   it('should resolve single target', async () => {
     const { action, foo, reset } = await getContext({
       target: 'Foo',
@@ -136,14 +144,14 @@ describe('The Action component', () => {
     await reset();
   });
 
-  it('should trigger the effect with ctx, target and event parameters', async () => {
+  it('should trigger the effect with ctx, target, event and action parameters', async () => {
     const { action, foo, fooFn, reset } = await getContext({
       target: 'Foo',
-      effect: 'target.fn(ctx, event, target)',
+      effect: 'target.fn(ctx, event, target, action)',
     });
     const event = new Event('click');
     action.$el.dispatchEvent(event);
-    expect(fooFn).toHaveBeenCalledWith(action.targets[0], event, foo);
+    expect(fooFn).toHaveBeenCalledWith(action.targets[0], event, foo, action);
     await reset();
   });
 

--- a/packages/ui/atoms/Action/Action.ts
+++ b/packages/ui/atoms/Action/Action.ts
@@ -53,8 +53,13 @@ export class Action<T extends BaseProps = BaseProps> extends Base<ActionProps & 
     return effectCache.get(effect);
   }
 
-  get targets() {
+  get targets(): Array<Record<string, Base>> {
     const { target } = this.$options;
+
+    if (!target) {
+      return [{ [this.__config.name]: this }];
+    }
+
     const parts = target.split(' ').map((part) => {
       const [, name, , selector] = part.match(TARGET_REGEX) ?? [];
       return [name, selector];

--- a/packages/ui/atoms/Action/Action.ts
+++ b/packages/ui/atoms/Action/Action.ts
@@ -48,7 +48,7 @@ export class Action<T extends BaseProps = BaseProps> extends Base<ActionProps & 
   get effect() {
     const { effect } = this.$options;
     if (!effectCache.has(effect)) {
-      effectCache.set(effect, new Function('ctx', 'event', 'target', `return ${effect}`));
+      effectCache.set(effect, new Function('ctx', 'event', 'target', 'action', `return ${effect}`));
     }
     return effectCache.get(effect);
   }
@@ -93,10 +93,10 @@ export class Action<T extends BaseProps = BaseProps> extends Base<ActionProps & 
 
     for (const target of targets) {
       try {
-        const [name, currentTarget] = Object.entries(target).flat();
-        const value = effect(target, event, currentTarget);
+        const [currentTarget] = Object.values(target).flat();
+        const value = effect(target, event, currentTarget, this);
         if (typeof value === 'function') {
-          value(target, event, currentTarget);
+          value(target, event, currentTarget, this);
         }
       } catch (err) {
         this.$warn(err);


### PR DESCRIPTION
<!---
☝️ PR title should be prefixed by [Feature], [Bugfix], [Release] or [Hotfix]
-->

### 🔗 Linked issue

#290 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR adds support for self reference in the effect of the `Action` component by:

- adding an extra `action` parameter that can be used in the `effect` callback
- defaulting to the current `Action` as target if the `target` option is not defined

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have added tests (if possible).
- [x] I have updated the documentation accordingly.
- [x] I have updated the changelog.
