### PR TITLE
Fix cross-file test flake from leaked animation frames

### DIFF
--- a/packages/tests/Menu/Menu.spec.ts
+++ b/packages/tests/Menu/Menu.spec.ts
@@ -1,16 +1,7 @@
-import { describe, it, expect, vi, afterEach } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { getInstanceFromElement } from '@studiometa/js-toolkit';
 import { Menu, MenuBtn, MenuList } from '@studiometa/ui';
 import { h, mount, wait } from '#test-utils';
-
-// The MenuList open/close/toggle transitions are asynchronous (`withTransition`
-// schedules work over a few animation frames). Tests trigger them without
-// awaiting, so let any pending transition settle within this file's happy-dom
-// environment — otherwise it resolves during a later test file whose globals
-// have been torn down (`ReferenceError: Node is not defined`).
-afterEach(async () => {
-  await wait(50);
-});
 
 async function getContext({ mode = 'click' } = {}) {
   const menuBtn = h('button', { dataComponent: 'MenuBtn' }, ['Click me']);

--- a/packages/tests/__utils__/happydom.ts
+++ b/packages/tests/__utils__/happydom.ts
@@ -1,4 +1,6 @@
 import { GlobalRegistrator } from '@happy-dom/global-registrator';
+import { afterEach } from 'vitest';
+import { getInstances } from '@studiometa/js-toolkit';
 
 GlobalRegistrator.register();
 
@@ -6,6 +8,15 @@ window.__DEV__ = true;
 
 let y = 0;
 let x = 0;
+
+// Track pending `requestAnimationFrame` callbacks (mocked with `setTimeout`) so
+// they can be cancelled — happy-dom does not provide `cancelAnimationFrame`,
+// and js-toolkit's RAF loop and the transition helper reschedule themselves
+// every frame. Without cancellation a leftover frame fires after the test
+// file's environment is torn down (`ReferenceError: Node is not defined`, …),
+// surfacing as cross-file unhandled errors.
+const pendingRafs = new Map<number, ReturnType<typeof setTimeout>>();
+let rafId = 0;
 
 Object.defineProperties(window, {
   scrollY: {
@@ -25,10 +36,42 @@ Object.defineProperties(window, {
     },
   },
   requestAnimationFrame: {
-    value(callback) {
-      return setTimeout(() => {
+    value(callback: FrameRequestCallback) {
+      const id = ++rafId;
+      const timer = setTimeout(() => {
+        pendingRafs.delete(id);
         callback(performance.now());
       }, 16);
+      pendingRafs.set(id, timer);
+      return id;
     },
   },
+  cancelAnimationFrame: {
+    value(id: number) {
+      const timer = pendingRafs.get(id);
+      if (timer) {
+        clearTimeout(timer);
+        pendingRafs.delete(id);
+      }
+    },
+  },
+});
+
+// Cancel every pending animation frame, breaking any self-rescheduling loop.
+function clearPendingRafs() {
+  for (const timer of pendingRafs.values()) {
+    clearTimeout(timer);
+  }
+  pendingRafs.clear();
+}
+
+// Clean up after every test: destroy any component a test left mounted (which
+// stops its services — the RAF loop, pointer/resize listeners…) and cancel any
+// frame still pending (e.g. an in-flight transition). This keeps a test's
+// asynchronous work from leaking into the next test file and firing against a
+// torn-down environment.
+afterEach(async () => {
+  const mounted = [...getInstances()].filter((instance) => instance.$isMounted);
+  await Promise.allSettled(mounted.map((instance) => instance.$destroy()));
+  clearPendingRafs();
 });


### PR DESCRIPTION
### ❓ Type of change

- [x] 🐞 Bug fix (test infrastructure)

### 📚 Description

Some component specs mount instances but never destroy them. Those components keep self-rescheduling `requestAnimationFrame` work running — the js-toolkit RAF loop (any component with a `ticked` hook, e.g. `Hoverable`) and the `withTransition` helper (`Menu`/`MenuList`). Because the happy-dom `requestAnimationFrame` mock is a `setTimeout(16)` with **no `cancelAnimationFrame`**, a leftover frame fires *after* the test file's environment has been torn down, throwing `ReferenceError: Node is not defined` (and similar) as an **intermittent, cross-file unhandled error** — reproduced at roughly 1 run in 6.

#### Fix

- Make the happy-dom `requestAnimationFrame` mock **cancellable**: track pending timers and add a real `cancelAnimationFrame`.
- Add a global `afterEach` in the test setup that:
  - destroys any instance a test left mounted (stops its services — the RAF loop, pointer/resize listeners…), and
  - cancels every still-pending animation frame (e.g. an in-flight transition),

  so a test's async work can't leak into the next file.
- Remove the now-redundant per-file transition-settle workaround (`afterEach(wait(50))`) from the Menu spec — the central fix supersedes it.

### ✅ Validation

- Baseline: the flake reproduced ~1/6 runs (`MenuList.leave → transition → Node is not defined`, and the `Hoverable` RAF loop).
- With the fix: **0 flakes across ~22 full-suite runs**, 343 tests passing, types + oxlint clean, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)