### PR TITLE
[Enhancement] Use the js-toolkit fold util in the withIndex decorator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
+- **Indexable:** reflect the `bounce` boundary through the new `fold` math util and require `@studiometa/js-toolkit` `^3.7.0`
 - **Slider:** require `@studiometa/js-toolkit` `^3.6.0` and share the current index through a per-instance store instead of the deprecated `$parent` accessor ([#507](https://github.com/studiometa/ui/pull/507))
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -4309,9 +4309,9 @@
       "link": true
     },
     "node_modules/@studiometa/js-toolkit": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@studiometa/js-toolkit/-/js-toolkit-3.6.0.tgz",
-      "integrity": "sha512-KJyPzw+eqePlEUOliskvJyweQ0kuNdVzPdfc41OPO1IvROqAPm6CUtk8eY7XCy91fQWs8O2rQdTujnHPA7yrSQ==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@studiometa/js-toolkit/-/js-toolkit-3.7.0.tgz",
+      "integrity": "sha512-17T6MVrOMZh73KAXuIU91UIgL10+Xf2qD+twZ363WQanEL0TvxQ6FWaHkWpXdn3wIFNqfqKIUeiFUYeVXsN6dg==",
       "license": "MIT",
       "dependencies": {
         "@motionone/easing": "^10.18.0",
@@ -21167,10 +21167,10 @@
         "morphdom": "^2.7.8"
       },
       "devDependencies": {
-        "@studiometa/js-toolkit": "^3.6.0"
+        "@studiometa/js-toolkit": "^3.7.0"
       },
       "peerDependencies": {
-        "@studiometa/js-toolkit": "^3.6.0"
+        "@studiometa/js-toolkit": "^3.7.0"
       }
     }
   }

--- a/packages/ui/decorators/withIndex.ts
+++ b/packages/ui/decorators/withIndex.ts
@@ -5,7 +5,7 @@ import type {
   BaseConfig,
   BaseInterface,
 } from '@studiometa/js-toolkit';
-import { clamp, isString, randomInt, wrap } from '@studiometa/js-toolkit/utils';
+import { clamp, fold, isString, randomInt, wrap } from '@studiometa/js-toolkit/utils';
 
 const INDEXABLE_BOUNDARIES = {
   CLAMP: 'clamp',
@@ -213,7 +213,7 @@ export function withIndex<S extends Base>(
     _normalizeIndex(value: number): number {
       switch (this.boundary) {
         case INDEXABLE_BOUNDARIES.BOUNCE:
-          return this._bounceIndex(value);
+          return fold(value, this.minIndex, this.maxIndex);
         case INDEXABLE_BOUNDARIES.LOOP:
           return this._loopIndex(value);
         case INDEXABLE_BOUNDARIES.CLAMP:
@@ -238,24 +238,6 @@ export function withIndex<S extends Base>(
     }
 
     /**
-     * Reflect a value back into the `minIndex...maxIndex` range, ping-pong
-     * style. Only normalizes the position: the travel direction is left
-     * untouched as it is managed by `goNext` and `goPrev`.
-     * @private
-     */
-    _bounceIndex(value: number): number {
-      const cycleLength = this.length * 2 - 2;
-
-      if (!Number.isFinite(cycleLength) || cycleLength <= 0) {
-        return 0;
-      }
-
-      const wrapped = wrap(value, 0, cycleLength);
-
-      return wrapped > this.maxIndex ? cycleLength - wrapped : wrapped;
-    }
-
-    /**
      * Compute the index reached by stepping `direction` (`1` or `-1`) with the
      * `bounce` boundary, reflecting at the bounds. Returns the target index and
      * whether a bounce reversed the travel direction.
@@ -265,7 +247,7 @@ export function withIndex<S extends Base>(
       const tentative = this.currentIndex + direction;
       const reversed = tentative > this.maxIndex || tentative < this.minIndex;
 
-      return { index: this._bounceIndex(tentative), reversed };
+      return { index: fold(tentative, this.minIndex, this.maxIndex), reversed };
     }
 
     get prevIndex() {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -34,9 +34,9 @@
     "morphdom": "^2.7.8"
   },
   "devDependencies": {
-    "@studiometa/js-toolkit": "^3.6.0"
+    "@studiometa/js-toolkit": "^3.7.0"
   },
   "peerDependencies": {
-    "@studiometa/js-toolkit": "^3.6.0"
+    "@studiometa/js-toolkit": "^3.7.0"
   }
 }


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Replaces the local `_bounceIndex` helper in the `withIndex` decorator with the new `fold` math util shipped in `@studiometa/js-toolkit@3.7.0`.

`_bounceIndex` computed a ping-pong reflection: `cycleLength = length*2 - 2 = 2*maxIndex`, `wrapped = wrap(value, 0, cycleLength)`, then returned `wrapped > maxIndex ? cycleLength - wrapped : wrapped`. `fold(value, minIndex, maxIndex)` performs the exact same computation internally (`cycle = 2*maxIndex`, `wrapped = wrap(value, 0, cycle)`, `wrapped > maxIndex ? 2*maxIndex - wrapped : wrapped`), including collapsing to `minIndex` (`0`) for a length of `0` or `1`. This is a pure, behavior-preserving swap in favor of the shared toolkit util.

`@studiometa/js-toolkit` is bumped from `^3.6.0` to `^3.7.0` (devDependencies and peerDependencies) to pick up `fold`.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
- [x] I have updated the changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ce9zHksixuR2yRnM35wHDM