### PR TITLE
[Enhancement] Align private members to the __ prefix convention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
+- **Data / Indexable:** align private and protected class members to the `__` prefix convention (with `@private`/`@protected` docblocks), dropping the erasable-only TypeScript `private`/`protected` keywords in favour of runtime-discoverable internals
 - **DataScope:** resolve scoped groups through the `withGroup` decorator's new `getScope`/`getGroup` options and `getScopedGroups` helper, and require `@studiometa/js-toolkit` `^3.7.0`
 - **Indexable:** reflect the `bounce` boundary through the new `fold` math util and require `@studiometa/js-toolkit` `^3.7.0`
 - **Slider:** require `@studiometa/js-toolkit` `^3.6.0` and share the current index through a per-instance store instead of the deprecated `$parent` accessor ([#507](https://github.com/studiometa/ui/pull/507))

--- a/packages/ui/Data/DataBind.ts
+++ b/packages/ui/Data/DataBind.ts
@@ -52,18 +52,21 @@ export class DataBind<T extends BaseProps = BaseProps> extends withGroup<Base, D
     },
   };
 
-  private __dataScopeResolved = false;
-  private __dataScope?: DataScope;
-  private __stopUpdates?: () => void;
-  private __virtualBindings?: VirtualBinding[];
-  private __virtualValue?: DataValue;
-  private __hasVirtualValue = false;
+  __dataScopeResolved = false;
+  __dataScope?: DataScope;
+  __stopUpdates?: () => void;
+  __virtualBindings?: VirtualBinding[];
+  __virtualValue?: DataValue;
+  __hasVirtualValue = false;
 
   get isDataSource() {
     return false;
   }
 
-  protected get supportsMutations() {
+  /**
+   * @protected
+   */
+  get __supportsMutations() {
     return true;
   }
 
@@ -144,14 +147,20 @@ export class DataBind<T extends BaseProps = BaseProps> extends withGroup<Base, D
     return this.group.endsWith('[]');
   }
 
