### PR TITLE
[Bugfix] Frame refs and children access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - ⚠️ **Draggable:** refactor component to add support for bounds, axis options and events ([#388](https://github.com/studiometa/ui/pull/388))
 
+### Fixed
+
+- **Frame:** fix accessing refs and components if they are not present ([#393](https://github.com/studiometa/ui/pull/393), [c997008](https://github.com/studiometa/ui/commit/c997008))
+
 ## [v1.0.0-rc.1](https://github.com/studiometa/ui/compare/1.0.0-rc.0..1.0.0-rc.1) (2025-05-05)
 
 ### Added

--- a/packages/tests/Frame/AbstractFrameTrigger.spec.ts
+++ b/packages/tests/Frame/AbstractFrameTrigger.spec.ts
@@ -58,4 +58,18 @@ describe('The AbstractFrameTrigger class', () => {
     expect(enterSpy).toHaveBeenCalledOnce();
     expect(leaveSpy).toHaveBeenCalledOnce();
   });
+
+  it('should not fail if FrameTriggerLoader componens are not present', async () => {
+    class Foo extends AbstractFrameTrigger {
+      static config = {
+        name: 'Foo',
+        components: {},
+      };
+    }
+
+    const form = h('form');
+    const frameForm = new Foo(form);
+    expect(() => frameForm.onFrameFetchBefore()).not.toThrow();
+    expect(() => frameForm.onFrameFetchAfter()).not.toThrow();
+  });
 });

--- a/packages/tests/Frame/FrameForm.spec.ts
+++ b/packages/tests/Frame/FrameForm.spec.ts
@@ -50,7 +50,7 @@ describe('The FrameForm class', () => {
     const fn = vi.fn();
     frameForm.$on('frame-trigger', (event: CustomEvent) => fn(event));
     await mount(frameForm);
-    const event = new SubmitEvent('submit')
+    const event = new SubmitEvent('submit');
     const spy = vi.spyOn(event, 'preventDefault');
     form.dispatchEvent(event);
     expect(fn).toHaveBeenCalledOnce();
@@ -59,5 +59,18 @@ describe('The FrameForm class', () => {
     form.dispatchEvent(event);
     expect(fn).toHaveBeenCalledOnce();
     expect(spy).toHaveBeenCalledOnce();
+  });
+
+  it('should not fail if headers[] refs are not present', async () => {
+    class Foo extends FrameForm {
+      static config = {
+        name: 'Foo',
+        refs: [],
+      };
+    }
+
+    const form = h('form');
+    const frameForm = new Foo(form);
+    expect(() => frameForm.requestInit).not.toThrow();
   });
 });

--- a/packages/ui/Frame/AbstractFrameTrigger.ts
+++ b/packages/ui/Frame/AbstractFrameTrigger.ts
@@ -64,9 +64,11 @@ export class AbstractFrameTrigger<T extends BaseProps = BaseProps> extends Base<
    * Trigger FrameLoaders enter.
    */
   onFrameFetchBefore() {
-    for (const loader of this.$children.FrameTriggerLoader) {
-      if (getClosestParent(loader, this.constructor) === this) {
-        loader.enter();
+    if (this.$children.FrameTriggerLoader) {
+      for (const loader of this.$children.FrameTriggerLoader) {
+        if (getClosestParent(loader, this.constructor) === this) {
+          loader.enter();
+        }
       }
     }
   }
@@ -75,9 +77,11 @@ export class AbstractFrameTrigger<T extends BaseProps = BaseProps> extends Base<
    * Trigger FrameLoaders leave.
    */
   onFrameFetchAfter() {
-    for (const loader of this.$children.FrameTriggerLoader) {
-      if (getClosestParent(loader, this.constructor) === this) {
-        loader.leave();
+    if (this.$children.FrameTriggerLoader) {
+      for (const loader of this.$children.FrameTriggerLoader) {
+        if (getClosestParent(loader, this.constructor) === this) {
+          loader.leave();
+        }
       }
     }
   }

--- a/packages/ui/Frame/FrameForm.ts
+++ b/packages/ui/Frame/FrameForm.ts
@@ -50,9 +50,11 @@ export class FrameForm<T extends BaseProps = BaseProps> extends AbstractFrameTri
     const requestInit = { ...super.requestInit };
     requestInit.headers ??= {};
 
-    for (const header of this.$refs.headers) {
-      if (header.dataset.name && header.value) {
-        requestInit.headers[header.dataset.name] = header.value;
+    if (this.$refs.headers) {
+      for (const header of this.$refs.headers) {
+        if (header.dataset.name && header.value) {
+          requestInit.headers[header.dataset.name] = header.value;
+        }
       }
     }
 


### PR DESCRIPTION
<!---
☝️ PR title should be prefixed by [Feature], [Bugfix], [Release] or [Hotfix]
-->

### 🔗 Linked issue

https://github.com/studiometa/js-toolkit/issues/627

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This fixes a potential issue when extending the Frame components.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have added tests (if possible).
- [x] I have updated the documentation accordingly.
- [ ] I have updated the changelog.
