### PR TITLE
Refactor Data reactivity with signals

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6369,10 +6369,9 @@
       }
     },
     "node_modules/alien-signals": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-3.1.2.tgz",
-      "integrity": "sha512-d9dYqZTS90WLiU0I5c6DHj/HcKkF8ZyGN3G5x8wSbslulz70KOxaqCT0hQCo9KOyhVqzqGojvNdJXoTumZOtcw==",
-      "dev": true,
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-3.2.1.tgz",
+      "integrity": "sha512-I8FjmltrfnDFoZedi5CG8DghVYNhzb/Ijluz7tCSJH0xpd0484Kowhbb1XDYOxfJpU1p5wnM2X54dA+IfGyD1g==",
       "license": "MIT"
     },
     "node_modules/ansi-html-community": {
@@ -21163,6 +21162,7 @@
       "version": "1.9.0-beta.0",
       "license": "MIT",
       "dependencies": {
+        "alien-signals": "^3.2.1",
         "deepmerge": "^4.3.1",
         "morphdom": "^2.7.8"
       },

--- a/packages/tests/Data/DataBind.spec.ts
+++ b/packages/tests/Data/DataBind.spec.ts
@@ -1,5 +1,13 @@
 import { it, describe, expect, vi } from 'vitest';
-import { Action, DataBind, DataComputed, DataEffect, DataModel, DataScope } from '@studiometa/ui';
+import {
+  Action,
+  DataBind,
+  DataComputed,
+  DataEffect,
+  DataModel,
+  DataScope,
+  type DataValue,
+} from '@studiometa/ui';
 import { nextTick } from '@studiometa/js-toolkit/utils';
 import { destroy, hConnected as h, mount } from '#test-utils';
 
@@ -304,6 +312,108 @@ describe('The DataBind component', () => {
     expect(instance2.value).toBe('bar');
     expect(instance3.value).toBe('barbar');
     expect(instance4.$el.id).toBe('bar');
+  });
+
+  it('should deliver group updates through the public set method', async () => {
+    const legacySource = new DataBind(h('div', { dataOptionGroup: 'custom-set' }));
+    const legacySubscriber = new DataBind(h('div', { dataOptionGroup: 'custom-set' }));
+    const legacySet = vi.spyOn(legacySubscriber, 'set');
+    await mount(legacySource, legacySubscriber);
+
+    legacySource.set('legacy');
+    expect(legacySet).toHaveBeenCalledWith('legacy', false);
+
+    const root = h('div', { dataOptionGroup: 'person' });
+    const input = h('input', { name: 'first' });
+    const output = h('div', { dataOptionKey: 'first' });
+    root.append(input, output);
+    const scope = new DataScope(root);
+    const scopedSource = new DataModel(input);
+    const scopedSubscriber = new DataBind(output);
+    const scopedSet = vi.spyOn(scopedSubscriber, 'set');
+    await mount(scope, scopedSource, scopedSubscriber);
+
+    scopedSource.set('scoped');
+    expect(scopedSet).toHaveBeenCalledWith('scoped', false);
+
+    await destroy(legacySource, legacySubscriber, scope, scopedSource, scopedSubscriber);
+  });
+
+  it('should preserve the latest value during reentrant group updates', async () => {
+    class ReentrantDataBind extends DataBind {
+      private dispatched = false;
+
+      set(value: DataValue, dispatch = true) {
+        super.set(value, dispatch);
+
+        if (!dispatch && value === 'outer' && !this.dispatched) {
+          this.dispatched = true;
+          super.set('inner');
+        }
+      }
+    }
+
+    const source = new DataBind(h('div', { dataOptionGroup: 'reentrant' }));
+    const reentrant = new ReentrantDataBind(h('div', { dataOptionGroup: 'reentrant' }));
+    const output = new DataBind(h('div', { dataOptionGroup: 'reentrant' }));
+    await mount(source, reentrant, output);
+
+    source.set('outer');
+
+    expect(source.value).toBe('inner');
+    expect(reentrant.value).toBe('inner');
+    expect(output.value).toBe('inner');
+
+    await destroy(source, reentrant, output);
+  });
+
+  it('should not run effects on mount unless an immediate value is dispatched', async () => {
+    const passiveElement = h('div', {
+      dataOptionGroup: 'passive-effect',
+      dataOptionEffect: 'target.dataset.called = "true"',
+    });
+    const immediateElement = h('div', {
+      dataOptionGroup: 'immediate-effect',
+      dataOptionEffect:
+        'target.dataset.calls = String(Number(target.dataset.calls || 0) + 1)',
+      dataOptionImmediate: true,
+    });
+    const passive = new DataEffect(passiveElement);
+    const immediate = new DataEffect(immediateElement);
+
+    await mount(passive, immediate);
+    expect(passiveElement.dataset.called).toBeUndefined();
+    expect(immediateElement.dataset.calls).toBeUndefined();
+
+    await nextTick();
+    expect(passiveElement.dataset.called).toBeUndefined();
+    expect(immediateElement.dataset.calls).toBe('1');
+
+    await destroy(passive, immediate);
+  });
+
+  it('should dispose and recreate group subscriptions across lifecycle changes', async () => {
+    const source = new DataBind(h('div', { dataOptionGroup: 'lifecycle' }));
+    const effectElement = h('div', {
+      dataOptionGroup: 'lifecycle',
+      dataOptionEffect:
+        'target.dataset.calls = String(Number(target.dataset.calls || 0) + 1)',
+    });
+    const effect = new DataEffect(effectElement);
+    await mount(source, effect);
+
+    source.set('first');
+    expect(effectElement.dataset.calls).toBe('1');
+
+    await destroy(effect);
+    source.set('second');
+    expect(effectElement.dataset.calls).toBe('1');
+
+    await mount(effect);
+    source.set('third');
+    expect(effectElement.dataset.calls).toBe('2');
+
+    await destroy(source, effect);
   });
 
   it('should forget related instances not in the DOM anymore', async () => {

--- a/packages/tests/Data/DataScope.spec.ts
+++ b/packages/tests/Data/DataScope.spec.ts
@@ -269,6 +269,37 @@ describe('The DataScope component', () => {
     });
   });
 
+  it('should synchronously notify scoped subscribers for repeated equal writes', async () => {
+    const root = h('div', { dataOptionGroup: 'person' });
+    const input = h('input', { name: 'first' });
+    const output = h('div', { dataOptionKey: 'first' });
+    const effectElement = h('div', {
+      dataOptionEffect:
+        'target.dataset.calls = String(Number(target.dataset.calls || 0) + 1); target.dataset.value = value',
+    });
+    root.append(input, output, effectElement);
+
+    const scope = new DataScope(root);
+    const model = new DataModel(input);
+    const bind = new DataBind(output);
+    const effect = new DataEffect(effectElement);
+    await mount(scope, model, bind, effect);
+
+    model.set('Ada');
+    const firstSnapshot = model.$data;
+    expect(bind.value).toBe('Ada');
+    expect(effectElement.dataset.calls).toBe('1');
+    expect(effectElement.dataset.value).toBe('Ada');
+
+    model.set('Ada');
+    expect(bind.value).toBe('Ada');
+    expect(effectElement.dataset.calls).toBe('2');
+    expect(model.$data).toEqual({ first: 'Ada' });
+    expect(model.$data).not.toBe(firstSnapshot);
+
+    await destroy(scope, model, bind, effect);
+  });
+
   it('should recompute unkeyed subscribers for every keyed update', async () => {
     const root = h('div', { dataOptionGroup: 'values' });
     const firstInput = h('input', {
@@ -338,6 +369,37 @@ describe('The DataScope component', () => {
     expect(effectElement.dataset.frozen).toBe('true');
 
     await destroy(scope, first, last, computed, effect);
+  });
+
+  it('should notify once when hydrating multiple immediate sources for the same key', async () => {
+    const root = h('div', { dataOptionGroup: 'person' });
+    const firstInput = h('input', {
+      name: 'first',
+      value: 'Ada',
+      dataOptionImmediate: true,
+    });
+    const secondInput = h('input', {
+      name: 'first',
+      value: 'Ada',
+      dataOptionImmediate: true,
+    });
+    const effectElement = h('div', {
+      dataOptionEffect:
+        'target.dataset.values = (target.dataset.values || "") + $data.first + "|"',
+    });
+    root.append(firstInput, secondInput, effectElement);
+
+    const scope = new DataScope(root);
+    const first = new DataModel(firstInput);
+    const second = new DataModel(secondInput);
+    const effect = new DataEffect(effectElement);
+    await mount(scope, first, second, effect);
+    await nextTick();
+
+    expect(effectElement.dataset.values?.split('|').filter(Boolean)).toEqual(['Ada']);
+    expect(scope.getData('person')).toEqual({ first: 'Ada' });
+
+    await destroy(scope, first, second, effect);
   });
 
   it('should hydrate and track only the selected radio', async () => {

--- a/packages/ui/Data/DataBind.ts
+++ b/packages/ui/Data/DataBind.ts
@@ -1,9 +1,20 @@
 import { Base, withGroup } from '@studiometa/js-toolkit';
 import type { BaseConfig, BaseProps } from '@studiometa/js-toolkit';
-import { isArray, nextTick } from '@studiometa/js-toolkit/utils';
+import { nextTick } from '@studiometa/js-toolkit/utils';
+import { getDataChannel } from './DataChannel.js';
 import { DataScope, getDataScope } from './DataScope.js';
-import type { DataValue } from './DataScope.js';
-import { getCallback, isInput, isCheckbox, isSelect } from './utils.js';
+import type { DataScopeMember, DataValue } from './DataScope.js';
+import {
+  type DataControlContext,
+  isCheckbox,
+  isInput,
+  readControlValue,
+  resolvePropertyName,
+  setProperty,
+  valuesEqual,
+  writeControlValue,
+} from './formControl.js';
+import { getCallback } from './utils.js';
 
 export interface DataBindProps extends BaseProps {
   $options: {
@@ -15,69 +26,9 @@ export interface DataBindProps extends BaseProps {
 
 const EMPTY_DATA = Object.freeze({});
 
-function valuesEqual(left: DataValue, right: DataValue) {
-  if (Object.is(left, right)) {
-    return true;
-  }
-
-  if (left instanceof Date && right instanceof Date) {
-    return left.getTime() === right.getTime();
-  }
-
-  if (Array.isArray(left) && Array.isArray(right)) {
-    return (
-      left.length === right.length && left.every((value, index) => value === right[index])
-    );
-  }
-
-  const isNumberAndString =
-    (typeof left === 'number' && typeof right === 'string') ||
-    (typeof left === 'string' && typeof right === 'number');
-  const isArrayAndString =
-    (Array.isArray(left) && typeof right === 'string') ||
-    (typeof left === 'string' && Array.isArray(right));
-
-  return (isNumberAndString || isArrayAndString) && String(left) === String(right);
-}
-
 type VirtualBinding =
   | { type: 'text'; expression: string }
   | { type: 'prop' | 'attr' | 'class' | 'style'; name: string; expression: string };
-
-function setProperty(target: HTMLElement, name: string, value: unknown) {
-  if (value !== null && value !== undefined) {
-    target[name] = value;
-    return;
-  }
-
-  switch (name) {
-    case 'valueAsDate':
-      target[name] = null;
-      break;
-    case 'valueAsNumber':
-      target[name] = Number.NaN;
-      break;
-    default:
-      target[name] = '';
-  }
-}
-
-function resolvePropertyName(target: HTMLElement, name: string) {
-  const normalizedName = name.replaceAll('-', '').toLowerCase();
-  let current: object | null = target;
-
-  while (current) {
-    const property = Object.getOwnPropertyNames(current).find(
-      (candidate) => candidate.toLowerCase() === normalizedName,
-    );
-    if (property) {
-      return property;
-    }
-    current = Object.getPrototypeOf(current);
-  }
-
-  return name.replace(/-([a-z])/g, (_, letter: string) => letter.toUpperCase());
-}
 
 /**
  * DataBind class.
@@ -97,6 +48,7 @@ export class DataBind<T extends BaseProps = BaseProps> extends withGroup(Base, '
 
   private __dataScopeResolved = false;
   private __dataScope?: DataScope;
+  private __stopUpdates?: () => void;
   private __virtualBindings?: VirtualBinding[];
   private __virtualValue?: DataValue;
   private __hasVirtualValue = false;
@@ -186,6 +138,23 @@ export class DataBind<T extends BaseProps = BaseProps> extends withGroup(Base, '
     return this.group.endsWith('[]');
   }
 
+  private get channel() {
+    return (
+      this.dataScope?.getChannel(this.group) ??
+      getDataChannel(this.$group as Set<DataScopeMember>)
+    );
+  }
+
+  protected get controlContext(): DataControlContext {
+    return {
+      dataKey: this.dataKey,
+      members: this.relatedInstances,
+      multiple: this.multiple,
+      prop: this.prop,
+      target: this.target,
+    };
+  }
+
   get target() {
     return this.$el;
   }
@@ -227,62 +196,18 @@ export class DataBind<T extends BaseProps = BaseProps> extends withGroup(Base, '
   }
 
   protected getTargetValue(): DataValue {
-    const { target, multiple } = this;
-
-    if (isSelect(target)) {
-      if (multiple) {
-        const values = [] as string[];
-        // @ts-ignore
-        for (const option of target.options) {
-          if (option.selected) {
-            values.push(option.value);
-          }
-        }
-
-        return values;
-      }
-
-      const option = target.options.item(target.selectedIndex);
-      return option?.value;
-    }
-
-    if (isCheckbox(target)) {
-      if (multiple) {
-        const values = new Set<string>();
-        for (const instance of this.relatedInstances) {
-          if (
-            (!this.dataKey || instance.dataKey === this.dataKey) &&
-            isCheckbox(instance.target) &&
-            instance.target.checked
-          ) {
-            values.add(instance.target.value);
-          }
-        }
-        return Array.from(values);
-      } else {
-        return target.checked;
-      }
-    }
-
-    return target[this.prop];
+    return readControlValue(this.controlContext);
   }
 
   set(value: DataValue, dispatch = true) {
-    if (dispatch && this.dataScope && this.dataKey) {
-      this.__dispatchScopedValue(value);
-      return;
+    const publication = dispatch ? this.publishValue(value) : undefined;
+
+    if (!publication || publication.channel.isCurrent(publication.frame)) {
+      this.applyValue(value);
     }
+  }
 
-    const { target, multiple, relatedInstances } = this;
-
-    if (dispatch) {
-      for (const instance of relatedInstances) {
-        if (instance !== this && (instance.hasVirtualBindings || instance.value !== value)) {
-          instance.set(value, false);
-        }
-      }
-    }
-
+  private applyValue(value: DataValue) {
     if (this.hasVirtualBindings) {
       this.__virtualValue = value;
       this.__hasVirtualValue = true;
@@ -290,28 +215,36 @@ export class DataBind<T extends BaseProps = BaseProps> extends withGroup(Base, '
       return;
     }
 
-    if (isSelect(target)) {
-      // @ts-ignore
-      for (const option of target.options) {
-        option.selected =
-          multiple && isArray(value) ? value.includes(option.value) : option.value === value;
+    writeControlValue(this.controlContext, value);
+  }
+
+  /**
+   * Publish a value to the resolved Data group without applying it locally.
+   * @internal
+   */
+  protected publishValue(value: DataValue, force = false, updateData = true) {
+    if (this.dataScope && this.dataKey) {
+      if (updateData) {
+        this.dataScope.setValue(this.group, this.dataKey, value, this);
       }
-      return;
+
+      const channel = this.dataScope.getChannel(this.group);
+      const frame = channel.publish({
+        force: true,
+        key: this.dataKey,
+        source: this,
+        value,
+      });
+      return { channel, frame };
     }
 
-    if (isInput(target)) {
-      switch (target.type) {
-        case 'radio':
-          target.checked = target.value === value;
-          return;
-        case 'checkbox':
-          target.checked =
-            multiple && isArray(value) ? value.includes(target.value) : Boolean(value);
-          return;
-      }
-    }
-
-    setProperty(target, this.prop, value);
+    const channel = this.channel;
+    const frame = channel.publish({
+      force,
+      source: this,
+      value,
+    });
+    return { channel, frame };
   }
 
   private applyVirtualBindings(value: DataValue) {
@@ -364,24 +297,11 @@ export class DataBind<T extends BaseProps = BaseProps> extends withGroup(Base, '
    * @internal
    */
   __dispatchScopedValue(value: DataValue, updateData = true) {
-    const { dataScope, dataKey, relatedInstances } = this;
+    const publication = this.publishValue(value, true, updateData);
 
-    if (!dataScope || !dataKey) {
-      this.set(value);
-      return;
+    if (publication.channel.isCurrent(publication.frame)) {
+      this.set(value, false);
     }
-
-    if (updateData) {
-      dataScope.setValue(this.group, dataKey, value, this);
-    }
-
-    for (const instance of relatedInstances) {
-      if (instance !== this && (!instance.dataKey || instance.dataKey === dataKey)) {
-        instance.set(value, false);
-      }
-    }
-
-    this.set(value, false);
   }
 
   private validateMutation(method: string) {
@@ -435,6 +355,23 @@ export class DataBind<T extends BaseProps = BaseProps> extends withGroup(Base, '
   }
 
   mounted() {
+    this.__stopUpdates?.();
+    this.__stopUpdates = this.channel.subscribe((update) => {
+      if (!this.$el.isConnected) {
+        this.__stopUpdates?.();
+        this.__stopUpdates = undefined;
+        return;
+      }
+
+      if (
+        update.source !== this &&
+        (!update.key || !this.dataKey || update.key === this.dataKey) &&
+        (update.force || this.hasVirtualBindings || this.value !== update.value)
+      ) {
+        this.set(update.value, false);
+      }
+    });
+
     if (!this.$options.immediate) {
       return;
     }
@@ -450,6 +387,9 @@ export class DataBind<T extends BaseProps = BaseProps> extends withGroup(Base, '
   }
 
   destroyed() {
+    this.__stopUpdates?.();
+    this.__stopUpdates = undefined;
+
     if (this.dataScope && this.dataKey) {
       this.dataScope.deleteValue(this.group, this.dataKey, this);
     }

--- a/packages/ui/Data/DataChannel.ts
+++ b/packages/ui/Data/DataChannel.ts
@@ -1,0 +1,68 @@
+import { effect, signal } from 'alien-signals';
+import type { DataScopeMember, DataValue } from './DataScope.js';
+
+const INITIAL = Symbol('initial-data-update');
+
+export interface DataUpdate {
+  readonly force: boolean;
+  readonly key?: string;
+  readonly source?: DataScopeMember;
+  readonly value: DataValue;
+}
+
+type DataUpdateSubscriber = (update: DataUpdate) => void;
+
+/**
+ * Synchronously publish Data group updates through a signal-backed channel.
+ * @internal
+ */
+export class DataChannel {
+  private update = signal<DataUpdate | typeof INITIAL>(INITIAL);
+  private latest?: DataUpdate;
+
+  publish(update: DataUpdate) {
+    // Always publish a fresh frame so equal values remain observable events.
+    const frame = { ...update };
+    this.latest = frame;
+    this.update(frame);
+    return frame;
+  }
+
+  isCurrent(frame: DataUpdate) {
+    return this.latest === frame;
+  }
+
+  subscribe(subscriber: DataUpdateSubscriber) {
+    let initialized = false;
+
+    return effect(() => {
+      const update = this.update();
+
+      if (!initialized) {
+        initialized = true;
+        return;
+      }
+
+      if (update !== INITIAL) {
+        subscriber(update);
+      }
+    });
+  }
+}
+
+const channels = new WeakMap<Set<DataScopeMember>, DataChannel>();
+
+/**
+ * Get the signal channel associated with a legacy Data group.
+ * @internal
+ */
+export function getDataChannel(group: Set<DataScopeMember>) {
+  let channel = channels.get(group);
+
+  if (!channel) {
+    channel = new DataChannel();
+    channels.set(group, channel);
+  }
+
+  return channel;
+}

--- a/packages/ui/Data/DataChannel.ts
+++ b/packages/ui/Data/DataChannel.ts
@@ -50,13 +50,25 @@ export class DataChannel {
   }
 }
 
-const channels = new WeakMap<Set<DataScopeMember>, DataChannel>();
+type GlobalWithDataChannels = typeof globalThis & {
+  __STUDIOMETA_UI_DATA_CHANNELS__?: WeakMap<Set<DataScopeMember>, DataChannel>;
+};
+
+/**
+ * Get the global Data channel storage so it can be shared between different
+ * instances of the package.
+ */
+function getChannelsStorage() {
+  const global = globalThis as GlobalWithDataChannels;
+  return (global.__STUDIOMETA_UI_DATA_CHANNELS__ ??= new WeakMap());
+}
 
 /**
  * Get the signal channel associated with a legacy Data group.
  * @internal
  */
 export function getDataChannel(group: Set<DataScopeMember>) {
+  const channels = getChannelsStorage();
   let channel = channels.get(group);
 
   if (!channel) {

--- a/packages/ui/Data/DataModel.ts
+++ b/packages/ui/Data/DataModel.ts
@@ -1,7 +1,7 @@
 import type { BaseConfig, BaseProps } from '@studiometa/js-toolkit';
 import { DataBind } from './DataBind.js';
 import type { DataBindProps } from './DataBind.js';
-import { isCheckbox } from './utils.js';
+import { serializeControlValue } from './formControl.js';
 
 export interface DataModelProps extends DataBindProps {}
 
@@ -11,22 +11,11 @@ export class DataModel<T extends BaseProps = BaseProps> extends DataBind<DataMod
   };
 
   dispatch() {
-    const { target, multiple } = this;
-    let value = this.getTargetValue();
+    const value = serializeControlValue(this.controlContext);
+    const publication = this.publishValue(value, true);
 
-    if (multiple && isCheckbox(target) && !target.checked && Array.isArray(value)) {
-      const set = new Set(value);
-      set.delete(target.value);
-      value = Array.from(set);
-    }
-
-    if (this.dataScope && this.dataKey) {
-      this.set(value);
-      return;
-    }
-
-    for (const instance of this.relatedInstances) {
-      instance.set(value, false);
+    if (publication.channel.isCurrent(publication.frame)) {
+      this.set(value, false);
     }
   }
 

--- a/packages/ui/Data/DataScope.ts
+++ b/packages/ui/Data/DataScope.ts
@@ -1,6 +1,7 @@
 import { Base } from '@studiometa/js-toolkit';
 import type { BaseConfig, BaseProps } from '@studiometa/js-toolkit';
 import { nextTick } from '@studiometa/js-toolkit/utils';
+import { DataChannel } from './DataChannel.js';
 
 export interface DataScopeProps extends BaseProps {
   $options: {
@@ -18,6 +19,7 @@ export interface DataScopeMember extends Base {
 }
 
 interface DataScopeGroup {
+  channel: DataChannel;
   instances: Set<DataScopeMember>;
   sources: Map<string, Set<DataScopeMember>>;
   values: Map<string, DataValue>;
@@ -81,6 +83,7 @@ export class DataScope<T extends BaseProps = BaseProps> extends Base<DataScopePr
 
     if (!record) {
       record = {
+        channel: new DataChannel(),
         instances: new Set(),
         sources: new Map(),
         values: new Map(),
@@ -161,15 +164,12 @@ export class DataScope<T extends BaseProps = BaseProps> extends Base<DataScopePr
     value: DataValue,
     excludedSource?: DataScopeMember,
   ) {
-    for (const instance of record.instances) {
-      if (
-        instance !== excludedSource &&
-        instance.$el.isConnected &&
-        (!instance.dataKey || instance.dataKey === key)
-      ) {
-        instance.set(value, false);
-      }
-    }
+    record.channel.publish({
+      force: true,
+      key,
+      source: excludedSource,
+      value,
+    });
   }
 
   getGroup(group: string) {
@@ -178,6 +178,14 @@ export class DataScope<T extends BaseProps = BaseProps> extends Base<DataScopePr
 
   getData(group: string) {
     return this.getRecord(group).data;
+  }
+
+  /**
+   * Get the signal channel for a scoped Data group.
+   * @internal
+   */
+  getChannel(group: string) {
+    return this.getRecord(group).channel;
   }
 
   setValue(group: string, key: string, value: DataValue, source?: DataScopeMember) {

--- a/packages/ui/Data/formControl.ts
+++ b/packages/ui/Data/formControl.ts
@@ -1,0 +1,177 @@
+import type { DataValue } from './DataScope.js';
+
+export interface DataControlMember {
+  readonly dataKey: string;
+  readonly target: HTMLElement;
+}
+
+export interface DataControlContext {
+  readonly dataKey: string;
+  readonly members: Iterable<DataControlMember>;
+  readonly multiple: boolean;
+  readonly prop: string;
+  readonly target: HTMLElement;
+}
+
+export function isInput(element: Element): element is HTMLInputElement {
+  return element instanceof HTMLInputElement;
+}
+
+export function isCheckbox(element: Element): element is HTMLInputElement {
+  return isInput(element) && element.type === 'checkbox';
+}
+
+export function isSelect(element: Element): element is HTMLSelectElement {
+  return element instanceof HTMLSelectElement;
+}
+
+export function valuesEqual(left: DataValue, right: DataValue) {
+  if (Object.is(left, right)) {
+    return true;
+  }
+
+  if (left instanceof Date && right instanceof Date) {
+    return left.getTime() === right.getTime();
+  }
+
+  if (Array.isArray(left) && Array.isArray(right)) {
+    return left.length === right.length && left.every((value, index) => value === right[index]);
+  }
+
+  const isNumberAndString =
+    (typeof left === 'number' && typeof right === 'string') ||
+    (typeof left === 'string' && typeof right === 'number');
+  const isArrayAndString =
+    (Array.isArray(left) && typeof right === 'string') ||
+    (typeof left === 'string' && Array.isArray(right));
+
+  return (isNumberAndString || isArrayAndString) && String(left) === String(right);
+}
+
+export function setProperty(target: HTMLElement, name: string, value: unknown) {
+  if (value !== null && value !== undefined) {
+    target[name] = value;
+    return;
+  }
+
+  switch (name) {
+    case 'valueAsDate':
+      target[name] = null;
+      break;
+    case 'valueAsNumber':
+      target[name] = Number.NaN;
+      break;
+    default:
+      target[name] = '';
+  }
+}
+
+export function resolvePropertyName(target: HTMLElement, name: string) {
+  const normalizedName = name.replaceAll('-', '').toLowerCase();
+  let current: object | null = target;
+
+  while (current) {
+    const property = Object.getOwnPropertyNames(current).find(
+      (candidate) => candidate.toLowerCase() === normalizedName,
+    );
+    if (property) {
+      return property;
+    }
+    current = Object.getPrototypeOf(current);
+  }
+
+  return name.replace(/-([a-z])/g, (_, letter: string) => letter.toUpperCase());
+}
+
+/**
+ * Read a value from a form control or generic element property.
+ * @internal
+ */
+export function readControlValue({
+  dataKey,
+  members,
+  multiple,
+  prop,
+  target,
+}: DataControlContext): DataValue {
+  if (isSelect(target)) {
+    if (multiple) {
+      const values = [] as string[];
+      for (const option of target.options) {
+        if (option.selected) {
+          values.push(option.value);
+        }
+      }
+
+      return values;
+    }
+
+    return target.options.item(target.selectedIndex)?.value;
+  }
+
+  if (isCheckbox(target)) {
+    if (multiple) {
+      const values = new Set<string>();
+      for (const member of members) {
+        if ((!dataKey || member.dataKey === dataKey) && isCheckbox(member.target)) {
+          if (member.target.checked) {
+            values.add(member.target.value);
+          }
+        }
+      }
+      return Array.from(values);
+    }
+
+    return target.checked;
+  }
+
+  return target[prop];
+}
+
+/**
+ * Serialize a model event while preserving grouped checkbox semantics.
+ * @internal
+ */
+export function serializeControlValue(context: DataControlContext): DataValue {
+  const value = readControlValue(context);
+  const { multiple, target } = context;
+
+  if (multiple && isCheckbox(target) && !target.checked && Array.isArray(value)) {
+    const values = new Set(value);
+    values.delete(target.value);
+    return Array.from(values);
+  }
+
+  return value;
+}
+
+/**
+ * Write a value to a form control or generic element property.
+ * @internal
+ */
+export function writeControlValue(
+  { multiple, prop, target }: DataControlContext,
+  value: DataValue,
+) {
+  if (isSelect(target)) {
+    for (const option of target.options) {
+      option.selected =
+        multiple && Array.isArray(value) ? value.includes(option.value) : option.value === value;
+    }
+    return;
+  }
+
+  if (isInput(target)) {
+    switch (target.type) {
+      case 'radio':
+        target.checked = target.value === value;
+        return;
+      case 'checkbox':
+        target.checked =
+          multiple && Array.isArray(value) ? value.includes(target.value) : Boolean(value);
+        return;
+    }
+  }
+
+  setProperty(target, prop, value);
+}

--- a/packages/ui/Data/utils.ts
+++ b/packages/ui/Data/utils.ts
@@ -1,15 +1,3 @@
-export function isInput(el: Element): el is HTMLInputElement {
-  return el instanceof HTMLInputElement;
-}
-
-export function isCheckbox(el: Element): el is HTMLInputElement {
-  return isInput(el) && el.type === 'checkbox';
-}
-
-export function isSelect(el: Element): el is HTMLSelectElement {
-  return el instanceof HTMLSelectElement;
-}
-
 const callbacks = new Map<string, Function>();
 
 export function getCallback(name: string, code: string): Function {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -29,6 +29,7 @@
   },
   "homepage": "https://github.com/studiometa/ui#readme",
   "dependencies": {
+    "alien-signals": "^3.2.1",
     "deepmerge": "^4.3.1",
     "morphdom": "^2.7.8"
   },


### PR DESCRIPTION
## Summary

- replace manual Data group fan-out with synchronous signal-backed update channels powered by `alien-signals`
- preserve keyed/unkeyed routing, repeated equal writes, hydration ordering, subclass `set()` dispatch and lifecycle disposal
- keep the latest value consistent during reentrant group updates
- extract form-control reading, model serialization and writing into Vue-inspired internal helpers without changing the public value model
- add regression coverage for equal scoped writes, initial effect gating, hydration deduplication, lifecycle recreation, public `set()` overrides and reentrant updates

## Implementation notes

The upstream `alien-signals` package is used directly instead of `@webreflection/alien-signals`: the latter is a Preact-style facade over the same dependency and does not reduce the final bundled core. Signals remain a private implementation detail.

The form-control extraction follows Vue's separation of DOM normalization from reactivity, while preserving the existing Data semantics for numbers, dates, grouped checkboxes, selects and the `[]` group convention.

## Validation

- `npm run test` — 47 files passed, 330 tests passed, 3 skipped, 1 todo
- `npm run lint` — passed with 15 pre-existing warnings
- `npm run build`
- `npm run docs:build`
- `git diff --check`