### PR TITLE
[Bugfix] Fix DataBind multiple inconsistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix inconsistencies with removed DOM elements ([#293](https://github.com/studiometa/ui/issues/293), [#294](https://github.com/studiometa/ui/pull/294), [de945b1](https://github.com/studiometa/ui/commit/de945b1))
+
 ## [v1.0.0-alpha.6](https://github.com/studiometa/ui/compare/1.0.0-alpha.5..1.0.0-alpha.6) (2024-08-27)
 
 ### Added

--- a/packages/tests/__utils__/h.ts
+++ b/packages/tests/__utils__/h.ts
@@ -32,3 +32,18 @@ export function h<T extends keyof HTMLElementTagNameMap = 'div'>(
 
   return el;
 }
+
+/**
+ * Connect the given element to a document instance in order
+ * to set its `isConnected` property to `true`.
+ */
+export function connectElement<T extends Node>(element:T):T {
+  const doc = new Document();
+  doc.append(element);
+  return element;
+}
+
+/**
+ * Create an HTMLElement and connect it to a document.
+ */
+export const hConnected: typeof h = (...args) => connectElement(h(...args));

--- a/packages/tests/atoms/DataComputed.spec.ts
+++ b/packages/tests/atoms/DataComputed.spec.ts
@@ -1,7 +1,7 @@
 import { it, describe, expect, vi } from 'vitest';
 import { Base } from '@studiometa/js-toolkit';
 import { DataComputed } from '@studiometa/ui';
-import { h } from '#test-utils';
+import { hConnected as h, } from '#test-utils';
 
 describe('The DataModel component', () => {
   it('should set the value as the returned value from the compute option', () => {

--- a/packages/tests/atoms/DataEffect.spec.ts
+++ b/packages/tests/atoms/DataEffect.spec.ts
@@ -1,7 +1,7 @@
 import { it, describe, expect, vi } from 'vitest';
 import { Base } from '@studiometa/js-toolkit';
 import { DataEffect } from '@studiometa/ui';
-import { h } from '#test-utils';
+import { hConnected as h } from '#test-utils';
 
 describe('The DataModel component', () => {
   it('should execute the compute option without setting a value', () => {

--- a/packages/tests/atoms/DataModel.spec.ts
+++ b/packages/tests/atoms/DataModel.spec.ts
@@ -1,6 +1,6 @@
 import { it, describe, expect } from 'vitest';
 import { DataModel } from '@studiometa/ui';
-import { h, mount } from '#test-utils';
+import { hConnected as h, mount } from '#test-utils';
 
 function check(input: HTMLInputElement, checked = true) {
   input.checked = checked;

--- a/packages/ui/atoms/Data/DataBind.ts
+++ b/packages/ui/atoms/Data/DataBind.ts
@@ -3,7 +3,7 @@ import type { BaseConfig, BaseProps } from '@studiometa/js-toolkit';
 import { isArray } from '@studiometa/js-toolkit/utils';
 import { isInput, isCheckbox, isSelect } from './utils.js';
 
-const instances = new Map<string, Set<DataBind>>();
+const groups = new Map<string, Set<DataBind>>();
 
 export interface DataBindProps extends BaseProps {
   $options: {
@@ -24,11 +24,15 @@ export class DataBind<T extends BaseProps = BaseProps> extends Base<DataBindProp
   get relatedInstances() {
     const { name } = this.$options;
 
-    if (!instances.has(name)) {
-      instances.set(name, new Set());
+    const instances = groups.get(name) ?? groups.set(name, new Set()).get(name);
+
+    for (const instance of instances) {
+      if (!instance.$el.isConnected) {
+        instances.delete(instance);
+      }
     }
 
-    return instances.get(name);
+    return instances;
   }
 
   get multiple() {


### PR DESCRIPTION
<!---
☝️ PR title should be prefixed by [Feature], [Bugfix], [Release] or [Hotfix]
-->

### 🔗 Linked issue

#293

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR fixes a bug where elements removed from the DOM were still included when computing the value of a multiple `DataBind` group. 

[Playground](https://294-develop-ui.ikko.studio/-/play/#html=eNrlkk1OwzAQhfc9xcgSBCRMqsKOJBKUFRIgwbLqwnGcYuHaVuxUaUvvjn%2BSUkEFB2AT25k3M9%2FzeHsChllYEdEyAznMklqp5AKSkjRx2SRzONmNRlnFV0AFMSZHtWAd%2BA%2BmSsCCaDxBxQjAa%2FzqdmVrrZJQEUucaKmVZNLm6JZaruQL04JQNlXSur8oZMBQXK%2FxBHSHr6Fc4NJx4avxGBrVyopVqOhzgcbkLI2dQvs09Hc7Z6tWTbQFXA7%2BnI8AJ0jJRAR1Jy51a8GuNcsRfWP0vVTdwAQ%2FHNy786OqmPgmUdo7w5IsD8rM5l%2BqwJCj7bbH2u0QpHsIo4kshtgHJZpbIvjGy7I0BCN6umd3HpmsvE0%2FHhfSRahylPiOywr9Dlr0fU5lafRNlupwpbphRwtO3bG1biAB6%2B8bOFT4Ui43Rw%2Bvz0%2BXxjZcLni9Pgvez6O%2BfwyWdRabJSpmc0fUsP853f5hfwKB3yXV&script=eNqVksFOwzAMhu99Ch8mdZNKua%2BaxDaQQGIXxAuExB1hTRw1rgSa9u54abf1UA4c2jrW78%2Bx%2F1oXqGU4wkZFLEC3qBjXIRSwR37xkZXXGOEEdUsO8ofInbHkkNX9V7xjouZgOa%2ByK%2BdRsdpYb4oUbcmFjnE4PdU1au7jHRlsJrmdFV6mGxUjrDVb8m8YGqVxS57RM%2BC3fExMV4ZjBiC3ZKtBk6%2FtHlYpB%2BCVwyXkU4i8EMUpk5fUJOYK8nNXAEedZMx8MVD408bypjKkOydh%2BUHmp7TeY%2Fv8vnutLjzy28bqw7X8D72QxuBz%2BdBq1hJxOeuCESPmix4s6GEfIfx3%2FBDStOdRxSMv3eJykMDkfns13Jwcna9%2BjnKDq6NM8rZPnNKmqzTB5d%2Bay7OofgErIsfu&html-editor=false&script-editor=true&style-editor=false)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
- [x] I have updated the changelog.
