### PR TITLE
Fix Slider and Accordion children dereferencing $parent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Changed
+
+- **Slider:** require `@studiometa/js-toolkit` `^3.6.0` and share the current index through a per-instance store instead of the deprecated `$parent` accessor ([#507](https://github.com/studiometa/ui/pull/507))
+
+### Fixed
+
+- **Slider:** fix `SliderBtn`, `SliderCount`, `SliderDots` and `SliderProgress` crashing when mounted before their parent `Slider` ([#507](https://github.com/studiometa/ui/pull/507))
+- **Accordion:** fix `AccordionItem` option inheritance relying on the deprecated `$parent` accessor ([#507](https://github.com/studiometa/ui/pull/507))
+
 ## [v1.9.0-beta.0](https://github.com/studiometa/ui/compare/1.8.0..1.9.0-beta.0) (2026-05-11)
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -4309,9 +4309,9 @@
       "link": true
     },
     "node_modules/@studiometa/js-toolkit": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@studiometa/js-toolkit/-/js-toolkit-3.4.3.tgz",
-      "integrity": "sha512-CF7+Q5JgK8d8730pnC+CfdtsCT1ayABkzsSLoihKtcx36uOJv1tDNGRMl8rsUFTUk4HTmROQAHrsmaqTH8pfUg==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@studiometa/js-toolkit/-/js-toolkit-3.6.0.tgz",
+      "integrity": "sha512-KJyPzw+eqePlEUOliskvJyweQ0kuNdVzPdfc41OPO1IvROqAPm6CUtk8eY7XCy91fQWs8O2rQdTujnHPA7yrSQ==",
       "license": "MIT",
       "dependencies": {
         "@motionone/easing": "^10.18.0",
@@ -20689,7 +20689,7 @@
       "name": "@studiometa/ui-docs",
       "version": "1.9.0-beta.0",
       "dependencies": {
-        "@studiometa/js-toolkit": "3.4.3"
+        "@studiometa/js-toolkit": "^3.6.0"
       },
       "devDependencies": {
         "@iconify-json/octicon": "1.2.22",
@@ -20742,7 +20742,7 @@
       },
       "devDependencies": {
         "@motionone/easing": "^10.18.0",
-        "@studiometa/js-toolkit": "^3.4.3",
+        "@studiometa/js-toolkit": "^3.6.0",
         "deepmerge": "^4.3.1",
         "morphdom": "^2.7.8",
         "tsdown": "^0.21.5"
@@ -21167,10 +21167,10 @@
         "morphdom": "^2.7.8"
       },
       "devDependencies": {
-        "@studiometa/js-toolkit": "3.4.3"
+        "@studiometa/js-toolkit": "^3.6.0"
       },
       "peerDependencies": {
-        "@studiometa/js-toolkit": "^3.4.0"
+        "@studiometa/js-toolkit": "^3.6.0"
       }
     }
   }

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -12,7 +12,7 @@
     "postbuild": "ln -sf ../../../api/public .vitepress/dist/api"
   },
   "dependencies": {
-    "@studiometa/js-toolkit": "3.4.3"
+    "@studiometa/js-toolkit": "^3.6.0"
   },
   "devDependencies": {
     "@iconify-json/octicon": "1.2.22",

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@motionone/easing": "^10.18.0",
-    "@studiometa/js-toolkit": "^3.4.3",
+    "@studiometa/js-toolkit": "^3.6.0",
     "deepmerge": "^4.3.1",
     "morphdom": "^2.7.8",
     "tsdown": "^0.21.5"

--- a/packages/tests/Menu/Menu.spec.ts
+++ b/packages/tests/Menu/Menu.spec.ts
@@ -1,7 +1,16 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { getInstanceFromElement } from '@studiometa/js-toolkit';
 import { Menu, MenuBtn, MenuList } from '@studiometa/ui';
 import { h, mount, wait } from '#test-utils';
+
+// The MenuList open/close/toggle transitions are asynchronous (`withTransition`
+// schedules work over a few animation frames). Tests trigger them without
+// awaiting, so let any pending transition settle within this file's happy-dom
+// environment — otherwise it resolves during a later test file whose globals
+// have been torn down (`ReferenceError: Node is not defined`).
+afterEach(async () => {
+  await wait(50);
+});
 
 async function getContext({ mode = 'click' } = {}) {
   const menuBtn = h('button', { dataComponent: 'MenuBtn' }, ['Click me']);

--- a/packages/tests/Slider/Slider.spec.ts
+++ b/packages/tests/Slider/Slider.spec.ts
@@ -1,11 +1,51 @@
 import { describe, it, expect, vi } from 'vitest';
-import { Slider } from '@studiometa/ui';
+import {
+  Slider as SliderCore,
+  SliderBtn,
+  SliderCount,
+  SliderDrag,
+  SliderItem,
+} from '@studiometa/ui';
+import { getInstanceFromElement } from '@studiometa/js-toolkit';
+import type { BaseConfig } from '@studiometa/js-toolkit';
 import { h } from '#test-utils';
+
+/**
+ * A Slider subclass registering the child controls, mirroring the documented
+ * usage where controls are added through `config.components`.
+ */
+class Slider extends SliderCore {
+  static config: BaseConfig = {
+    name: 'Slider',
+    components: {
+      SliderItem,
+      SliderDrag,
+      SliderCount,
+      SliderBtn,
+    },
+  };
+}
+
+function sliderHtml() {
+  const root = h('div');
+  root.innerHTML = `
+    <div data-component="Slider" data-option-contain>
+      <div data-component="SliderDrag" data-ref="wrapper">
+        <div data-component="SliderItem">1</div>
+        <div data-component="SliderItem">2</div>
+        <div data-component="SliderItem">3</div>
+      </div>
+      <button data-component="SliderBtn" data-option-next data-option-contain>Next</button>
+      <div data-component="SliderCount"><span data-ref="current">0</span></div>
+    </div>
+  `;
+  return root;
+}
 
 describe('The Slider component', () => {
   it('should not prevent drag or drop when delta.y is greater than delta.x', async () => {
     const div = h('div', [h('div', { dataComponent: 'SliderItem' })]);
-    const slider = new Slider(div);
+    const slider = new SliderCore(div);
     const spy = vi.spyOn(slider, '$children', 'get');
     // @ts-expect-error
     spy.mockImplementation(() => ({
@@ -28,5 +68,107 @@ describe('The Slider component', () => {
       ],
     });
     expect(slider.__distanceX).toBe(10);
+  });
+
+  it('should connect a `contain` SliderBtn on first mount without reading empty geometry', async () => {
+    const root = sliderHtml();
+    const sliderEl = root.querySelector('[data-component="Slider"]') as HTMLElement;
+    const btnEl = root.querySelector('[data-component="SliderBtn"]') as HTMLElement;
+
+    vi.useFakeTimers();
+    // A `contain` SliderBtn used to crash on first mount by reading the Slider
+    // geometry (`states`) before `Slider.mounted()` had computed it. Reaching
+    // the assertions below (rather than an unhandled scheduler error) proves the
+    // update no longer runs against a not-yet-initialised Slider.
+    const slider = new Slider(sliderEl);
+    slider.$mount();
+    await vi.advanceTimersByTimeAsync(200);
+    vi.useRealTimers();
+
+    const btn = getInstanceFromElement(btnEl, SliderBtn);
+    expect(btn?.slider).toBeInstanceOf(SliderCore);
+  });
+});
+
+describe('A Slider child component', () => {
+  it('should synchronise even when fully mounted before its Slider', async () => {
+    const root = sliderHtml();
+    const sliderEl = root.querySelector('[data-component="Slider"]') as HTMLElement;
+    const countEl = root.querySelector('[data-component="SliderCount"]') as HTMLElement;
+    const currentRef = countEl.querySelector('[data-ref="current"]') as HTMLElement;
+
+    vi.useFakeTimers();
+
+    // Fully mount the child *before* the Slider is even constructed, so it
+    // cannot resolve `$closest('Slider')` on its own.
+    const count = new SliderCount(countEl);
+    count.$mount();
+    await vi.advanceTimersByTimeAsync(200);
+    // Not connected yet: the counter still shows its initial markup.
+    expect(currentRef.textContent).toBe('0');
+
+    // Mounting the Slider connects the pre-mounted child (parent-side handshake)
+    // and seeds the current index (0, rendered as `0 + 1`).
+    const slider = new Slider(sliderEl);
+    slider.$mount();
+    await vi.advanceTimersByTimeAsync(200);
+    expect(currentRef.textContent).toBe('1');
+
+    // A later index change propagates through the store subscription, proving
+    // the child is genuinely connected (not merely showing the default value).
+    slider.goTo(2);
+    await vi.advanceTimersByTimeAsync(200);
+    expect(currentRef.textContent).toBe('3');
+
+    vi.useRealTimers();
+  });
+});
+
+describe('The SliderBtn component in `contain` mode', () => {
+  function createStates(leftValues: number[]) {
+    return leftValues.map((left) => ({ x: { left, center: 0, right: 0 } }));
+  }
+
+  it('should be disabled once the parent reaches the max contain state', () => {
+    const el = h('button', {
+      dataComponent: 'SliderBtn',
+      dataOptionNext: true,
+      dataOptionContain: true,
+    });
+    const btn = new SliderBtn(el);
+
+    const states = createStates([0, -10, -20, -100, -100, -100]);
+    const fakeSlider = {
+      $options: { contain: true, mode: 'left' as const },
+      indexMax: 5,
+      containMaxState: -100,
+      getStates: () => states,
+    };
+    // Shadow the inherited `slider` getter with a controlled instance.
+    Object.defineProperty(btn, 'slider', { configurable: true, get: () => fakeSlider });
+
+    // Index 3 is the first state matching the max contain value → disabled.
+    btn.update(3);
+    expect(el.hasAttribute('disabled')).toBe(true);
+
+    // Index 2 has not reached the max contain state and is not the last index.
+    btn.update(2);
+    expect(el.hasAttribute('disabled')).toBe(false);
+  });
+
+  it('should not be disabled when the parent Slider cannot be resolved', () => {
+    const el = h('button', {
+      dataComponent: 'SliderBtn',
+      dataOptionNext: true,
+      dataOptionContain: true,
+    });
+    el.setAttribute('disabled', '');
+    const btn = new SliderBtn(el);
+    Object.defineProperty(btn, 'slider', { configurable: true, get: () => undefined });
+
+    // With no resolvable Slider the update is a no-op and must not throw.
+    expect(() => btn.update(0)).not.toThrow();
+    // The pre-existing attribute is left untouched (no dereference happened).
+    expect(el.hasAttribute('disabled')).toBe(true);
   });
 });

--- a/packages/ui/Accordion/AccordionItem.ts
+++ b/packages/ui/Accordion/AccordionItem.ts
@@ -2,7 +2,7 @@ import deepmerge from 'deepmerge';
 import { Base, BaseConfig } from '@studiometa/js-toolkit';
 import type { BaseProps } from '@studiometa/js-toolkit';
 import { transition } from '@studiometa/js-toolkit/utils';
-import { AccordionCore as Accordion } from './AccordionCore.js';
+import type { AccordionCore as Accordion } from './AccordionCore.js';
 
 type AccordionItemStates = Partial<
   Record<'open' | 'active' | 'closed', string | Partial<CSSStyleDeclaration>>
@@ -51,8 +51,9 @@ export class AccordionItem<T extends BaseProps = BaseProps> extends Base<T & Acc
    * Add aria-attributes on mounted.
    */
   mounted() {
-    if (this.$parent && this.$parent instanceof Accordion && this.$parent.$options.item) {
-      Object.entries(this.$parent.$options.item).forEach(([key, value]) => {
+    const accordion = this.$closest<Accordion>('Accordion');
+    if (accordion && accordion.$options.item) {
+      Object.entries(accordion.$options.item).forEach(([key, value]) => {
         if (key in this.$options) {
           // @ts-ignore
           const type = AccordionItem.config.options[key].type ?? AccordionItem.config.options[key];

--- a/packages/ui/Slider/AbstractSliderChild.ts
+++ b/packages/ui/Slider/AbstractSliderChild.ts
@@ -3,9 +3,7 @@ import type { BaseProps, BaseConfig } from '@studiometa/js-toolkit';
 import { nextFrame, domScheduler, isFunction } from '@studiometa/js-toolkit/utils';
 import type { Slider } from './Slider.js';
 
-export interface AbstractSliderChildProps extends BaseProps {
-  $parent: Slider;
-}
+export interface AbstractSliderChildProps extends BaseProps {}
 
 /**
  * AbstractSliderChild class.
@@ -21,43 +19,109 @@ export class AbstractSliderChild<T extends BaseProps = BaseProps> extends Base<
   };
 
   /**
-   * Listen to the `goto` event of the parent on mount.
+   * The parent Slider this child is connected to.
+   * @private
+   */
+  __slider: Slider | undefined;
+
+  /**
+   * Unsubscribe callback for the parent Slider store subscription.
+   * @private
+   */
+  __unsubscribe: (() => void) | null = null;
+
+  /**
+   * The parent Slider instance, if any.
+   *
+   * Returns the Slider that connected this child, falling back to a guarded
+   * `$closest('Slider')` lookup. Child components never dereference the
+   * deprecated `$parent` accessor; this may be `undefined` before the child has
+   * been connected to a Slider.
+   */
+  get slider(): Slider | undefined {
+    return this.__slider ?? this.$closest<Slider>('Slider');
+  }
+
+  /**
+   * Connect to the parent Slider on mount.
    */
   mounted() {
-    this.$parent.$on('index', this);
+    this.__connect();
   }
 
   /**
-   * Trigger update on resize.
+   * Reconnect and refresh with the current index on resize.
    */
   resized() {
-    nextFrame(() => {
-      this.update(this.$parent.currentIndex);
-    });
-  }
-
-  /**
-   * Remove the event listener.
-   */
-  destroyed() {
-    this.$parent.$off('index', this);
-  }
-
-  /**
-   * Dispatch event.
-   */
-  handleEvent(event: CustomEvent) {
-    if (event.type === 'index') {
-      domScheduler.read(() => {
-        const callback = this.update(event.detail[0]);
-        if (isFunction(callback)) {
-          domScheduler.write(() => {
-            // @ts-ignore
-            callback();
-          });
-        }
+    this.__connect();
+    const { slider } = this;
+    if (slider?.store.has('index')) {
+      nextFrame(() => {
+        this.__updateWith(slider.store.get('index', 0));
       });
     }
+  }
+
+  /**
+   * Reconnect after each update as a safety net.
+   */
+  updated() {
+    this.__connect();
+  }
+
+  /**
+   * Remove the store subscription.
+   */
+  destroyed() {
+    this.__unsubscribe?.();
+    this.__unsubscribe = null;
+    this.__slider = undefined;
+  }
+
+  /**
+   * Subscribe to a Slider index store.
+   *
+   * The subscription never relies on the deprecated `$parent` accessor. The
+   * Slider is either handed over by the parent itself — see `Slider.mounted`,
+   * which connects the children that mounted before it — or resolved through a
+   * guarded `$closest('Slider')` lookup. The call is idempotent and a no-op once
+   * the child is connected or unmounted.
+   *
+   * The current index is pulled immediately only when the Slider has already
+   * seeded its store, which happens after its geometry has been computed. This
+   * ensures the `update` callback never runs against a not-yet-initialised
+   * Slider (e.g. a `SliderBtn` in `contain` mode reading empty states).
+   * @private
+   */
+  __connect(slider: Slider | undefined = this.slider) {
+    if (this.__unsubscribe || !this.$isMounted || !slider) {
+      return;
+    }
+
+    this.__slider = slider;
+    this.__unsubscribe = slider.store.subscribe('index', (index) => {
+      this.__updateWith(index ?? 0);
+    });
+
+    if (slider.store.has('index')) {
+      this.__updateWith(slider.store.get('index', 0));
+    }
+  }
+
+  /**
+   * Schedule the `update` callback for the given index.
+   * @private
+   */
+  __updateWith(index: number) {
+    domScheduler.read(() => {
+      const callback = this.update(index);
+      if (isFunction(callback)) {
+        domScheduler.write(() => {
+          // @ts-ignore
+          callback();
+        });
+      }
+    });
   }
 
   /**

--- a/packages/ui/Slider/Slider.ts
+++ b/packages/ui/Slider/Slider.ts
@@ -5,13 +5,25 @@ import type {
   DragServiceProps,
   KeyServiceProps,
 } from '@studiometa/js-toolkit';
-import { clamp, inertiaFinalValue, nextFrame } from '@studiometa/js-toolkit/utils';
+import {
+  clamp,
+  createMemoryStorageProvider,
+  createStorage,
+  inertiaFinalValue,
+  nextFrame,
+} from '@studiometa/js-toolkit/utils';
+import { AbstractSliderChild } from './AbstractSliderChild.js';
 import { SliderDrag } from './SliderDrag.js';
 import { SliderItem } from './SliderItem.js';
 
 export type SliderModes = 'left' | 'center' | 'right';
 
 type SliderState = { x: Record<SliderModes, number> };
+
+/**
+ * Shape of the per-instance store shared with the child components.
+ */
+export type SliderStore = { index: number };
 
 export interface SliderProps extends BaseProps {
   $refs: {
@@ -80,6 +92,13 @@ export class Slider<T extends BaseProps = BaseProps> extends Base<T & SliderProp
   states: SliderState[] = [];
 
   /**
+   * Per-instance store used to broadcast the current index to the child
+   * components. Children subscribe to it through a guarded `$closest('Slider')`
+   * lookup instead of dereferencing the deprecated `$parent` accessor.
+   */
+  store = createStorage<SliderStore>({ provider: createMemoryStorageProvider() });
+
+  /**
    * Origins for the different modes.
    */
   origins: Record<SliderModes, number> = {
@@ -106,6 +125,7 @@ export class Slider<T extends BaseProps = BaseProps> extends Base<T & SliderProp
   set currentIndex(value: number) {
     this.currentSliderItem.disactivate();
     this.$emit('index', value);
+    this.store.set('index', value);
     this.__currentIndex = value;
     this.currentSliderItem.activate();
   }
@@ -245,6 +265,22 @@ export class Slider<T extends BaseProps = BaseProps> extends Base<T & SliderProp
     this.states = this.getStates();
     this.setAccessibilityAttributes();
     this.goTo(this.currentIndex);
+    this.connectChildren();
+  }
+
+  /**
+   * Connect the child components that track the current index, including those
+   * that mounted before this Slider. Runs after `goTo` has seeded the store so
+   * connected children synchronise against an initialised Slider.
+   */
+  connectChildren() {
+    for (const children of Object.values(this.$children as Record<string, Base[]>)) {
+      for (const child of children) {
+        if (child instanceof AbstractSliderChild) {
+          child.__connect(this as unknown as Slider);
+        }
+      }
+    }
   }
 
   /**

--- a/packages/ui/Slider/SliderBtn.ts
+++ b/packages/ui/Slider/SliderBtn.ts
@@ -31,7 +31,12 @@ export class SliderBtn<T extends BaseProps = BaseProps> extends AbstractSliderCh
    * Update attributes.
    */
   update(index: number) {
-    if (this.$options.contain && !this.$parent.$options.contain) {
+    const { slider } = this;
+    if (!slider) {
+      return;
+    }
+
+    if (this.$options.contain && !slider.$options.contain) {
       this.$warn(
         `The contain option will only works if the parent Slider also has the contain option.`,
       );
@@ -39,13 +44,12 @@ export class SliderBtn<T extends BaseProps = BaseProps> extends AbstractSliderCh
 
     const isContainMaxState =
       this.$options.contain &&
-      this.$parent.$options.contain &&
-      this.$parent.containMaxState ===
-        this.$parent.getStates()[index].x[this.$parent.$options.mode];
+      slider.$options.contain &&
+      slider.containMaxState === slider.getStates()[index].x[slider.$options.mode];
 
     if (
       (index === 0 && this.$options.prev) ||
-      ((index === this.$parent.indexMax || isContainMaxState) && this.$options.next)
+      ((index === slider.indexMax || isContainMaxState) && this.$options.next)
     ) {
       this.$el.setAttribute('disabled', '');
     } else {
@@ -58,11 +62,15 @@ export class SliderBtn<T extends BaseProps = BaseProps> extends AbstractSliderCh
    */
   onClick() {
     const { prev, next } = this.$options;
+    const { slider } = this;
+    if (!slider) {
+      return;
+    }
 
     if (prev) {
-      this.$parent.goPrev();
+      slider.goPrev();
     } else if (next) {
-      this.$parent.goNext();
+      slider.goNext();
     }
   }
 }

--- a/packages/ui/Slider/SliderDots.ts
+++ b/packages/ui/Slider/SliderDots.ts
@@ -49,6 +49,6 @@ export class SliderDots<
    * Go to the given index on dot click.
    */
   onDotsClick({ index }: { index: number }) {
-    this.$parent.goTo(index);
+    this.slider?.goTo(index);
   }
 }

--- a/packages/ui/Slider/SliderProgress.ts
+++ b/packages/ui/Slider/SliderProgress.ts
@@ -26,9 +26,14 @@ export class SliderProgress<T extends BaseProps = BaseProps> extends AbstractSli
    * Update the progress indicator.
    */
   update(index: number) {
+    const { slider } = this;
+    if (!slider) {
+      return;
+    }
+
     domScheduler.read(() => {
       const { progress } = this.$refs;
-      const x = map(index, 0, this.$parent.indexMax, progress.clientWidth * -1, 0);
+      const x = map(index, 0, slider.indexMax, progress.clientWidth * -1, 0);
       domScheduler.write(() => {
         transform(progress, { x });
       });

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -33,9 +33,9 @@
     "morphdom": "^2.7.8"
   },
   "devDependencies": {
-    "@studiometa/js-toolkit": "3.4.3"
+    "@studiometa/js-toolkit": "^3.6.0"
   },
   "peerDependencies": {
-    "@studiometa/js-toolkit": "^3.4.0"
+    "@studiometa/js-toolkit": "^3.6.0"
   }
 }


### PR DESCRIPTION
## Problem

Slider child components (`SliderBtn`, `SliderCount`, `SliderDots`, `SliderProgress`) dereferenced the deprecated `$parent` accessor during `mounted()` (`this.$parent.$on('index', this)`). Since `@studiometa/js-toolkit` 3.4.1, children auto-mount independently of their parent, so `$parent` can be `null`/`undefined` while a child mounts before its parent — crashing the child. `AccordionItem` had the same pattern (guarded, so it failed silently rather than crashing). `$parent`, `$children` and `$root` are deprecated in js-toolkit 3.5+ and removed in v4.

## Fix

- **Baseline:** target `@studiometa/js-toolkit@^3.6.0`, which ships `createStorage` / `createMemoryStorageProvider` and the corrected `$closest` ancestor resolution. All workspace pins aligned to a single `3.6.0` to avoid a duplicated component instance registry.
- **Slider → children:** `Slider` broadcasts the current index through a per-instance store (`createStorage`). Children subscribe via a guarded, cached `$closest('Slider')` lookup and never touch `$parent`.
- **Deterministic two-sided handshake:** a child connects on its own `mounted()` when the Slider already exists; the Slider connects its children in its own `mounted()` (after seeding the store) to cover children that mounted first. The initial index is pulled only once the store is seeded, so `update()` never runs against a not-yet-initialised Slider (this previously crashed `contain`-mode `SliderBtn` reading empty geometry).
- **Upward calls / geometry reads** in the controls and **option inheritance** in `AccordionItem` resolve their ancestor through a guarded `$closest(...)` lookup.

## Tests

- New Slider tests: a child fully mounted **before** its Slider still synchronises; a `contain` `SliderBtn` connects on first mount without reading empty geometry; contain-mode disabled logic. Each new test was verified to **fail when its corresponding fix is reverted**.
- The `js-toolkit` 3.6.0 bump surfaced a **pre-existing** async-transition leak in the Menu tests (an unawaited `withTransition` resolving after happy-dom teardown → `ReferenceError: Node is not defined`). Fixed in its own commit by letting Menu transitions settle between tests.

## Validation

`npm run lint` ✅ · `npm run test` ✅ (292 passing, stable across repeated runs) · typecheck ✅.

## Notes

- Versioned as a minor within the current beta line; changelog under `[Unreleased]`.
- Out of scope: a full `$children` → `$query` migration (`$children` is also deprecated and used across several components) — a larger v4-readiness pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)