### PR TITLE
[Feature] FrameTarget: differentiate morph and replace modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Changed
+
+- **FrameTarget**: differentiate `morph` and `replace` modes ([#394](https://github.com/studiometa/ui/issues/394), [#423](https://github.com/studiometa/ui/pull/423), [65315b8](https://github.com/studiometa/ui/commit/65315b8))
+
 ## [v1.0.0-rc.7](https://github.com/studiometa/ui/compare/1.0.0-rc.6..1.0.0-rc.7) (2025-06-19)
 
 ### Added

--- a/packages/docs/components/Frame/js-api/frame-target.md
+++ b/packages/docs/components/Frame/js-api/frame-target.md
@@ -10,15 +10,21 @@ The `FrameLoader` component extends the [`Transition` component](/components/Tra
 
 ### `mode`
 
-- Type: `'replace' | 'append' | 'prepend'`
+- Type: `'replace' | 'append' | 'prepend' | 'morph'`
 - Default: `'replace'`
 
-Use this option to define how new content should be inserted in the actual DOM: `replace` (the default), `append` or `prepend`.
+Use this option to define how new content should be inserted in the actual DOM: `replace` (the default), `append`, `prepend`, or `morph`.
 
 When using the `replace` mode, transitions defined by the [`Transition` component API](/components/Transition/) will be played sequencially:
 
 - the leave transition is applied to the root element
-- new content replaces the old content
+- new content completely replaces the old content using [the `Element.replaceChildren()` method](https://developer.mozilla.org/en-US/docs/Web/API/Element/replaceChildren)
+- the enter transition is applied to the root element
+
+When using the `morph` mode, transitions are played sequencially but content is intelligently updated:
+
+- the leave transition is applied to the root element
+- new content is merged with existing content using DOM diffing (morphdom)
 - the enter transition is applied to the root element
 
 When using any of the `append` or `prepend` mode, transitions are played in parallel:
@@ -28,7 +34,9 @@ When using any of the `append` or `prepend` mode, transitions are played in para
 
 ::: info DOM diffing
 
-When in `replace` mode, the [`morphdom` package](https://github.com/patrick-steele-idem/morphdom) is used to smartly update the content of the component. This prevents losing any existing state that might not need to be erased: focus, event listeners, mounted components, etc..
+When in `morph` mode, the [`morphdom` package](https://github.com/patrick-steele-idem/morphdom) is used to smartly update the content of the component. This prevents losing any existing state that might not need to be erased: focus, event listeners, mounted components, etc.
+
+When in `replace` mode, the content is completely replaced using [the `Element.replaceChildren()` method](https://developer.mozilla.org/en-US/docs/Web/API/Element/replaceChildren), which removes all existing content and replaces it with the new content.
 
 :::
 

--- a/packages/tests/Frame/FrameTarget.spec.ts
+++ b/packages/tests/Frame/FrameTarget.spec.ts
@@ -52,4 +52,46 @@ describe('The FrameTarget class', () => {
     await frameTarget.updateContent(null);
     expect(spy).not.toHaveBeenCalled();
   });
+
+  it('should be able to morph content', async () => {
+    const div = h('div', { id: 'foo', dataOptionMode: 'morph' }, [
+      h('p', {}, ['Original content']),
+      h('span', { class: 'keep' }, ['Keep this']),
+    ]);
+    const frameTarget = new FrameTarget(div);
+    await mount(frameTarget);
+
+    const newContent = h('div', { id: 'foo', dataOptionMode: 'morph' }, [
+      h('p', {}, ['Updated content']),
+      h('span', { class: 'keep' }, ['Keep this']),
+      h('div', {}, ['New element']),
+    ]);
+
+    await frameTarget.updateContent(newContent);
+    
+    expect(div.querySelector('p')?.textContent).toBe('Updated content');
+    expect(div.querySelector('span.keep')?.textContent).toBe('Keep this');
+    expect(div.querySelector('div')?.textContent).toBe('New element');
+  });
+
+  it('should use replaceChildren for replace mode', async () => {
+    const div = h('div', { id: 'foo', dataOptionMode: 'replace' }, [
+      h('p', { id: 'original' }, ['Original content']),
+    ]);
+    const frameTarget = new FrameTarget(div);
+    await mount(frameTarget);
+
+    const originalElement = div.querySelector('#original');
+    const spy = vi.spyOn(div, 'replaceChildren');
+
+    const newContent = h('div', { id: 'foo', dataOptionMode: 'replace' }, [
+      h('p', { id: 'new' }, ['New content']),
+    ]);
+
+    await frameTarget.updateContent(newContent);
+    
+    expect(spy).toHaveBeenCalledWith(newContent);
+    expect(div.querySelector('#new')?.textContent).toBe('New content');
+    expect(div.querySelector('#original')).toBeNull();
+  });
 });

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "test": "vitest"
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "author": "Studio Meta <agence@studiometa.fr> (https://www.studiometa.fr/)",
   "license": "MIT",


### PR DESCRIPTION
<!---
☝️ PR title should be prefixed by [Feature], [Bugfix], [Release] or [Hotfix]
-->

### 🔗 Linked issue

#394 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR fixes #394 by: 

- adding a new `morph` mode which will use [morphdom](https://github.com/patrick-steele-idem/morphdom) to update the `FrameTarget` children
- updatuing the `replace` mode to be a full replace of the `FrameTarget` children with the [`Element.replaceChildren()` method](https://developer.mozilla.org/en-US/docs/Web/API/Element/replaceChildren)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have added tests (if possible).
- [x] I have updated the documentation accordingly.
- [x] I have updated the changelog.
