### PR TITLE
Update Data component examples

### DIFF
--- a/packages/docs/components/Action/js-api.md
+++ b/packages/docs/components/Action/js-api.md
@@ -45,8 +45,6 @@ Modifiers can be chained with a `.` as separator:
 
 Use this option to define the components that should be used as targets to the [effect callback](#effect). Multiple components can be defined by using a single space as delimiter.
 
-When an Action is inside a [`DataScope`](../DataScope/index.md), targets are limited to components in that same nearest scope. Actions outside a `DataScope` keep resolving targets globally.
-
 ::: info Name definition
 The `Action` component will use the `name` property defined in the static `config` object of each class to resolve components on the page.
 

--- a/packages/docs/components/DataBind/examples.md
+++ b/packages/docs/components/DataBind/examples.md
@@ -6,7 +6,7 @@ title: DataBind, DataModel, DataEffect and DataComputed examples
 
 ## Immediate propagation
 
-In the following example, we use the `data-option-immediate` attribute to enable the [`immediate` option](./js-api.md#immediate) on the first `<input>`, in order to set the value of the second `<input>` on mount.
+In the following example, the first [`DataModel`](../DataModel/index.md) uses the [`immediate` option](./js-api.md#immediate) to hydrate the scoped `text` key on mount. The second model mirrors the same native `name`, and the keyed `DataBind` renders their shared value.
 
 <llm-exclude>
 <PreviewPlayground

--- a/packages/docs/components/DataBind/index.md
+++ b/packages/docs/components/DataBind/index.md
@@ -6,7 +6,7 @@ badges: [JS]
 
 Use the `DataBind` to create a one-way binding of a property of the targeted DOM element. This component should be used with the [`DataModel` component](../DataModel/index.md), which handles two-way bindings.
 
-The related [`DateComputed`](../DataComputed/index.md) and [`DataEffect`](../DataEffect/index.md) components can also be used for computed values and side effects respectively.
+The related [`DataComputed`](../DataComputed/index.md) and [`DataEffect`](../DataEffect/index.md) components can also be used for computed values and side effects respectively.
 
 ## Table of content
 
@@ -23,20 +23,22 @@ Import the components in your main app and use the [`DataModel` component](../Da
 
 ```js [app.js] twoslash
 import { registerComponent } from '@studiometa/js-toolkit';
-import { DataBind } from '@studiometa/ui';
+import { Action, DataBind, DataModel, DataScope } from '@studiometa/ui';
 
+registerComponent(DataScope);
 registerComponent(DataBind);
+registerComponent(DataModel);
+registerComponent(Action);
 ```
 
 ```html [index.html]
-<!-- Bind "textContent" to the "text" group -->
-<div data-component="DataBind" data-option-group="text"></div>
+<div data-component="DataScope" data-option-group="message">
+  <!-- Hydrate the "text" key from the input's native name. -->
+  <input name="text" value="Hello world" data-component="DataModel" data-option-immediate />
 
-<!-- Bind "value" to the "text" group -->
-<input type="text" data-component="DataModel" data-option-group="text" />
-
-<!-- Bind "value" to the "text" group and sync it on mount -->
-<input type="text" data-component="DataModel" data-option-group="text" data-option-immediate />
+  <!-- Render only updates published for the "text" key. -->
+  <output data-component="DataBind" data-option-key="text">Hello world</output>
+</div>
 ```
 
 :::
@@ -59,46 +61,34 @@ Use kebab-case for camel-cased DOM properties because HTML attribute names are c
 
 For ARIA attributes, explicitly stringify booleans when `"false"` must remain present, for example `data-bind:attr.aria-selected="String(value === 'overview')"`.
 
-The following Tabs-like controls keep their labels while updating state and panels from the `tab` group:
+The following disclosure keeps its button label while updating its class, ARIA state, and panel visibility from one scoped value. The `DataModel` uses its `value` property to hydrate the initial state; virtual bindings then retain the reactive value without replacing the label.
 
 ```html
-<input
-  id="current-tab"
-  type="hidden"
-  value="overview"
-  data-component="DataBind"
-  data-option-group="tab"
-  data-option-immediate />
+<div data-component="DataScope" data-option-group="disclosure">
+  <button
+    type="button"
+    value="closed"
+    aria-controls="details"
+    aria-expanded="false"
+    data-component="Action DataModel"
+    data-option-key="state"
+    data-option-prop="value"
+    data-option-immediate
+    data-on:click="DataModel.toggle('open', 'closed')"
+    data-bind:class.is-active="value === 'open'"
+    data-bind:attr.aria-expanded="String(value === 'open')">
+    Details
+  </button>
 
-<button
-  data-component="Action DataBind"
-  data-option-group="tab"
-  data-on:click="DataBind(#current-tab) -> target.value = 'overview'"
-  data-bind:class.is-active="value === 'overview'"
-  data-bind:attr.aria-selected="String(value === 'overview')">
-  Overview
-</button>
-<button
-  data-component="Action DataBind"
-  data-option-group="tab"
-  data-on:click="DataBind(#current-tab) -> target.value = 'details'"
-  data-bind:class.is-active="value === 'details'"
-  data-bind:attr.aria-selected="String(value === 'details')">
-  Details
-</button>
-
-<section
-  data-component="DataBind"
-  data-option-group="tab"
-  data-bind:attr.hidden="value !== 'overview'">
-  Overview panel
-</section>
-<section
-  data-component="DataBind"
-  data-option-group="tab"
-  data-bind:attr.hidden="value !== 'details'">
-  Details panel
-</section>
+  <section
+    id="details"
+    hidden
+    data-component="DataBind"
+    data-option-key="state"
+    data-bind:attr.hidden="value !== 'open'">
+    Disclosure content
+  </section>
+</div>
 ```
 
 Expression errors are reported without interrupting updates to the other bindings, matching `DataComputed` and `DataEffect` behavior.

--- a/packages/docs/components/DataBind/js-api.md
+++ b/packages/docs/components/DataBind/js-api.md
@@ -14,10 +14,10 @@ The `DataBind` component can be used to keep a value in sync between multiple DO
 - Type: `string`
 - Default: `'textContent'`
 
-The default value for the `prop` options depends on the type of the targeted element. If the element is an input, a textearea or a select, the default prop will be one of the following:
+The default value for the `prop` option depends on the type of the targeted element. If the element is an input, a textarea, or a select, the default prop will be one of the following:
 
 - `valueAsDate` for `<input type="date">`
-- `valueAsNumber` from `<input type="number">`
+- `valueAsNumber` for `<input type="number">`
 - `value` for all other inputs
 - for `<select>` elements, the prop option is not used and the value will always be the selected option(s)
 
@@ -44,13 +44,13 @@ The `group` option is used to group instances together. All related instances wi
 
 A keyed value updates only bindings with the same key while notifying unkeyed subscribers. Keys are local to a `DataScope`; unscoped bindings preserve scalar group behavior.
 
-When using it with multiple checkboxes or select multiple, use the `[]` suffix to push each selected value in an array. See the [checkboxes example](/components/DataBind/examples.md#checkboxes) for more details on how this works.
+When using it with multiple checkboxes or a multiple select, use the `[]` suffix to push each selected value into an array. See the [checkboxes example](../DataModel/examples.md#checkboxes) for more details.
 
 ## Properties
 
 ### `value`
 
-Get and set the value on the current instance. This is a getter and setter alias for the [`set(value)`](#set-value-string-boolean-string) and [get()](#get) methods.
+Get and set the value on the current instance. This is a getter and setter alias for the `set(value)` and [`get()`](#get) methods.
 
 ### `target`
 
@@ -64,7 +64,7 @@ The targeted DOM element.
 - Type: `boolean`
 - Readonly
 
-Wether new values should be pushed to an array instead of a single value. This is enabled by adding the `[]` suffix to the [`group` option](#group).
+Whether new values should be pushed to an array instead of a single value. This is enabled by adding the `[]` suffix to the [`group` option](#group).
 
 ## Methods
 
@@ -77,7 +77,7 @@ Set the value for the current instance and dispatch it to others if the second p
 **Params**
 
 - `value` (`DataValue`): the value to set
-- `dispatch` (`boolean`, default to `true`): wether to dispatch the value to other related instances or not
+- `dispatch` (`boolean`, defaults to `true`): whether to dispatch the value to other related instances
 
 The mutation helpers below are available on `DataBind` and `DataModel`. They are not supported on computed values or effects.
 
@@ -88,21 +88,60 @@ Toggle between two values and dispatch the result to the group. Single checkboxe
 Custom values can describe disclosure state without repeating comparison logic in an Action:
 
 ```html
-<button
-  data-component="Action"
-  data-option-target="DataBind(.state)"
-  data-option-effect="target.toggle('open', 'closed')">
-  Toggle
-</button>
+<div data-component="DataScope" data-option-group="disclosure">
+  <button
+    type="button"
+    value="closed"
+    data-component="Action DataModel"
+    data-option-key="state"
+    data-option-prop="value"
+    data-option-immediate
+    data-on:click="DataModel.toggle('open', 'closed')"
+    data-bind:attr.aria-expanded="String(value === 'open')">
+    Toggle
+  </button>
+</div>
 ```
 
 ### `increment(step = 1)`
 
 Convert the current value to a number, increment it by `step`, and dispatch the result. A non-numeric current value starts at `0`. Pass a negative step to decrement. Date inputs are not supported.
 
+```html
+<div data-component="DataScope" data-option-group="counter">
+  <button
+    type="button"
+    value="0"
+    data-component="Action DataModel"
+    data-option-key="count"
+    data-option-prop="value"
+    data-option-immediate
+    data-on:click="DataModel.increment()"
+    data-bind:text="`Count: ${value}`">
+    Count: 0
+  </button>
+</div>
+```
+
 ### `cycle(values)`
 
 Select and dispatch the value following the current value in the given array. The method wraps to the first value; an unknown current value also selects the first value. An empty array does nothing.
+
+```html
+<div data-component="DataScope" data-option-group="workflow">
+  <button
+    type="button"
+    value="draft"
+    data-component="Action DataModel"
+    data-option-key="status"
+    data-option-prop="value"
+    data-option-immediate
+    data-on:click="DataModel.cycle(['draft', 'review', 'published'])"
+    data-bind:text="`Status: ${value}`">
+    Status: draft
+  </button>
+</div>
+```
 
 ### `get()`
 

--- a/packages/docs/components/DataBind/stories/basic.js
+++ b/packages/docs/components/DataBind/stories/basic.js
@@ -1,7 +1,7 @@
 import { registerComponent } from '@studiometa/js-toolkit';
-import { DataBind, DataComputed, DataEffect, DataModel } from '@studiometa/ui';
+import { DataBind, DataComputed, DataModel, DataScope } from '@studiometa/ui';
 
+registerComponent(DataScope);
 registerComponent(DataBind);
 registerComponent(DataComputed);
-registerComponent(DataEffect);
 registerComponent(DataModel);

--- a/packages/docs/components/DataBind/stories/basic.twig
+++ b/packages/docs/components/DataBind/stories/basic.twig
@@ -1,25 +1,28 @@
-<div data-component="DataEffect"
-  data-option-group="msg"
-  data-option-effect="target.classList.toggle('bg-red-400/50', value.length > 15)"
-  class="flex flex-col gap-4">
-  <input
-    data-component="DataModel"
-    data-option-group="msg"
-    data-option-main
-    value="Hello world"
-    class="p-4 bg-transparent ring rounded" />
+<div
+  data-component="DataScope"
+  data-option-group="message"
+  class="grid gap-4 max-w-lg rounded ring p-4">
+  <label class="grid gap-1">
+    <span>Message</span>
+    <input
+      name="text"
+      value="Hello world"
+      data-component="DataModel"
+      data-option-immediate
+      class="p-4 bg-transparent ring rounded" />
+  </label>
   <h1
-    data-component="DataBind DataEffect"
-    data-option-group="msg"
-    data-option-effect="target.classList.toggle('text-red-600', value.length > 15)"
+    data-component="DataBind"
+    data-option-key="text"
+    data-bind:text
+    data-bind:class.text-red-600="value.length > 15"
     class="text-4xl font-bold">
     Hello world
   </h1>
-  <p
-    data-component="DataComputed"
-    data-option-compute="`Length: ${value.length}`"
-    data-option-group="msg"
-    class="text-xl">
-    Lengh: 11
+  <p class="text-xl">
+    <span
+      data-component="DataComputed"
+      data-option-key="text"
+      data-option-compute="`Length: ${value.length}`">Length: 11</span>
   </p>
 </div>

--- a/packages/docs/components/DataBind/stories/immediate.js
+++ b/packages/docs/components/DataBind/stories/immediate.js
@@ -1,4 +1,6 @@
 import { registerComponent } from '@studiometa/js-toolkit';
-import { DataBind } from '@studiometa/ui';
+import { DataBind, DataModel, DataScope } from '@studiometa/ui';
 
+registerComponent(DataScope);
 registerComponent(DataBind);
+registerComponent(DataModel);

--- a/packages/docs/components/DataBind/stories/immediate.twig
+++ b/packages/docs/components/DataBind/stories/immediate.twig
@@ -1,16 +1,22 @@
-<div class="grid gap-4 max-w-sm">
-  <input
-    data-component="DataBind"
-    data-option-group="foo"
-    data-option-immediate
-    type="text"
-    value="foo"
-    class="p-2 border border-current/20 rounded" />
-  <input
-    data-component="DataBind"
-    data-option-group="foo"
-    type="text"
-    value=""
-    readonly
-    class="p-2 border border-current/20 rounded" />
+<div
+  data-component="DataScope"
+  data-option-group="message"
+  class="grid gap-4 max-w-sm rounded ring p-4">
+  <label class="grid gap-1">
+    <span>Primary model</span>
+    <input
+      name="text"
+      value="Hello world"
+      data-component="DataModel"
+      data-option-immediate
+      class="p-2 bg-transparent ring rounded" />
+  </label>
+  <label class="grid gap-1">
+    <span>Mirrored model</span>
+    <input
+      name="text"
+      data-component="DataModel"
+      class="p-2 bg-transparent ring rounded" />
+  </label>
+  <output data-component="DataBind" data-option-key="text">Hello world</output>
 </div>

--- a/packages/docs/components/DataComputed/index.md
+++ b/packages/docs/components/DataComputed/index.md
@@ -20,7 +20,7 @@ Use the `DataComputed` component alongside the [`DataModel` component](../DataMo
 ::: code-group
 
 ```html [index.html]
-<!-- Two ways binding on the "text" group for the input's value -->
+<!-- Two-way binding on the "text" group for the input's value -->
 <input type="text" data-component="DataModel" data-option-group="text" />
 
 <!-- Update the text content with the input's value in UPPERCASE -->
@@ -62,7 +62,9 @@ registerComponent(DataComputed);
 
 </llm-only>
 
-### Double computed value
+### Combine scoped values
+
+Inside a [`DataScope`](../DataScope/index.md), an unkeyed computed expression can derive a value from several named models through the frozen `$data` snapshot.
 
 <llm-exclude>
 <PreviewPlayground

--- a/packages/docs/components/DataComputed/js-api.md
+++ b/packages/docs/components/DataComputed/js-api.md
@@ -5,7 +5,7 @@ outline: deep
 
 # JS API
 
-The `DataComputed` component extends the [`DataBind` component](../DataBind/js-api.md), it inherits from its API.
+The `DataComputed` component extends the [`DataBind` component](../DataBind/js-api.md) and inherits its binding API. Mutation helpers such as `toggle()`, `increment()`, and `cycle()` are not supported on computed values.
 
 ## Options
 
@@ -37,13 +37,13 @@ Use this option to define a piece of JavaScript code to transform the value befo
 
 ## Methods
 
-### `set(value: string | boolean | string[])`
+### `set(value: DataValue)`
 
-Set the value for the current instance.
+Compute and set the value for the current instance.
 
 **Params**
 
-- `value` (`string | boolean | string[]`): the value to set
+- `value` (`DataValue`): the source value to transform
 
 ### `get()`
 

--- a/packages/docs/components/DataComputed/stories/compute-example.js
+++ b/packages/docs/components/DataComputed/stories/compute-example.js
@@ -1,6 +1,6 @@
 import { registerComponent } from '@studiometa/js-toolkit';
-import { DataBind, DataComputed, DataModel } from '@studiometa/ui';
+import { DataComputed, DataModel, DataScope } from '@studiometa/ui';
 
-registerComponent(DataBind);
-registerComponent(DataComputed);
+registerComponent(DataScope);
 registerComponent(DataModel);
+registerComponent(DataComputed);

--- a/packages/docs/components/DataComputed/stories/compute-example.twig
+++ b/packages/docs/components/DataComputed/stories/compute-example.twig
@@ -1,20 +1,33 @@
-<div class="flex flex-col gap-4">
-  <input
-    data-component="DataModel"
-    data-option-group="counter"
-    type="range"
-    value="10"
-    min="0"
-    max="100"
-    step="1" />
-  <p>
-    Count:
-    <span data-component="DataBind" data-option-group="counter">10</span>
-  </p>
-  <p>
-    Double:
-    <span data-component="DataComputed" data-option-group="counter" data-option-compute="value * 2">
-      20
-    </span>
+<div
+  data-component="DataScope"
+  data-option-group="order"
+  class="grid gap-4 max-w-sm rounded ring p-4">
+  <label class="grid gap-1">
+    <span>Quantity</span>
+    <input
+      name="quantity"
+      type="number"
+      value="2"
+      min="0"
+      data-component="DataModel"
+      data-option-immediate
+      class="p-2 bg-transparent ring rounded" />
+  </label>
+  <label class="grid gap-1">
+    <span>Unit price</span>
+    <input
+      name="unitPrice"
+      type="number"
+      value="10"
+      min="0"
+      data-component="DataModel"
+      data-option-immediate
+      class="p-2 bg-transparent ring rounded" />
+  </label>
+  <p class="text-xl">
+    Total:
+    <output
+      data-component="DataComputed"
+      data-option-compute="($data.quantity || 0) * ($data.unitPrice || 0)">20</output>
   </p>
 </div>

--- a/packages/docs/components/DataComputed/stories/uppercase.twig
+++ b/packages/docs/components/DataComputed/stories/uppercase.twig
@@ -1,5 +1,5 @@
 <div class="grid gap-4 max-w-sm">
-  <!-- Two ways binding on the "text" group for the input's value -->
+  <!-- Two-way binding on the "text" group for the input's value -->
   <input
     type="text"
     placeholder="..."

--- a/packages/docs/components/DataEffect/index.md
+++ b/packages/docs/components/DataEffect/index.md
@@ -14,20 +14,22 @@ Use the `DataEffect` component to execute side effects when the value of the `Da
 
 ::: code-group
 
-```html {5,7} [index.html]
-<!-- Two ways binding on the "text" group for the input's value -->
-<!-- And show an alert if the content of the input is too loong -->
-<input
-  type="text"
-  data-component="DataModel DataEffect"
-  data-option-group="text"
-  data-option-effect="value.length > 20 && alert('Too long')" />
+```html [index.html]
+<div data-component="DataScope" data-option-group="validation">
+  <!-- "message" is the scoped key for both components. -->
+  <input
+    name="message"
+    type="text"
+    data-component="DataModel DataEffect"
+    data-option-effect="target.setCustomValidity(value.length > 10 ? 'Use 10 characters or fewer.' : '')" />
+</div>
 ```
 
 ```js [app.js] twoslash
 import { registerComponent } from '@studiometa/js-toolkit';
-import { DataModel, DataEffect } from '@studiometa/ui';
+import { DataEffect, DataModel, DataScope } from '@studiometa/ui';
 
+registerComponent(DataScope);
 registerComponent(DataModel);
 registerComponent(DataEffect);
 ```

--- a/packages/docs/components/DataEffect/js-api.md
+++ b/packages/docs/components/DataEffect/js-api.md
@@ -5,7 +5,7 @@ outline: deep
 
 # DataEffect JS API
 
-The `DataEffect` component extends the [`DataBind` component](../DataBind/js-api.md), it inherits from its API.
+The `DataEffect` component extends the [`DataBind` component](../DataBind/js-api.md) and inherits its binding API. Mutation helpers such as `toggle()`, `increment()`, and `cycle()` are not supported on effects.
 
 ## Options
 
@@ -18,7 +18,7 @@ Use this option to define a piece of JavaScript code to be executed when the val
 
 **Example**
 
-In the following example, the counter text color is changed based on the input's length:
+In the following example, the counter is animated whenever the range value changes:
 
 <llm-exclude>
 <PreviewPlayground

--- a/packages/docs/components/DataEffect/stories/effect-example.twig
+++ b/packages/docs/components/DataEffect/stories/effect-example.twig
@@ -10,7 +10,7 @@
   <p
     data-component="DataEffect"
     data-option-group="counter"
-    data-option-effect="target.classList.toggle('text-red-500', value > 50)">
+    data-option-effect="target.animate([{ opacity: 0.5 }, { opacity: 1 }], { duration: 200 })">
     Count:
     <span data-component="DataBind" data-option-group="counter">50</span>
   </p>

--- a/packages/docs/components/DataEffect/stories/too-long.js
+++ b/packages/docs/components/DataEffect/stories/too-long.js
@@ -1,5 +1,6 @@
 import { registerComponent } from '@studiometa/js-toolkit';
-import { DataEffect, DataModel } from '@studiometa/ui';
+import { DataEffect, DataModel, DataScope } from '@studiometa/ui';
 
-registerComponent(DataEffect);
+registerComponent(DataScope);
 registerComponent(DataModel);
+registerComponent(DataEffect);

--- a/packages/docs/components/DataEffect/stories/too-long.twig
+++ b/packages/docs/components/DataEffect/stories/too-long.twig
@@ -1,10 +1,15 @@
-<div class="grid gap-4 max-w-sm">
-  <!-- Two ways binding on the "text" group for the input's value -->
+<div
+  data-component="DataScope"
+  data-option-group="validation"
+  class="grid gap-2 max-w-sm">
+  <label for="validated-text">Message</label>
   <input
+    id="validated-text"
+    name="message"
     type="text"
-    placeholder="..."
+    placeholder="Use 10 characters or fewer"
     data-component="DataModel DataEffect"
-    data-option-group="text"
-    data-option-effect="value.length > 10 && alert('Too long')"
-    class="p-2 border border-current/20 rounded" />
+    data-option-effect="target.setCustomValidity(value.length > 10 ? 'Use 10 characters or fewer.' : '')"
+    class="p-2 border border-current/20 invalid:ring-red-500 bg-transparent ring rounded" />
+  <small>The effect updates the input's native validation state.</small>
 </div>

--- a/packages/docs/components/DataModel/index.md
+++ b/packages/docs/components/DataModel/index.md
@@ -15,6 +15,8 @@ Use the `DataModel` component to create a two-way binding of a property of HTML 
 
 Import the components in your main app and use the `DataModel` component on HTML form elements and the `DataBind` and `DataComputed` components on other elements that need to be updated accordingly. The `DataEffect` component can be used to execute side effects when the value changes.
 
+Inside a [`DataScope`](../DataScope/index.md), non-radio controls with the same key are mirrored models. In this example, both inputs use the native name `text`: editing either input updates the other one and every subscriber for that key. The first model uses `data-option-immediate` to hydrate the initial value.
+
 <llm-exclude>
 <PreviewPlayground
   :html="() => import('./stories/basic.twig')"

--- a/packages/docs/components/DataModel/js-api.md
+++ b/packages/docs/components/DataModel/js-api.md
@@ -5,9 +5,23 @@ outline: deep
 
 # DataModel JS API
 
-The `DataModel` component have the same public API as the [`DataBind` component](../DataBind/js-api.md).
+The `DataModel` component has the same public API as the [`DataBind` component](../DataBind/js-api.md).
 
-This component will [dispatch](#dispatch) its current value to all other related instances within the same group when the `input` event is triggered on its root element.
+It [dispatches](#dispatch) its current value to related instances in the same group when an `input` event is triggered on its root element.
+
+## Keyed and mirrored models
+
+Inside a [`DataScope`](../DataScope/index.md), a `DataModel` is a source for its resolved key. Non-radio models with the same key mirror each other and jointly retain the value in the scope:
+
+```html
+<div data-component="DataScope" data-option-group="profile">
+  <input name="first" value="Ada" data-component="DataModel" data-option-immediate />
+  <input name="first" data-component="DataModel" />
+  <output data-component="DataBind" data-option-key="first">Ada</output>
+</div>
+```
+
+Destroying one mirrored model does not remove the value from `$data`. The key is removed only after its last `DataModel` source is destroyed.
 
 ## Methods
 

--- a/packages/docs/components/DataModel/stories/app.js
+++ b/packages/docs/components/DataModel/stories/app.js
@@ -1,7 +1,7 @@
 import { registerComponent } from '@studiometa/js-toolkit';
-import { DataBind, DataComputed, DataEffect, DataModel } from '@studiometa/ui';
+import { DataBind, DataComputed, DataModel, DataScope } from '@studiometa/ui';
 
+registerComponent(DataScope);
 registerComponent(DataBind);
 registerComponent(DataComputed);
-registerComponent(DataEffect);
 registerComponent(DataModel);

--- a/packages/docs/components/DataModel/stories/basic.twig
+++ b/packages/docs/components/DataModel/stories/basic.twig
@@ -1,25 +1,31 @@
-<div data-component="DataEffect"
-  data-option-group="msg"
-  data-option-effect="target.classList.toggle('bg-red-400/50', value.length > 15)"
-  class="flex flex-col gap-4">
-  <input
-    data-component="DataModel"
-    data-option-group="msg"
-    data-option-main
-    value="Hello world"
-    class="p-4 bg-transparent ring rounded" />
-  <h1
-    data-component="DataBind DataEffect"
-    data-option-group="msg"
-    data-option-effect="target.classList.toggle('text-red-600', value.length > 15)"
-    class="text-4xl font-bold">
-    Hello world
-  </h1>
-  <p
-    data-component="DataComputed"
-    data-option-compute="`Length: ${value.length}`"
-    data-option-group="msg"
-    class="text-xl">
-    Lengh: 11
+<div
+  data-component="DataScope"
+  data-option-group="message"
+  class="grid gap-4 max-w-lg rounded ring p-4">
+  <label class="grid gap-1">
+    <span>Primary model</span>
+    <input
+      name="text"
+      value="Hello world"
+      data-component="DataModel"
+      data-option-immediate
+      class="p-2 bg-transparent ring rounded" />
+  </label>
+  <label class="grid gap-1">
+    <span>Mirrored model</span>
+    <input
+      name="text"
+      data-component="DataModel"
+      class="p-2 bg-transparent ring rounded" />
+  </label>
+  <p class="text-2xl font-bold">
+    <span data-component="DataBind" data-option-key="text">Hello world</span>
+  </p>
+  <p>
+    Length:
+    <span
+      data-component="DataComputed"
+      data-option-key="text"
+      data-option-compute="value.length">11</span>
   </p>
 </div>

--- a/packages/docs/components/DataScope/examples.md
+++ b/packages/docs/components/DataScope/examples.md
@@ -27,7 +27,7 @@ Sibling scopes remain independent even when they use the same group name. In the
 
 ## Tabs
 
-The following example implements two independent tab interfaces with `DataScope`, [`Action`](../Action/index.md), and [`DataBind`](../DataBind/index.md). Each scope contains a hidden source of truth, while virtual bindings synchronize the selected state and panels. The `Tabs` component is not registered.
+The following example implements two independent tab interfaces with `DataScope`, [`Action`](../Action/index.md), [`DataModel`](../DataModel/index.md), and [`DataBind`](../DataBind/index.md). The tab buttons are mirrored models for the same `active` key: the first button hydrates the initial value, every button can publish a new value, and virtual bindings synchronize the selected state and panels. The `Tabs` component is not registered.
 
 <llm-exclude>
 <PreviewPlayground
@@ -48,7 +48,7 @@ The following example implements two independent tab interfaces with `DataScope`
 
 ## Accordion
 
-This example uses the same pattern for two independent accordion interfaces. Each action toggles the scoped hidden value; opening one panel closes the other panels in that scope, and clicking the open item closes it. The `Accordion` component is not registered.
+This example uses the same mirrored-model pattern for two independent accordion interfaces. Each button toggles the shared `active` key with [`toggle()`](../DataBind/js-api.md); opening one panel closes the other panels in that scope, and clicking the open item closes it. The `Accordion` component is not registered.
 
 <llm-exclude>
 <PreviewPlayground

--- a/packages/docs/components/DataScope/index.md
+++ b/packages/docs/components/DataScope/index.md
@@ -34,6 +34,6 @@ Import the `DataScope` component with the Data components used by your applicati
 
 </llm-only>
 
-The native `name` of a form control becomes its key inside the scope. Use `data-option-key` to define a key explicitly. Unkeyed computed values and effects receive the complete frozen `$data` snapshot, allowing expressions to combine several keyed values.
+The native `name` of a form control becomes its key inside the scope. Use `data-option-key` to define a key explicitly. Non-radio `DataModel` controls with the same key mirror each other and jointly retain the scoped value. Unkeyed computed values and effects receive the complete frozen `$data` snapshot, allowing expressions to combine several keyed values.
 
 See the [JavaScript API](./js-api.md) for details about group inheritance, keys, and scoped data snapshots.

--- a/packages/docs/components/DataScope/index.md
+++ b/packages/docs/components/DataScope/index.md
@@ -4,7 +4,7 @@ badges: [JS]
 
 # DataScope <Badges :texts="$frontmatter.badges" />
 
-Use the `DataScope` component to isolate [`DataBind`](../DataBind/index.md), [`DataModel`](../DataModel/index.md), [`DataComputed`](../DataComputed/index.md), and [`DataEffect`](../DataEffect/index.md) groups inside a reusable widget. [`Action`](../Action/index.md) targets inside the widget are isolated by the same scope.
+Use the `DataScope` component to isolate [`DataBind`](../DataBind/index.md), [`DataModel`](../DataModel/index.md), [`DataComputed`](../DataComputed/index.md), and [`DataEffect`](../DataEffect/index.md) groups inside a reusable widget.
 
 Descendant Data components inherit the scope's group unless they define their own `data-option-group`. Nested scopes use the nearest `DataScope` boundary.
 

--- a/packages/docs/components/DataScope/js-api.md
+++ b/packages/docs/components/DataScope/js-api.md
@@ -45,10 +45,6 @@ Data callbacks receive the group's `$data` snapshot as their third argument:
 
 The snapshot object and its array values are frozen. Array and `Date` values are cloned before they are exposed, so mutating the original value does not mutate an existing snapshot. A cloned `Date` can still be changed through its mutation methods, but later snapshots remain isolated from those changes.
 
-## Action targets
-
-An [`Action`](../Action/index.md) inside a `DataScope` resolves targets only among components in the same nearest scope. An Action outside a scope continues to resolve targets globally.
-
 ## Lifecycle
 
 Scope membership is resolved when a Data component is initialized. Moving a mounted component between scopes or changing its group or key dynamically is not supported.

--- a/packages/docs/components/DataScope/js-api.md
+++ b/packages/docs/components/DataScope/js-api.md
@@ -53,4 +53,6 @@ An [`Action`](../Action/index.md) inside a `DataScope` resolves targets only amo
 
 Scope membership is resolved when a Data component is initialized. Moving a mounted component between scopes or changing its group or key dynamically is not supported.
 
-When the last component providing a key is destroyed, that key is removed from the scope's `$data` snapshot.
+A keyed [`DataModel`](../DataModel/index.md) is a data source. For non-radio values, every mounted `DataModel` with the same key is tracked as a mirrored source after publication. Destroying one mirrored model keeps the value in `$data`; the key is removed only when its last source is destroyed. Same-key `DataBind`, `DataComputed`, and `DataEffect` instances are subscribers and do not retain the key. A radio key is owned by the model representing its selected value.
+
+Disconnected sources are cleaned up the next time the scope is read or updated. For `[]` groups, the remaining selected values are recomputed before subscribers are notified.

--- a/packages/docs/components/DataScope/stories/accordion.js
+++ b/packages/docs/components/DataScope/stories/accordion.js
@@ -1,6 +1,7 @@
 import { registerComponent } from '@studiometa/js-toolkit';
-import { Action, DataBind, DataScope } from '@studiometa/ui';
+import { Action, DataBind, DataModel, DataScope } from '@studiometa/ui';
 
 registerComponent(DataScope);
 registerComponent(DataBind);
+registerComponent(DataModel);
 registerComponent(Action);

--- a/packages/docs/components/DataScope/stories/accordion.twig
+++ b/packages/docs/components/DataScope/stories/accordion.twig
@@ -1,21 +1,22 @@
 <div class="grid gap-8">
   {% for i in 1..2 %}
-    <section data-component="DataScope" class="grid gap-2 rounded ring p-4">
-      <input
-        class="accordion-state"
-        type="hidden"
-        value="accordion-1"
-        data-component="DataBind"
-        data-option-immediate />
+    <section
+      data-component="DataScope"
+      data-option-group="accordion"
+      class="grid gap-2 rounded ring p-4">
       <div class="grid gap-2">
         <button
           id="accordion-{{ i }}-button-1"
           type="button"
+          value="accordion-1"
           aria-controls="accordion-{{ i }}-panel-1"
           aria-expanded="true"
-          data-component="Action DataBind"
+          data-component="Action DataModel"
+          data-option-key="active"
+          data-option-prop="value"
+          data-option-immediate
           data-bind:attr.aria-expanded="String(value === 'accordion-1')"
-          data-on:click="DataBind(.accordion-state)->target.toggle('accordion-1', '')">
+          data-on:click="DataModel.toggle('accordion-1', '')">
           First item
         </button>
         <div
@@ -23,6 +24,7 @@
           role="region"
           aria-labelledby="accordion-{{ i }}-button-1"
           data-component="DataBind"
+          data-option-key="active"
           data-bind:attr.hidden="value !== 'accordion-1'">
           First accordion panel. Clicking again closes it.
         </div>
@@ -31,11 +33,14 @@
         <button
           id="accordion-{{ i }}-button-2"
           type="button"
+          value="accordion-2"
           aria-controls="accordion-{{ i }}-panel-2"
           aria-expanded="false"
-          data-component="Action DataBind"
+          data-component="Action DataModel"
+          data-option-key="active"
+          data-option-prop="value"
           data-bind:attr.aria-expanded="String(value === 'accordion-2')"
-          data-on:click="DataBind(.accordion-state)->target.toggle('accordion-2', '')">
+          data-on:click="DataModel.toggle('accordion-2', '')">
           Second item
         </button>
         <div
@@ -44,6 +49,7 @@
           aria-labelledby="accordion-{{ i }}-button-2"
           hidden
           data-component="DataBind"
+          data-option-key="active"
           data-bind:attr.hidden="value !== 'accordion-2'">
           Second accordion panel. Opening it auto-closes the first one.
         </div>
@@ -52,11 +58,14 @@
         <button
           id="accordion-{{ i }}-button-3"
           type="button"
+          value="accordion-3"
           aria-controls="accordion-{{ i }}-panel-3"
           aria-expanded="false"
-          data-component="Action DataBind"
+          data-component="Action DataModel"
+          data-option-key="active"
+          data-option-prop="value"
           data-bind:attr.aria-expanded="String(value === 'accordion-3')"
-          data-on:click="DataBind(.accordion-state)->target.toggle('accordion-3', '')">
+          data-on:click="DataModel.toggle('accordion-3', '')">
           Third item
         </button>
         <div
@@ -65,6 +74,7 @@
           aria-labelledby="accordion-{{ i }}-button-3"
           hidden
           data-component="DataBind"
+          data-option-key="active"
           data-bind:attr.hidden="value !== 'accordion-3'">
           Third accordion panel. No Accordion component is registered.
         </div>

--- a/packages/docs/components/DataScope/stories/tabs.js
+++ b/packages/docs/components/DataScope/stories/tabs.js
@@ -1,6 +1,7 @@
 import { registerComponent } from '@studiometa/js-toolkit';
-import { Action, DataBind, DataScope } from '@studiometa/ui';
+import { Action, DataBind, DataModel, DataScope } from '@studiometa/ui';
 
 registerComponent(DataScope);
 registerComponent(DataBind);
+registerComponent(DataModel);
 registerComponent(Action);

--- a/packages/docs/components/DataScope/stories/tabs.twig
+++ b/packages/docs/components/DataScope/stories/tabs.twig
@@ -1,12 +1,9 @@
 <div class="grid gap-8">
   {% for i in 1..2 %}
-    <section data-component="DataScope" class="grid gap-4 rounded ring p-4">
-      <input
-        class="tabs-state"
-        type="hidden"
-        value="tab-1"
-        data-component="DataBind"
-        data-option-immediate />
+    <section
+      data-component="DataScope"
+      data-option-group="tabs"
+      class="grid gap-4 rounded ring p-4">
       <div
         class="flex gap-2 border-b"
         role="tablist"
@@ -14,34 +11,44 @@
         <button
           id="tabs-{{ i }}-tab-1"
           type="button"
+          value="tab-1"
           role="tab"
           aria-controls="tabs-{{ i }}-panel-1"
           aria-selected="true"
-          data-component="Action DataBind"
+          data-component="Action DataModel"
+          data-option-key="active"
+          data-option-prop="value"
+          data-option-immediate
           data-bind:attr.aria-selected="String(value === 'tab-1')"
-          data-on:click="DataBind(.tabs-state)->target.value = 'tab-1'">
+          data-on:click="DataModel.set('tab-1')">
           First tab
         </button>
         <button
           id="tabs-{{ i }}-tab-2"
           type="button"
+          value="tab-2"
           role="tab"
           aria-controls="tabs-{{ i }}-panel-2"
           aria-selected="false"
-          data-component="Action DataBind"
+          data-component="Action DataModel"
+          data-option-key="active"
+          data-option-prop="value"
           data-bind:attr.aria-selected="String(value === 'tab-2')"
-          data-on:click="DataBind(.tabs-state)->target.value = 'tab-2'">
+          data-on:click="DataModel.set('tab-2')">
           Second tab
         </button>
         <button
           id="tabs-{{ i }}-tab-3"
           type="button"
+          value="tab-3"
           role="tab"
           aria-controls="tabs-{{ i }}-panel-3"
           aria-selected="false"
-          data-component="Action DataBind"
+          data-component="Action DataModel"
+          data-option-key="active"
+          data-option-prop="value"
           data-bind:attr.aria-selected="String(value === 'tab-3')"
-          data-on:click="DataBind(.tabs-state)->target.value = 'tab-3'">
+          data-on:click="DataModel.set('tab-3')">
           Third tab
         </button>
       </div>
@@ -50,8 +57,9 @@
         role="tabpanel"
         aria-labelledby="tabs-{{ i }}-tab-1"
         data-component="DataBind"
+        data-option-key="active"
         data-bind:attr.hidden="value !== 'tab-1'">
-        First tab content. The hidden input is the single source of truth.
+        First tab content. The tab controls are mirrored state sources.
       </div>
       <div
         id="tabs-{{ i }}-panel-2"
@@ -59,6 +67,7 @@
         aria-labelledby="tabs-{{ i }}-tab-2"
         hidden
         data-component="DataBind"
+        data-option-key="active"
         data-bind:attr.hidden="value !== 'tab-2'">
         Second tab content. DataBind synchronizes this panel.
       </div>
@@ -68,6 +77,7 @@
         aria-labelledby="tabs-{{ i }}-tab-3"
         hidden
         data-component="DataBind"
+        data-option-key="active"
         data-bind:attr.hidden="value !== 'tab-3'">
         Third tab content. No Tabs component is registered.
       </div>

--- a/packages/tests/Action/Action.spec.ts
+++ b/packages/tests/Action/Action.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, vi, expect } from 'vitest';
 import { Base } from '@studiometa/js-toolkit';
-import { Action, DataScope } from '@studiometa/ui';
+import { Action } from '@studiometa/ui';
 import { h, mount, destroy } from '#test-utils';
 
 async function getContext({
@@ -146,48 +146,5 @@ describe('The Action component', () => {
     expect(action.$el.id).toBe('bar');
     action.$el.dispatchEvent(new Event('click'));
     expect(action.$el.id).toBe('foo');
-  });
-
-  it('should only target instances in the nearest DataScope', async () => {
-    const fn = vi.fn();
-    class Foo extends Base {
-      static config = { name: 'Foo' };
-
-      run() {
-        fn(this);
-      }
-    }
-
-    const scopeRoot = h('div');
-    const actionRoot = h('button', {
-      dataOptionTarget: 'Foo',
-      dataOptionEffect: 'target.run()',
-    });
-    const localRoot = h('div');
-    const nestedScopeRoot = h('div');
-    const nestedRoot = h('div');
-    nestedScopeRoot.append(nestedRoot);
-    scopeRoot.append(actionRoot, localRoot, nestedScopeRoot);
-
-    const siblingScopeRoot = h('div');
-    const siblingRoot = h('div');
-    siblingScopeRoot.append(siblingRoot);
-    const globalRoot = h('div');
-
-    const scope = new DataScope(scopeRoot);
-    const nestedScope = new DataScope(nestedScopeRoot);
-    const siblingScope = new DataScope(siblingScopeRoot);
-    const action = new Action(actionRoot);
-    const local = new Foo(localRoot);
-    const nested = new Foo(nestedRoot);
-    const sibling = new Foo(siblingRoot);
-    const global = new Foo(globalRoot);
-    await mount(scope, nestedScope, siblingScope, action, local, nested, sibling, global);
-
-    actionRoot.dispatchEvent(new Event('click'));
-    expect(fn).toHaveBeenCalledTimes(1);
-    expect(fn).toHaveBeenCalledWith(local);
-
-    await destroy(scope, nestedScope, siblingScope, action, local, nested, sibling, global);
   });
 });

--- a/packages/ui/Action/ActionEvent.ts
+++ b/packages/ui/Action/ActionEvent.ts
@@ -1,7 +1,6 @@
 import { getInstances } from '@studiometa/js-toolkit';
 import type { Base } from '@studiometa/js-toolkit';
 import { isFunction } from '@studiometa/js-toolkit/utils';
-import { getDataScope } from '../Data/DataScope.js';
 
 /**
  * Extract component name and an optional additional selector from a string.
@@ -130,14 +129,9 @@ export class ActionEvent<T extends Base> {
     });
 
     const targets = [] as Array<Record<string, Base>>;
-    const actionScope = getDataScope(this.action.$el);
 
     for (const instance of getInstances()) {
       const { name } = instance.__config;
-
-      if (actionScope && getDataScope(instance.$el) !== actionScope) {
-        continue;
-      }
 
       for (const part of parts) {
         const shouldPush =


### PR DESCRIPTION
## Summary

- modernize Data component stories with scoped keyed state and virtual bindings
- demonstrate mirrored DataModel sources and mutation helpers
- document scoped source lifecycle and fix stale Data API references

## Validation

- `npm run test -- -- Data Action/Action.spec.ts`
- `npm run lint:types`
- `npm run lint:static`
- uncached Prettier check for modified Markdown files

The docs build was intentionally not run locally.