### PR TITLE
[Bugfix] Fix accordion triggering submit when used inside a form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix accordion triggering submit when used inside a form ([#433](https://github.com/studiometa/ui/issues/433), [#434](https://github.com/studiometa/ui/pull/434), [37617c1](https://github.com/studiometa/ui/commit/37617c1))
+
 ## [v1.1.0](https://github.com/studiometa/ui/compare/1.0.1..1.1.0) (2025-08-01)
 
 ### Added

--- a/packages/ui/Accordion/Accordion.twig
+++ b/packages/ui/Accordion/Accordion.twig
@@ -26,7 +26,7 @@
     {% set item_attributes = merge_html_attributes(item_attr ?? null, { data_component: 'AccordionItem' }, item.attr ?? null) %}
     {% set is_open = item_attributes.data_option_is_open ?? false %}
     <div {{ html_attributes(item_attributes) }}>
-      <button data-ref="btn" class="block w-full" aria-expanded="{{ is_open ? 'true' : 'false' }}">
+      <button data-ref="btn" type="button" class="block w-full" aria-expanded="{{ is_open ? 'true' : 'false' }}">
         {% block title %}
           {{ item.title }}
         {% endblock %}

--- a/tests/__snapshots__/AccordionTest__it_renders_an_Accordion__default_is__open_option_is_set_to_true__the_first_item_overrides_the_config_to_false__1.txt
+++ b/tests/__snapshots__/AccordionTest__it_renders_an_Accordion__default_is__open_option_is_set_to_true__the_first_item_overrides_the_config_to_false__1.txt
@@ -1,6 +1,6 @@
 <div data-component="Accordion">
   <div data-component="AccordionItem">
-    <button data-ref="btn" class="block w-full" aria-expanded="false">Item #1</button>
+    <button data-ref="btn" type="button" class="block w-full" aria-expanded="false">Item #1</button>
     <div
       data-ref="container"
       style="visibility: hidden; height: 0"
@@ -9,13 +9,13 @@
     </div>
   </div>
   <div data-component="AccordionItem" data-option-is-open>
-    <button data-ref="btn" class="block w-full" aria-expanded="true">Item #2</button>
+    <button data-ref="btn" type="button" class="block w-full" aria-expanded="true">Item #2</button>
     <div data-ref="container" class="relative overflow-hidden">
       <div data-ref="content" aria-hidden="true">lorem lorem</div>
     </div>
   </div>
   <div data-component="AccordionItem" data-option-is-open>
-    <button data-ref="btn" class="block w-full" aria-expanded="true">Item #3</button>
+    <button data-ref="btn" type="button" class="block w-full" aria-expanded="true">Item #3</button>
     <div data-ref="container" class="relative overflow-hidden">
       <div data-ref="content" aria-hidden="true">lorem lorem</div>
     </div>


### PR DESCRIPTION
<!---
☝️ PR title should be prefixed by [Feature], [Bugfix], [Release] or [Hotfix]
-->

### 🔗 Linked issue

#433

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When using the `Accordion.twig` template inside a `<form>` element, the button in the templating were triggering the form submission because they have no `type="button"` attribute.

This is fixed by adding a `type="button"` attribute. 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have added tests (if possible).
- [x] I have updated the documentation accordingly.
- [x] I have updated the changelog.
