### PR TITLE
[Bugfix] Fix AbstractSliderChild crash with js-toolkit >= 3.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Changed
+
+- **Slider:** replace deprecated `$parent` with `$closest('Slider')` in `AbstractSliderChild` and all subclasses (`SliderBtn`, `SliderDots`, `SliderProgress`) ([#506](https://github.com/studiometa/ui/pull/506))
+- **Accordion:** replace deprecated `$parent` with `$closest('Accordion')` in `AccordionItem` ([#506](https://github.com/studiometa/ui/pull/506))
+- Bump `@studiometa/js-toolkit` from `3.4.3` to `^3.5.0` ([#506](https://github.com/studiometa/ui/pull/506))
+
+### Fixed
+
+- **Slider:** fix `TypeError: Cannot read properties of null (reading '$on')` crash when `AbstractSliderChild.mounted()` runs before parent Slider is registered ([#506](https://github.com/studiometa/ui/pull/506))
+
 ## [v1.9.0-beta.0](https://github.com/studiometa/ui/compare/1.8.0..1.9.0-beta.0) (2026-05-11)
 
 ### Added

--- a/packages/ui/Accordion/AccordionItem.ts
+++ b/packages/ui/Accordion/AccordionItem.ts
@@ -51,8 +51,9 @@ export class AccordionItem<T extends BaseProps = BaseProps> extends Base<T & Acc
    * Add aria-attributes on mounted.
    */
   mounted() {
-    if (this.$parent && this.$parent instanceof Accordion && this.$parent.$options.item) {
-      Object.entries(this.$parent.$options.item).forEach(([key, value]) => {
+    const accordion = this.$closest('Accordion') as InstanceType<typeof Accordion> | undefined;
+    if (accordion?.$options.item) {
+      Object.entries(accordion.$options.item).forEach(([key, value]) => {
         if (key in this.$options) {
           // @ts-ignore
           const type = AccordionItem.config.options[key].type ?? AccordionItem.config.options[key];

--- a/packages/ui/Slider/AbstractSliderChild.ts
+++ b/packages/ui/Slider/AbstractSliderChild.ts
@@ -26,7 +26,10 @@ export class AbstractSliderChild<T extends BaseProps = BaseProps> extends Base<T
    */
   mounted() {
     nextFrame(() => {
-      this.slider?.$on('index', this);
+      if (this.slider) {
+        this.slider.$on('index', this);
+        this.update(this.slider.currentIndex);
+      }
     });
   }
 

--- a/packages/ui/Slider/AbstractSliderChild.ts
+++ b/packages/ui/Slider/AbstractSliderChild.ts
@@ -3,16 +3,10 @@ import type { BaseProps, BaseConfig } from '@studiometa/js-toolkit';
 import { nextFrame, domScheduler, isFunction } from '@studiometa/js-toolkit/utils';
 import type { Slider } from './Slider.js';
 
-export interface AbstractSliderChildProps extends BaseProps {
-  $parent: Slider;
-}
-
 /**
  * AbstractSliderChild class.
  */
-export class AbstractSliderChild<T extends BaseProps = BaseProps> extends Base<
-  T & AbstractSliderChildProps
-> {
+export class AbstractSliderChild<T extends BaseProps = BaseProps> extends Base<T> {
   /**
    * Config.
    */
@@ -21,10 +15,19 @@ export class AbstractSliderChild<T extends BaseProps = BaseProps> extends Base<
   };
 
   /**
+   * Get the closest Slider ancestor.
+   */
+  get slider(): Slider | null {
+    return this.$closest('Slider') as Slider | null;
+  }
+
+  /**
    * Listen to the `goto` event of the parent on mount.
    */
   mounted() {
-    this.$parent.$on('index', this);
+    nextFrame(() => {
+      this.slider?.$on('index', this);
+    });
   }
 
   /**
@@ -32,7 +35,9 @@ export class AbstractSliderChild<T extends BaseProps = BaseProps> extends Base<
    */
   resized() {
     nextFrame(() => {
-      this.update(this.$parent.currentIndex);
+      if (this.slider) {
+        this.update(this.slider.currentIndex);
+      }
     });
   }
 
@@ -40,7 +45,7 @@ export class AbstractSliderChild<T extends BaseProps = BaseProps> extends Base<
    * Remove the event listener.
    */
   destroyed() {
-    this.$parent.$off('index', this);
+    this.slider?.$off('index', this);
   }
 
   /**

--- a/packages/ui/Slider/SliderBtn.ts
+++ b/packages/ui/Slider/SliderBtn.ts
@@ -31,7 +31,9 @@ export class SliderBtn<T extends BaseProps = BaseProps> extends AbstractSliderCh
    * Update attributes.
    */
   update(index: number) {
-    if (this.$options.contain && !this.$parent.$options.contain) {
+    if (!this.slider) return;
+
+    if (this.$options.contain && !this.slider.$options.contain) {
       this.$warn(
         `The contain option will only works if the parent Slider also has the contain option.`,
       );
@@ -39,13 +41,13 @@ export class SliderBtn<T extends BaseProps = BaseProps> extends AbstractSliderCh
 
     const isContainMaxState =
       this.$options.contain &&
-      this.$parent.$options.contain &&
-      this.$parent.containMaxState ===
-        this.$parent.getStates()[index].x[this.$parent.$options.mode];
+      this.slider.$options.contain &&
+      this.slider.containMaxState ===
+        this.slider.getStates()[index].x[this.slider.$options.mode];
 
     if (
       (index === 0 && this.$options.prev) ||
-      ((index === this.$parent.indexMax || isContainMaxState) && this.$options.next)
+      ((index === this.slider.indexMax || isContainMaxState) && this.$options.next)
     ) {
       this.$el.setAttribute('disabled', '');
     } else {
@@ -60,9 +62,9 @@ export class SliderBtn<T extends BaseProps = BaseProps> extends AbstractSliderCh
     const { prev, next } = this.$options;
 
     if (prev) {
-      this.$parent.goPrev();
+      this.slider?.goPrev();
     } else if (next) {
-      this.$parent.goNext();
+      this.slider?.goNext();
     }
   }
 }

--- a/packages/ui/Slider/SliderDots.ts
+++ b/packages/ui/Slider/SliderDots.ts
@@ -49,6 +49,6 @@ export class SliderDots<
    * Go to the given index on dot click.
    */
   onDotsClick({ index }: { index: number }) {
-    this.$parent.goTo(index);
+    this.slider?.goTo(index);
   }
 }

--- a/packages/ui/Slider/SliderProgress.ts
+++ b/packages/ui/Slider/SliderProgress.ts
@@ -28,7 +28,8 @@ export class SliderProgress<T extends BaseProps = BaseProps> extends AbstractSli
   update(index: number) {
     domScheduler.read(() => {
       const { progress } = this.$refs;
-      const x = map(index, 0, this.$parent.indexMax, progress.clientWidth * -1, 0);
+      if (!this.slider) return;
+      const x = map(index, 0, this.slider.indexMax, progress.clientWidth * -1, 0);
       domScheduler.write(() => {
         transform(progress, { x });
       });

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -33,9 +33,9 @@
     "morphdom": "^2.7.8"
   },
   "devDependencies": {
-    "@studiometa/js-toolkit": "3.4.3"
+    "@studiometa/js-toolkit": "^3.5.0"
   },
   "peerDependencies": {
-    "@studiometa/js-toolkit": "^3.4.0"
+    "@studiometa/js-toolkit": "^3.5.0"
   }
 }


### PR DESCRIPTION
### 🔗 Linked issue

#505 

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

#### Problem

`AbstractSliderChild.mounted()` calls `this.$parent.$on("index", this)` which throws `TypeError: Cannot read properties of null (reading '$on')` with `@studiometa/js-toolkit` >= 3.4.3.

In js-toolkit 3.4.3, `$parent` changed from a property assigned during mounting to a dynamic getter that looks up registered instances at runtime. This getter can return `null` when a child's `mounted()` runs before the parent Slider is fully resolved in the instance registry.

Any page using `SliderBtn`, `SliderCount`, `SliderDots`, or `SliderProgress` crashes on mount.

#### Changes

**Commit 1 — Fix Slider child components**
- Replace `this.$parent` with a `slider` getter using `this.$closest('Slider')` in `AbstractSliderChild` and all subclasses (`SliderBtn`, `SliderDots`, `SliderProgress`)
- Defer `$on` subscription in `mounted()` with `nextFrame` to ensure the parent Slider is registered before the child looks it up
- Add null guards throughout
- Bump `@studiometa/js-toolkit` to `^3.5.0` (required for `$closest` support)

**Commit 2 — Fix AccordionItem**
- Replace `this.$parent` with `this.$closest('Accordion')` in `AccordionItem.mounted()`, consistent with the js-toolkit 3.5.0 deprecation of `$parent`

#### Out of scope

- **`Frame.ts`**: `this.$root.$update()` — deprecated but does not crash. Replacing with `this.$update()` would change behavior (only updates the Frame subtree instead of the entire app). Needs a separate discussion.
- **`$children`** (22 usages across 11 files) — deprecated in favor of `$query()` but still functional. Migration should be handled in a dedicated ticket.


### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have added tests (if possible).
- [x] I have updated the documentation accordingly.
- [x] I have updated the changelog.
