### PR TITLE
[Transition] Add support for grouped transitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 
 - Add a [FigureShopify](https://ui.studiometa.dev/-/components/atoms/FigureShopify/) component ([#303](https://github.com/studiometa/ui/pull/303))
+- **Transition:** add support for grouped transitions ([#305](https://github.com/studiometa/ui/issues/305), [#306](https://github.com/studiometa/ui/pull/306), [be85501](https://github.com/studiometa/ui/commit/be85501))
 
 ## [v1.0.0-alpha.8](https://github.com/studiometa/ui/compare/1.0.0-alpha.7..1.0.0-alpha.8) (2024-09-25)
 

--- a/packages/docs/components/atoms/FigureShopify/examples.md
+++ b/packages/docs/components/atoms/FigureShopify/examples.md
@@ -21,3 +21,11 @@ This example uses a small sized image with a maximum width of 10 pixels with a b
   :html="() => import('./stories/blurred.liquid?raw')"
   :script="() => import('./stories/app.js?raw')"
   />
+
+## Advanced reveal
+
+<PreviewPlayground
+  :html="() => import('./stories/reveal.liquid?raw')"
+  :script="() => import('./stories/reveal.js?raw')"
+  :css="() => import('./stories/reveal.css?raw')"
+  />

--- a/packages/docs/components/atoms/FigureShopify/stories/reveal.css
+++ b/packages/docs/components/atoms/FigureShopify/stories/reveal.css
@@ -1,0 +1,12 @@
+html {
+  background-color: #f1c092;
+}
+
+html.dark {
+  background-color: #a76844;
+  color: #eee;
+}
+
+body {
+  padding: 1rem;
+}

--- a/packages/docs/components/atoms/FigureShopify/stories/reveal.js
+++ b/packages/docs/components/atoms/FigureShopify/stories/reveal.js
@@ -1,0 +1,14 @@
+import { Base, createApp } from '@studiometa/js-toolkit';
+import { FigureShopify, Transition } from '@studiometa/ui';
+
+class App extends Base {
+  static config = {
+    name: 'App',
+    components: {
+      Figure: FigureShopify,
+      Transition,
+    },
+  };
+}
+
+export default createApp(App, document.body);

--- a/packages/docs/components/atoms/FigureShopify/stories/reveal.liquid
+++ b/packages/docs/components/atoms/FigureShopify/stories/reveal.liquid
@@ -1,0 +1,26 @@
+<div class="max-w-lg mx-auto p-10 space-y-10">
+  {% for i in 1..10 %}
+    <figure
+      data-component="Figure"
+      class="relative overflow-hidden"
+      data-option-enter-from="translate-x-full skew-x-12"
+      data-option-enter-active="transition duration-[2s] ease-out-expo"
+      data-option-group="figure-{{ i }}">
+      <div class="absolute inset-0 bg-[#a76844] dark:bg-[#f1c092]"></div>
+      <div data-component="Transition"
+        data-option-group="figure-{{ i }}"
+        data-option-enter-from="-translate-x-full -skew-x-12"
+        data-option-enter-active="transition duration-[2s] ease-out-expo"
+        class="overflow-hidden -translate-x-full -skew-x-12 origin-top-left">
+        <img
+          data-ref="FigureShopify.img"
+          class="relative w-full h-auto translate-x-full skew-x-12 origin-top-left"
+          src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="
+          data-src="https://theme-dawn-demo.myshopify.com/cdn/shop/files/beige_1100x_d4e0c67c-45cd-4f0f-903f-74d6dd8467fd.jpg"
+          width="400"
+          height="400"
+          alt="" />
+      </div>
+    </figure>
+  {% endfor %}
+</div>

--- a/packages/docs/components/primitives/Transition/examples.md
+++ b/packages/docs/components/primitives/Transition/examples.md
@@ -10,3 +10,12 @@ title: Transition examples
   :html="() => import('./stories/toggle/app.twig')"
   :script="() => import('./stories/toggle/app.js?raw')"
   />
+
+## Group
+
+Use the [`group` option](/components/primitives/Transition/js-api.html#group) to keep multiple instances in sync. In the example below, the buttons only control the first component, the second one is synced with the `data-option-group` attribute.
+
+<PreviewPlayground
+  :html="() => import('./stories/group/app.twig')"
+  :script="() => import('./stories/group/app.js?raw')"
+  />

--- a/packages/docs/components/primitives/Transition/js-api.md
+++ b/packages/docs/components/primitives/Transition/js-api.md
@@ -120,6 +120,26 @@ Configure wether or not the `leaveTo` classes should be kept on the target eleme
 ```
 
 
+### `group`
+
+- Type: `String`
+- Default: `''`
+
+Define a group to sync `enter` and `leave` transition between multiple instances.
+
+```html {2,7}
+<div data-component="Transition"
+  data-option-group="my-group">
+  ...
+</div>
+
+<div data-component="Transition"
+  data-option-group="my-group">
+  ...
+</div>
+```
+
+
 ## Properties
 
 ### `target`

--- a/packages/docs/components/primitives/Transition/stories/group/app.js
+++ b/packages/docs/components/primitives/Transition/stories/group/app.js
@@ -1,0 +1,14 @@
+import { Base, createApp } from '@studiometa/js-toolkit';
+import { Action, Transition } from '@studiometa/ui';
+
+class App extends Base {
+  static config = {
+    name: 'App',
+    components: {
+      Action,
+      Transition,
+    },
+  };
+}
+
+export default createApp(App);

--- a/packages/docs/components/primitives/Transition/stories/group/app.twig
+++ b/packages/docs/components/primitives/Transition/stories/group/app.twig
@@ -1,0 +1,37 @@
+<div class="flex flex-col gap-8 max-w-xl">
+  <div class="flex items-center gap-4">
+    {% include '@ui/atoms/Button/StyledButton.twig' with {
+      label: 'Enter',
+      attr: {
+        data_component: 'Action',
+        'data-option-on:click': 'Transition(#one) -> target.enter()'
+      }
+    } %}
+    {% include '@ui/atoms/Button/StyledButton.twig' with {
+      label: 'Leave',
+      attr: {
+        data_component: 'Action',
+        'data-option-on:click': 'Transition(#one) -> target.leave()'
+      }
+    } %}
+  </div>
+  <div
+    id="one"
+    data-component="Transition"
+    data-option-group="my-group"
+    data-option-enter-from="scale-50 opacity-50"
+    data-option-enter-active="transition duration-500 ease-out-expo"
+    data-option-leave-active="transition duration-500 ease-out-expo"
+    data-option-leave-to="scale-50 opacity-50"
+    data-option-leave-keep
+    class="w-48 h-48 rounded-lg bg-blue-400 transform scale-50 opacity-50"></div>
+  <div
+    data-component="Transition"
+    data-option-group="my-group"
+    data-option-enter-from="scale-50 opacity-50"
+    data-option-enter-active="transition duration-500 ease-out-expo"
+    data-option-leave-active="transition duration-500 ease-out-expo"
+    data-option-leave-to="scale-50 opacity-50"
+    data-option-leave-keep
+    class="w-48 h-48 rounded-lg bg-green-400 transform scale-50 opacity-50"></div>
+</div>

--- a/packages/tests/primitives/Transition.spec.ts
+++ b/packages/tests/primitives/Transition.spec.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect, vi } from 'vitest';
+import { Transition } from '@studiometa/ui';
+import { mount, h } from '#test-utils';
+
+describe('The Transition component', () => {
+  it('should default to its root element as target', async () => {
+    const div = h('div');
+    const transition = new Transition(div);
+    expect(transition.target).toBe(div);
+  });
+
+  it('should dispatch enter and leave method to grouped elements', async () => {
+    const opts = { dataOptionGroup: 'group' };
+    const transitionA = new Transition(h('div', opts));
+    const transitionB = new Transition(h('div', opts));
+    const enterMock = vi.spyOn(transitionA, 'enter');
+    const leaveMock = vi.spyOn(transitionA, 'enter');
+
+    await mount(transitionA, transitionB);
+    expect(transitionA.$options.group).toBe(transitionB.$options.group);
+    await transitionB.enter();
+    expect(enterMock).toHaveBeenCalledOnce();
+    await transitionB.leave();
+    expect(leaveMock).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/ui/decorators/withTransition.ts
+++ b/packages/ui/decorators/withTransition.ts
@@ -1,3 +1,4 @@
+import { getInstances } from '@studiometa/js-toolkit';
 import { transition } from '@studiometa/js-toolkit/utils';
 import type {
   Base,
@@ -17,6 +18,7 @@ export interface TransitionProps extends BaseProps {
     leaveActive: string;
     leaveTo: string;
     leaveKeep: boolean;
+    group: string;
   };
 }
 
@@ -59,6 +61,7 @@ export function withTransition<S extends Base>(
         leaveActive: String,
         leaveTo: String,
         leaveKeep: Boolean,
+        group: String,
       },
     };
 
@@ -72,37 +75,64 @@ export function withTransition<S extends Base>(
     /**
      * Trigger the enter transition.
      */
-    async enter(target?: HTMLElement | HTMLElement[]): Promise<void> {
+    async enter(target?: HTMLElement | HTMLElement[], { dispatch = true } = {}): Promise<void> {
       const { enterFrom, enterActive, enterTo, enterKeep, leaveTo } = this.$options;
 
-      await transition(
-        target ?? this.target,
-        {
-          // eslint-disable-next-line prefer-template
-          from: (leaveTo + ' ' + enterFrom).trim(),
-          active: enterActive as string,
-          to: enterTo as string,
-        },
-        enterKeep ? 'keep' : undefined,
-      );
+      await Promise.all([
+        transition(
+          target ?? this.target,
+          {
+            // eslint-disable-next-line prefer-template
+            from: (leaveTo + ' ' + enterFrom).trim(),
+            active: enterActive as string,
+            to: enterTo as string,
+          },
+          enterKeep ? 'keep' : undefined,
+        ),
+        dispatch && this.dispatch('enter'),
+      ]);
     }
 
     /**
      * Trigger the leave transition.
      */
-    async leave(target?: HTMLElement | HTMLElement[]): Promise<void> {
+    async leave(target?: HTMLElement | HTMLElement[], { dispatch = true } = {}): Promise<void> {
       const { leaveFrom, leaveActive, leaveTo, leaveKeep, enterTo } = this.$options;
 
-      await transition(
-        target ?? this.target,
-        {
-          // eslint-disable-next-line prefer-template
-          from: (enterTo + ' ' + leaveFrom).trim(),
-          active: leaveActive as string,
-          to: leaveTo as string,
-        },
-        leaveKeep ? 'keep' : undefined,
-      );
+      await Promise.all([
+        transition(
+          target ?? this.target,
+          {
+            // eslint-disable-next-line prefer-template
+            from: (enterTo + ' ' + leaveFrom).trim(),
+            active: leaveActive as string,
+            to: leaveTo as string,
+          },
+          leaveKeep ? 'keep' : undefined,
+        ),
+        dispatch && this.dispatch('leave'),
+      ]);
+    }
+
+    /**
+     * Dispatch the callback to related instances.
+     */
+    async dispatch(method: 'enter' | 'leave') {
+      const { group } = this.$options;
+
+      if (!group) {
+        return;
+      }
+
+      const promises = [];
+
+      for (const instance of getInstances(Transition)) {
+        if (instance !== this && instance.$options.group === group) {
+          promises.push(instance[method](undefined, { dispatch: false }));
+        }
+      }
+
+      await Promise.all(promises);
     }
   }
 


### PR DESCRIPTION
<!---
☝️ PR title should be prefixed by [Feature], [Bugfix], [Release] or [Hotfix]
-->

### 🔗 Linked issue

#305 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR adds a new `group` option to the `Transition` component and its `withTransition` decorator. This enables defining multiple transition in the DOM that should be synced: when one enters, so do the others in the same group. 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have added tests (if possible).
- [x] I have updated the documentation accordingly.
- [x] I have updated the changelog.