-  private get channel() {
+  /**
+   * @private
+   */
+  get __channel() {
     return (
       this.dataScope?.getChannel(this.group) ??
       getDataChannel(this.$group as Set<DataScopeMember>)
     );
   }
 
-  protected get controlContext(): DataControlContext {
+  /**
+   * @protected
+   */
+  get __controlContext(): DataControlContext {
     return {
       dataKey: this.dataKey,
       members: this.relatedInstances,
@@ -198,37 +207,43 @@ export class DataBind<T extends BaseProps = BaseProps> extends withGroup<Base, D
       return this.__virtualValue;
     }
 
-    return this.getTargetValue();
+    return this.__getTargetValue();
   }
 
-  protected getTargetValue(): DataValue {
-    return readControlValue(this.controlContext);
+  /**
+   * @protected
+   */
+  __getTargetValue(): DataValue {
+    return readControlValue(this.__controlContext);
   }
 
   set(value: DataValue, dispatch = true) {
-    const publication = dispatch ? this.publishValue(value) : undefined;
+    const publication = dispatch ? this.__publishValue(value) : undefined;
 
     if (!publication || publication.channel.isCurrent(publication.frame)) {
-      this.applyValue(value);
+      this.__applyValue(value);
     }
   }
 
-  private applyValue(value: DataValue) {
+  /**
+   * @private
+   */
+  __applyValue(value: DataValue) {
     if (this.hasVirtualBindings) {
       this.__virtualValue = value;
       this.__hasVirtualValue = true;
-      this.applyVirtualBindings(value);
+      this.__applyVirtualBindings(value);
       return;
     }
 
-    writeControlValue(this.controlContext, value);
+    writeControlValue(this.__controlContext, value);
   }
 
   /**
    * Publish a value to the resolved Data group without applying it locally.
-   * @internal
+   * @protected
    */
-  protected publishValue(value: DataValue, force = false, updateData = true) {
+  __publishValue(value: DataValue, force = false, updateData = true) {
     if (this.dataScope && this.dataKey) {
       if (updateData) {
         this.dataScope.setValue(this.group, this.dataKey, value, this);
@@ -244,7 +259,7 @@ export class DataBind<T extends BaseProps = BaseProps> extends withGroup<Base, D
       return { channel, frame };
     }
 
-    const channel = this.channel;
+    const channel = this.__channel;
     const frame = channel.publish({
       force,
       source: this,
@@ -253,7 +268,10 @@ export class DataBind<T extends BaseProps = BaseProps> extends withGroup<Base, D
     return { channel, frame };
   }
 
-  private applyVirtualBindings(value: DataValue) {
+  /**
+   * @private
+   */
+  __applyVirtualBindings(value: DataValue) {
     for (const binding of this.virtualBindings) {
       let result: unknown = value;
 
@@ -303,15 +321,18 @@ export class DataBind<T extends BaseProps = BaseProps> extends withGroup<Base, D
    * @internal
    */
   __dispatchScopedValue(value: DataValue, updateData = true) {
-    const publication = this.publishValue(value, true, updateData);
+    const publication = this.__publishValue(value, true, updateData);
 
     if (publication.channel.isCurrent(publication.frame)) {
       this.set(value, false);
     }
   }
 
-  private validateMutation(method: string) {
-    if (this.supportsMutations) {
+  /**
+   * @private
+   */
+  __validateMutation(method: string) {
+    if (this.__supportsMutations) {
       return true;
     }
 
@@ -320,7 +341,7 @@ export class DataBind<T extends BaseProps = BaseProps> extends withGroup<Base, D
   }
 
   toggle(onValue: DataValue = true, offValue: DataValue = false) {
-    if (!this.validateMutation('toggle')) {
+    if (!this.__validateMutation('toggle')) {
       return;
     }
 
@@ -338,7 +359,7 @@ export class DataBind<T extends BaseProps = BaseProps> extends withGroup<Base, D
   }
 
   increment(step = 1) {
-    if (!this.validateMutation('increment')) {
+    if (!this.__validateMutation('increment')) {
       return;
     }
 
@@ -352,7 +373,7 @@ export class DataBind<T extends BaseProps = BaseProps> extends withGroup<Base, D
   }
 
   cycle(values: readonly DataValue[]) {
-    if (!this.validateMutation('cycle') || values.length === 0) {
+    if (!this.__validateMutation('cycle') || values.length === 0) {
       return;
     }
 
@@ -362,7 +383,7 @@ export class DataBind<T extends BaseProps = BaseProps> extends withGroup<Base, D
 
   mounted() {
     this.__stopUpdates?.();
-    this.__stopUpdates = this.channel.subscribe((update) => {
+    this.__stopUpdates = this.__channel.subscribe((update) => {
       if (!this.$el.isConnected) {
         this.__stopUpdates?.();
         this.__stopUpdates = undefined;

--- a/packages/ui/Data/DataChannel.ts
+++ b/packages/ui/Data/DataChannel.ts
@@ -17,26 +17,33 @@ type DataUpdateSubscriber = (update: DataUpdate) => void;
  * @internal
  */
 export class DataChannel {
-  private update = signal<DataUpdate | typeof INITIAL>(INITIAL);
-  private latest?: DataUpdate;
+  /**
+   * @private
+   */
+  __update = signal<DataUpdate | typeof INITIAL>(INITIAL);
+
+  /**
+   * @private
+   */
+  __latest?: DataUpdate;
 
   publish(update: DataUpdate) {
     // Always publish a fresh frame so equal values remain observable events.
     const frame = { ...update };
-    this.latest = frame;
-    this.update(frame);
+    this.__latest = frame;
+    this.__update(frame);
     return frame;
   }
 
   isCurrent(frame: DataUpdate) {
-    return this.latest === frame;
+    return this.__latest === frame;
   }
 
   subscribe(subscriber: DataUpdateSubscriber) {
     let initialized = false;
 
     return effect(() => {
-      const update = this.update();
+      const update = this.__update();
 
       if (!initialized) {
         initialized = true;

--- a/packages/ui/Data/DataComputed.ts
+++ b/packages/ui/Data/DataComputed.ts
@@ -18,7 +18,10 @@ export class DataComputed<T extends BaseProps = BaseProps> extends DataBind<Data
     },
   };
 
-  protected get supportsMutations() {
+  /**
+   * @protected
+   */
+  get __supportsMutations() {
     return false;
   }
 

--- a/packages/ui/Data/DataEffect.ts
+++ b/packages/ui/Data/DataEffect.ts
@@ -18,7 +18,10 @@ export class DataEffect<T extends BaseProps = BaseProps> extends DataBind<DataEf
     },
   };
 
-  protected get supportsMutations() {
+  /**
+   * @protected
+   */
+  get __supportsMutations() {
     return false;
   }
 

--- a/packages/ui/Data/DataModel.ts
+++ b/packages/ui/Data/DataModel.ts
@@ -15,8 +15,8 @@ export class DataModel<T extends BaseProps = BaseProps> extends DataBind<DataMod
   }
 
   dispatch() {
-    const value = serializeControlValue(this.controlContext);
-    const publication = this.publishValue(value, true);
+    const value = serializeControlValue(this.__controlContext);
+    const publication = this.__publishValue(value, true);
 
     if (publication.channel.isCurrent(publication.frame)) {
       this.set(value, false);

--- a/packages/ui/Data/DataScope.ts
+++ b/packages/ui/Data/DataScope.ts
@@ -78,10 +78,16 @@ export class DataScope<T extends BaseProps = BaseProps> extends Base<DataScopePr
     },
   };
 
-  private groups = new Map<string, DataScopeGroup>();
+  /**
+   * @private
+   */
+  __groups = new Map<string, DataScopeGroup>();
 
-  private getRecord(group: string) {
-    let record = this.groups.get(group);
+  /**
+   * @private
+   */
+  __getRecord(group: string) {
+    let record = this.__groups.get(group);
 
     if (!record) {
       record = {
@@ -92,7 +98,7 @@ export class DataScope<T extends BaseProps = BaseProps> extends Base<DataScopePr
         hydration: new Set(),
         hydrationPending: false,
       };
-      this.groups.set(group, record);
+      this.__groups.set(group, record);
     }
 
     const deletedKeys = [] as string[];
@@ -112,7 +118,7 @@ export class DataScope<T extends BaseProps = BaseProps> extends Base<DataScopePr
           deletedKeys.push(key);
         }
       } else if (sourcesChanged && group.endsWith('[]')) {
-        const value = this.getMultipleSourcesValue(sources);
+        const value = this.__getMultipleSourcesValue(sources);
         record.values.set(key, value);
         updatedValues.set(key, value);
       }
@@ -121,17 +127,20 @@ export class DataScope<T extends BaseProps = BaseProps> extends Base<DataScopePr
     if (deletedKeys.length > 0 || updatedValues.size > 0) {
       record.data = createSnapshot(record.values);
       for (const key of deletedKeys) {
-        this.notifyValue(record, key, undefined);
+        this.__notifyValue(record, key, undefined);
       }
       for (const [key, value] of updatedValues) {
-        this.notifyValue(record, key, value);
+        this.__notifyValue(record, key, value);
       }
     }
 
     return record;
   }
 
-  private getInstances(group: string): Set<DataScopeMember> {
+  /**
+   * @private
+   */
+  __getInstances(group: string): Set<DataScopeMember> {
     const instances = getScopedGroups(this).get(`${DATA_GROUP_NAMESPACE}${group}`) as
       | Set<DataScopeMember>
       | undefined;
@@ -149,7 +158,10 @@ export class DataScope<T extends BaseProps = BaseProps> extends Base<DataScopePr
     return instances;
   }
 
-  private getMultipleSourcesValue(sources: Set<DataScopeMember>) {
+  /**
+   * @private
+   */
+  __getMultipleSourcesValue(sources: Set<DataScopeMember>) {
     const values = new Set<string>();
 
     for (const source of sources) {
@@ -171,7 +183,10 @@ export class DataScope<T extends BaseProps = BaseProps> extends Base<DataScopePr
     return Array.from(values);
   }
 
-  private notifyValue(
+  /**
+   * @private
+   */
+  __notifyValue(
     record: DataScopeGroup,
     key: string,
     value: DataValue,
@@ -186,11 +201,11 @@ export class DataScope<T extends BaseProps = BaseProps> extends Base<DataScopePr
   }
 
   getGroup(group: string) {
-    return this.getInstances(group);
+    return this.__getInstances(group);
   }
 
   getData(group: string) {
-    return this.getRecord(group).data;
+    return this.__getRecord(group).data;
   }
 
   /**
@@ -198,14 +213,14 @@ export class DataScope<T extends BaseProps = BaseProps> extends Base<DataScopePr
    * @internal
    */
   getChannel(group: string) {
-    return this.getRecord(group).channel;
+    return this.__getRecord(group).channel;
   }
 
   setValue(group: string, key: string, value: DataValue, source?: DataScopeMember) {
-    const record = this.getRecord(group);
+    const record = this.__getRecord(group);
 
     if (source) {
-      const instances = this.getInstances(group);
+      const instances = this.__getInstances(group);
       if (source.$el instanceof HTMLInputElement && source.$el.type === 'radio') {
         const matchingSource =
           source.$el.value === value
@@ -235,7 +250,7 @@ export class DataScope<T extends BaseProps = BaseProps> extends Base<DataScopePr
   }
 
   deleteValue(group: string, key: string, source: DataScopeMember) {
-    const record = this.getRecord(group);
+    const record = this.__getRecord(group);
     const sources = record.sources.get(key);
 
     if (!sources?.delete(source)) {
@@ -246,12 +261,12 @@ export class DataScope<T extends BaseProps = BaseProps> extends Base<DataScopePr
       record.sources.delete(key);
       record.values.delete(key);
       record.data = createSnapshot(record.values);
-      this.notifyValue(record, key, undefined, source);
+      this.__notifyValue(record, key, undefined, source);
     } else if (group.endsWith('[]')) {
-      const value = this.getMultipleSourcesValue(sources);
+      const value = this.__getMultipleSourcesValue(sources);
       record.values.set(key, value);
       record.data = createSnapshot(record.values);
-      this.notifyValue(record, key, value, source);
+      this.__notifyValue(record, key, value, source);
     }
   }
 
@@ -262,7 +277,7 @@ export class DataScope<T extends BaseProps = BaseProps> extends Base<DataScopePr
       return;
     }
 
-    const record = this.getRecord(group);
+    const record = this.__getRecord(group);
     record.hydration.add(instance);
 
     if (record.hydrationPending) {
@@ -289,7 +304,7 @@ export class DataScope<T extends BaseProps = BaseProps> extends Base<DataScopePr
             } else {
               const valueSources = record.sources.get(source.dataKey) ?? new Set();
               valueSources.add(source);
-              for (const instance of this.getInstances(group)) {
+              for (const instance of this.__getInstances(group)) {
                 if (instance.isDataSource && instance.dataKey === source.dataKey) {
                   valueSources.add(instance);
                 }

--- a/packages/ui/decorators/withIndex.ts
+++ b/packages/ui/decorators/withIndex.ts
@@ -184,7 +184,7 @@ export function withIndex<S extends Base>(
 
     set currentIndex(value) {
       const oldIndex = this.__index;
-      this.__index = this._normalizeIndex(value);
+      this.__index = this.__normalizeIndex(value);
       if (this.__index !== oldIndex) {
         this.$emit('index', this.currentIndex);
       }
@@ -202,7 +202,7 @@ export function withIndex<S extends Base>(
      * Get the travel direction: `1` when going forward, `-1` when reversed.
      * @private
      */
-    get _direction(): number {
+    get __direction(): number {
       return this.isReverse ? -1 : 1;
     }
 
@@ -210,12 +210,12 @@ export function withIndex<S extends Base>(
      * Normalize any value to a valid index according to the current boundary.
      * @private
      */
-    _normalizeIndex(value: number): number {
+    __normalizeIndex(value: number): number {
       switch (this.boundary) {
         case INDEXABLE_BOUNDARIES.BOUNCE:
           return fold(value, this.minIndex, this.maxIndex);
         case INDEXABLE_BOUNDARIES.LOOP:
-          return this._loopIndex(value);
+          return this.__loopIndex(value);
         case INDEXABLE_BOUNDARIES.CLAMP:
         default:
           return clamp(value, this.minIndex, this.maxIndex);
@@ -227,7 +227,7 @@ export function withIndex<S extends Base>(
      * is not a positive finite number.
      * @private
      */
-    _loopIndex(value: number): number {
+    __loopIndex(value: number): number {
       const { length } = this;
 
       if (!Number.isFinite(length) || length <= 0) {
@@ -243,7 +243,7 @@ export function withIndex<S extends Base>(
      * whether a bounce reversed the travel direction.
      * @private
      */
-    _bounceStep(direction: number): { index: number; reversed: boolean } {
+    __bounceStep(direction: number): { index: number; reversed: boolean } {
       const tentative = this.currentIndex + direction;
       const reversed = tentative > this.maxIndex || tentative < this.minIndex;
 
@@ -251,11 +251,11 @@ export function withIndex<S extends Base>(
     }
 
     get prevIndex() {
-      return this._normalizeIndex(this.currentIndex - this._direction);
+      return this.__normalizeIndex(this.currentIndex - this.__direction);
     }
 
     get nextIndex() {
-      return this._normalizeIndex(this.currentIndex + this._direction);
+      return this.__normalizeIndex(this.currentIndex + this.__direction);
     }
 
     goTo(indexOrInstruction) {
@@ -288,11 +288,11 @@ export function withIndex<S extends Base>(
     }
 
     goNext() {
-      return this._step(this._direction);
+      return this.__step(this.__direction);
     }
 
     goPrev() {
-      return this._step(-this._direction);
+      return this.__step(-this.__direction);
     }
 
     /**
@@ -300,15 +300,15 @@ export function withIndex<S extends Base>(
      * `bounce` boundary when reaching a bound.
      * @private
      */
-    _step(direction: number) {
+    __step(direction: number) {
       if (this.boundary === INDEXABLE_BOUNDARIES.BOUNCE) {
-        const { index, reversed } = this._bounceStep(direction);
+        const { index, reversed } = this.__bounceStep(direction);
         if (reversed) {
           this.isReverse = !this.isReverse;
         }
         return this.goTo(index);
       }
-      return this.goTo(this._normalizeIndex(this.currentIndex + direction));
+      return this.goTo(this.__normalizeIndex(this.currentIndex + direction));
     }
   }
 


### PR DESCRIPTION
### ❓ Type of change

- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [x] 👌 Enhancement (improving an existing functionality like performance)

### 📚 Description

Aligns the private-member representation across the **Indexable** and **Data** features to the project's preferred `__` prefix convention, following review feedback on PRs #519 and #520.

**Why:** the codebase intentionally uses two privacy styles — the JS `#` prefix (real privates, but unsupported on old browsers) and the `__` prefix (conventional privates that stay discoverable while debugging, documented with `@private`). The team prefers `__`. My two previous PRs left the surface inconsistent: `withIndex` used single-underscore helpers while the `Data` family used the TypeScript `private`/`protected` keywords.

**Changes (behaviour-preserving):**
- `withIndex.ts`: `_normalizeIndex`/`_loopIndex`/`_bounceStep`/`_step`/`_direction` → double-underscore (`__index` already conformed).
- `Data` family (`DataScope`, `DataBind`, `DataChannel`, `DataModel`, `DataComputed`, `DataEffect`): dropped the `private`/`protected` keywords and renamed members to the `__` prefix with `@private`/`@protected` docblocks; updated every call site including the `__supportsMutations`/`__getTargetValue` subclass overrides.
- Keeps the TypeScript surface to **erasable-only** syntax — verified there are no non-erasable features (enums, namespaces, constructor parameter-properties) in these files.

No public API changed; the renamed members were all private/protected. Full `npm run lint` (0 errors) and `npm run test` (410 passed) are green.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [x] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
- [x] I have updated the changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ce9zHksixuR2yRnM35wHDM