### PR TITLE
Delegate local utils to @studiometa/js-toolkit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - **DataScope:** resolve scoped groups through the `withGroup` decorator's new `getScope`/`getGroup` options and `getScopedGroups` helper, and require `@studiometa/js-toolkit` `^3.7.0`
 - **Indexable:** reflect the `bounce` boundary through the new `fold` math util and require `@studiometa/js-toolkit` `^3.7.0`
 - **Slider:** require `@studiometa/js-toolkit` `^3.6.0` and share the current index through a per-instance store instead of the deprecated `$parent` accessor ([#507](https://github.com/studiometa/ui/pull/507))
+- **Figure / FigureVideo:** delegate image loading to the `@studiometa/js-toolkit` `loadImage` util and drop the local re-implementation, deduplicate the `normalizeSize` helper, and replace the hand-rolled kebab→camelCase regex in `Data` form controls with the toolkit's memoized `camelCase` ([#518](https://github.com/studiometa/ui/issues/518))
 
 ### Fixed
 
+- **Figure / FigureVideo:** stop hanging forever when an image or poster fails to load — the failed load is now caught and logged instead of leaving the component stuck ([#518](https://github.com/studiometa/ui/issues/518))
 - **Slider:** fix `SliderBtn`, `SliderCount`, `SliderDots` and `SliderProgress` crashing when mounted before their parent `Slider` ([#507](https://github.com/studiometa/ui/pull/507))
 - **Accordion:** fix `AccordionItem` option inheritance relying on the deprecated `$parent` accessor ([#507](https://github.com/studiometa/ui/pull/507))
 

--- a/packages/tests/Data/DataBind.spec.ts
+++ b/packages/tests/Data/DataBind.spec.ts
@@ -98,6 +98,13 @@ describe('The DataBind component', () => {
     expect(input.checked).toBe(false);
   });
 
+  it('should resolve dashed custom property names via camelCase', () => {
+    const div = h('div', { 'data-bind:prop.custom-thing': '' });
+    const instance = new DataBind(div);
+    instance.set('foo');
+    expect((div as any).customThing).toBe('foo');
+  });
+
   it('should select an option of a select', () => {
     const optionA = h('option', { value: 'foo' }, ['Foo']);
     const optionB = h('option', { value: 'bar' }, ['Bar']);

--- a/packages/tests/Figure/Figure.spec.ts
+++ b/packages/tests/Figure/Figure.spec.ts
@@ -7,6 +7,7 @@ import {
   intersectionObserverBeforeAllCallback,
   intersectionObserverAfterEachCallback,
   mockImageLoad,
+  mockImageLoadError,
   unmockImageLoad,
 } from '#test-utils';
 
@@ -41,6 +42,31 @@ describe('The Figure component', () => {
     await wait(100);
     expect(img.src).toBe(src);
     expect(fn).toHaveBeenCalledOnce();
+  });
+
+  it('should warn and not terminate when the image fails to load', async () => {
+    unmockImageLoad();
+    mockImageLoadError();
+
+    const src = 'http://localhost/broken.jpg';
+    const img = h('img', {
+      dataRef: 'img',
+      src: 'data:image/svg+xml,<svg viewport="0 0 1 1"></svg>',
+      dataSrc: src,
+    });
+    const figure = h('figure', { dataOptionLazy: '' }, [img]);
+
+    const instance = new Figure(figure);
+    const warnSpy = vi.spyOn(instance, '$warn', 'get');
+    const terminated = vi.fn();
+    instance.$on('terminated', terminated);
+
+    mockIsIntersecting(figure, true);
+    await wait(100);
+
+    expect(img.src).not.toBe(src);
+    expect(warnSpy).toHaveBeenCalledOnce();
+    expect(terminated).not.toHaveBeenCalled();
   });
 
   it('should warn if the `img` ref is misconfigured', async () => {

--- a/packages/tests/Figure/FigureTwicpics.spec.ts
+++ b/packages/tests/Figure/FigureTwicpics.spec.ts
@@ -8,6 +8,7 @@ import {
   intersectionObserverAfterEachCallback,
   unmockImageLoad,
   mockImageLoad,
+  mockImageLoadError,
   resizeWindow,
 } from '#test-utils';
 
@@ -93,6 +94,20 @@ describe('The FigureTwicpics component', () => {
     expect(instance.$options.domain).toBe('');
     expect(instance.domain).toBe('localhost');
     expect(instance.original).toBe('https://localhost/path/image.jpg?twic=v1/cover=100x100');
+  });
+
+  it('should warn and keep the source when the image fails to load on resize', async () => {
+    const { instance, setSize, img } = await getContext();
+    const src = img.src;
+    const warnSpy = vi.spyOn(instance, '$warn', 'get');
+
+    unmockImageLoad();
+    mockImageLoadError();
+    setSize({ width: 200, height: 200 });
+    await resizeWindow();
+
+    expect(warnSpy).toHaveBeenCalledOnce();
+    expect(img.src).toBe(src);
   });
 
   it('should take the device pixel ratio into account', async () => {

--- a/packages/tests/FigureVideo/FigureVideo.spec.ts
+++ b/packages/tests/FigureVideo/FigureVideo.spec.ts
@@ -1,0 +1,79 @@
+import { it, describe, expect, vi, beforeAll, beforeEach, afterEach } from 'vitest';
+import { FigureVideo } from '@studiometa/ui';
+import {
+  wait,
+  hConnected as h,
+  mockIsIntersecting,
+  intersectionObserverBeforeAllCallback,
+  intersectionObserverAfterEachCallback,
+  mockImageLoad,
+  mockImageLoadError,
+  unmockImageLoad,
+  mockVideoLoad,
+  unmockVideoLoad,
+} from '#test-utils';
+
+beforeAll(() => {
+  intersectionObserverBeforeAllCallback();
+});
+
+beforeEach(() => {
+  mockImageLoad();
+  mockVideoLoad();
+});
+
+afterEach(() => {
+  intersectionObserverAfterEachCallback();
+  unmockImageLoad();
+  unmockVideoLoad();
+});
+
+function getContext({ poster = 'http://localhost/poster.jpg' } = {}) {
+  const source = h('source', { dataSrc: 'http://localhost/video.mp4' });
+  const video = h('video', poster ? { dataRef: 'video', dataPoster: poster } : { dataRef: 'video' }, [
+    source,
+  ]);
+  const figure = h('figure', { dataOptionLazy: '' }, [video]);
+
+  return { source, video, figure, instance: new FigureVideo(figure) };
+}
+
+describe('The FigureVideo component', () => {
+  it('should lazily load the poster and sources then emit load', async () => {
+    const { video, source, figure, instance } = getContext();
+    const load = vi.fn();
+    instance.$on('load', load);
+
+    mockIsIntersecting(figure, true);
+    await wait(100);
+
+    expect(video.poster).toBe('http://localhost/poster.jpg');
+    expect(source.src).toBe('http://localhost/video.mp4');
+    expect(load).toHaveBeenCalledOnce();
+  });
+
+  it('should resolve the poster silently when no poster is defined', async () => {
+    const { video, figure, instance } = getContext({ poster: '' });
+    const load = vi.fn();
+    instance.$on('load', load);
+
+    mockIsIntersecting(figure, true);
+    await wait(100);
+
+    expect(video.poster).toBeFalsy();
+    expect(load).toHaveBeenCalledOnce();
+  });
+
+  it('should warn when the poster fails to load', async () => {
+    unmockImageLoad();
+    mockImageLoadError();
+
+    const { figure, instance } = getContext();
+    const warnSpy = vi.spyOn(instance, '$warn', 'get');
+
+    mockIsIntersecting(figure, true);
+    await wait(100);
+
+    expect(warnSpy).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/tests/FigureVideo/FigureVideoTwicpics.spec.ts
+++ b/packages/tests/FigureVideo/FigureVideoTwicpics.spec.ts
@@ -1,0 +1,101 @@
+import { it, describe, expect, vi, beforeAll, beforeEach, afterEach } from 'vitest';
+import { FigureVideoTwicpics } from '@studiometa/ui';
+import {
+  wait,
+  hConnected as h,
+  mockIsIntersecting,
+  intersectionObserverBeforeAllCallback,
+  intersectionObserverAfterEachCallback,
+  mockImageLoad,
+  mockImageLoadError,
+  unmockImageLoad,
+  mockVideoLoad,
+  unmockVideoLoad,
+  resizeWindow,
+} from '#test-utils';
+
+beforeAll(() => {
+  intersectionObserverBeforeAllCallback();
+});
+
+beforeEach(() => {
+  mockImageLoad();
+  mockVideoLoad();
+});
+
+afterEach(() => {
+  intersectionObserverAfterEachCallback();
+  unmockImageLoad();
+  unmockVideoLoad();
+});
+
+async function getContext({ figureAttributes = {}, poster = 'poster.jpg' } = {}) {
+  const source = h('source', { dataSrc: 'https://localhost/video.mp4' });
+  const video = h('video', { dataRef: 'video', dataPoster: poster }, [source]);
+  const figure = h('figure', { dataOptionLazy: '', ...figureAttributes }, [video]);
+
+  const widthSpy = vi.spyOn(video, 'offsetWidth', 'get').mockImplementation(() => 100);
+  const heightSpy = vi.spyOn(video, 'offsetHeight', 'get').mockImplementation(() => 100);
+
+  const instance = new FigureVideoTwicpics(figure);
+  mockIsIntersecting(figure, true);
+  await wait(100);
+
+  return {
+    source,
+    video,
+    figure,
+    instance,
+    setSize({ width, height }: { width?: number; height?: number } = {}) {
+      if (width) {
+        widthSpy.mockImplementation(() => width);
+      }
+      if (height) {
+        heightSpy.mockImplementation(() => height);
+      }
+    },
+  };
+}
+
+describe('The FigureVideoTwicpics component', () => {
+  it('should format the sources with the normalized size', async () => {
+    const { source } = await getContext();
+    expect(source.src).toBe('https://localhost/video.mp4?twic=v1/cover=100x100');
+  });
+
+  it('should format the poster with the normalized size', async () => {
+    const { video } = await getContext();
+    expect(video.poster).toBe('https://localhost/poster.jpg?twic=v1/cover=100x100');
+  });
+
+  it('should use the domain and path options', async () => {
+    const { source } = await getContext({
+      figureAttributes: {
+        dataOptionDomain: 'twic.pics',
+        dataOptionPath: 'path',
+      },
+    });
+    expect(source.src).toBe('https://twic.pics/path/video.mp4?twic=v1/cover=100x100');
+  });
+
+  it('should reformat the sources on resize', async () => {
+    const { source, setSize } = await getContext();
+    expect(source.src).toContain('cover=100x100');
+    setSize({ width: 200, height: 200 });
+    await resizeWindow();
+    expect(source.src).toContain('cover=200x200');
+  });
+
+  it('should warn when the poster fails to load', async () => {
+    unmockImageLoad();
+    mockImageLoadError();
+
+    const { instance } = await getContext();
+    const warnSpy = vi.spyOn(instance, '$warn', 'get');
+
+    // Reload to trigger a fresh poster load with the error mock in place.
+    await instance.loadPoster();
+
+    expect(warnSpy).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/tests/__utils__/index.ts
+++ b/packages/tests/__utils__/index.ts
@@ -3,6 +3,7 @@ export * from './faketimers.js';
 export * from './h.js';
 export * from './lifecycle.js';
 export * from './mockImageLoad.js';
+export * from './mockVideoLoad.js';
 export * from './mockIntersectionObserver.js';
 export * from './resizeWindow.js';
 export * from './wait.js';

--- a/packages/tests/__utils__/mockImageLoad.ts
+++ b/packages/tests/__utils__/mockImageLoad.ts
@@ -1,19 +1,31 @@
-let tmp;
+let descriptor;
+
+function mockImage(event) {
+  descriptor = Object.getOwnPropertyDescriptor(HTMLImageElement.prototype, 'src');
+  Object.defineProperty(HTMLImageElement.prototype, 'src', {
+    configurable: true,
+    get() {
+      return descriptor.get.call(this);
+    },
+    set(src) {
+      descriptor.set.call(this, src);
+      this.dispatchEvent(new Event(event));
+    },
+  });
+}
 
 export function mockImageLoad() {
-  tmp = global.Image;
-  global.Image = class extends tmp {
-    set src(src) {
-      this.setAttribute('src', src);
-      this.dispatchEvent(new Event('load'));
-    }
-  }
+  mockImage('load');
+}
+
+export function mockImageLoadError() {
+  mockImage('error');
 }
 
 export function unmockImageLoad() {
-  if (tmp) {
-    global.Image = tmp;
+  if (descriptor) {
+    Object.defineProperty(HTMLImageElement.prototype, 'src', descriptor);
   }
 
-  tmp = null;
+  descriptor = null;
 }

--- a/packages/tests/__utils__/mockVideoLoad.ts
+++ b/packages/tests/__utils__/mockVideoLoad.ts
@@ -1,0 +1,23 @@
+let originalLoad;
+
+/**
+ * Mock `HTMLMediaElement.prototype.load` so it synchronously dispatches the
+ * `loadeddata` and `canplaythrough` events — happy-dom's `load()` is a no-op
+ * and never fires them, which would otherwise leave `FigureVideo` waiting
+ * forever.
+ */
+export function mockVideoLoad() {
+  originalLoad = HTMLMediaElement.prototype.load;
+  HTMLMediaElement.prototype.load = function load() {
+    this.dispatchEvent(new Event('loadeddata'));
+    this.dispatchEvent(new Event('canplaythrough'));
+  };
+}
+
+export function unmockVideoLoad() {
+  if (originalLoad) {
+    HTMLMediaElement.prototype.load = originalLoad;
+  }
+
+  originalLoad = null;
+}

--- a/packages/ui/Data/formControl.ts
+++ b/packages/ui/Data/formControl.ts
@@ -1,3 +1,4 @@
+import { camelCase } from '@studiometa/js-toolkit/utils';
 import type { DataValue } from './DataScope.js';
 
 export interface DataControlMember {
@@ -80,7 +81,7 @@ export function resolvePropertyName(target: HTMLElement, name: string) {
     current = Object.getPrototypeOf(current);
   }
 
-  return name.replace(/-([a-z])/g, (_, letter: string) => letter.toUpperCase());
+  return camelCase(name);
 }
 
 /**

--- a/packages/ui/Figure/AbstractFigure.ts
+++ b/packages/ui/Figure/AbstractFigure.ts
@@ -1,7 +1,7 @@
 import { withMountWhenInView } from '@studiometa/js-toolkit';
 import type { BaseConfig, BaseProps } from '@studiometa/js-toolkit';
+import { loadImage } from '@studiometa/js-toolkit/utils';
 import { Transition } from '../Transition/index.js';
-import { loadImage } from './utils.js';
 
 export interface AbstractFigureProps extends BaseProps {
   $refs: {
@@ -76,7 +76,13 @@ export class AbstractFigure<
     const src = this.original;
 
     if (this.$options.lazy && src && src !== this.src) {
-      await loadImage(src);
+      try {
+        await loadImage(src);
+      } catch {
+        this.$warn(`Failed to load image "${src}".`);
+        return;
+      }
+
       this.src = src;
       this.enter();
       this.$emit('load');

--- a/packages/ui/Figure/AbstractFigureDynamic.ts
+++ b/packages/ui/Figure/AbstractFigureDynamic.ts
@@ -1,6 +1,6 @@
 import type { BaseConfig, BaseProps } from '@studiometa/js-toolkit';
+import { loadImage } from '@studiometa/js-toolkit/utils';
 import { AbstractFigure } from './AbstractFigure.js';
-import { loadImage } from './utils.js';
 
 export interface AbstractFigureDynamicProps extends BaseProps {
   $options: {
@@ -55,7 +55,14 @@ export class AbstractFigureDynamic<T extends BaseProps = BaseProps> extends Abst
    */
   async resized() {
     const { original } = this;
-    await loadImage(original);
+
+    try {
+      await loadImage(original);
+    } catch {
+      this.$warn(`Failed to load image "${original}".`);
+      return;
+    }
+
     this.src = original;
   }
 }

--- a/packages/ui/Figure/utils.ts
+++ b/packages/ui/Figure/utils.ts
@@ -1,15 +1,4 @@
 /**
- * Load the given image.
- */
-export function loadImage(src: string): Promise<HTMLImageElement> {
-  return new Promise((resolve) => {
-    const img = new Image();
-    img.addEventListener('load', () => resolve(img));
-    img.src = src;
-  });
-}
-
-/**
  * Normalize a size to the given step.
  */
 export function normalizeSize(size:number, step:number): number {

--- a/packages/ui/FigureVideo/FigureVideo.ts
+++ b/packages/ui/FigureVideo/FigureVideo.ts
@@ -1,7 +1,7 @@
 import { withMountWhenInView } from '@studiometa/js-toolkit';
 import type { BaseConfig, BaseProps } from '@studiometa/js-toolkit';
+import { loadImage } from '@studiometa/js-toolkit/utils';
 import { Transition } from '../Transition/index.js';
-import { loadImage } from '../Figure/utils.js';
 
 export interface FigureVideoProps extends BaseProps {
   $refs: {
@@ -53,17 +53,21 @@ export class FigureVideo<T extends BaseProps = BaseProps> extends withMountWhenI
   /**
    * Load poster
    */
-  loadPoster(): Promise<void|HTMLImageElement> {
+  loadPoster(): Promise<void> {
     const { video } = this.$refs;
 
     if (!video.dataset.poster) {
       return Promise.resolve();
     }
 
-    return loadImage(video.dataset.poster).then(() => {
-      video.poster = video.dataset.poster;
-      this.$log('fresh poster loaded');
-    })
+    return loadImage(video.dataset.poster)
+      .then(() => {
+        video.poster = video.dataset.poster;
+        this.$log('fresh poster loaded');
+      })
+      .catch(() => {
+        this.$warn(`Failed to load poster "${video.dataset.poster}".`);
+      });
   }
 
   /**

--- a/packages/ui/FigureVideo/FigureVideoTwicpics.ts
+++ b/packages/ui/FigureVideo/FigureVideoTwicpics.ts
@@ -1,10 +1,11 @@
 import type { BaseConfig, BaseProps } from '@studiometa/js-toolkit';
 import {
+  loadImage,
   withLeadingSlash,
   withoutLeadingSlash,
   withoutTrailingSlash,
 } from '@studiometa/js-toolkit/utils';
-import { loadImage } from '../Figure/utils.js';
+import { normalizeSize } from '../Figure/utils.js';
 import { FigureVideo } from './FigureVideo.js';
 
 export interface FigureVideoTwicpicsProps extends BaseProps {
@@ -19,15 +20,6 @@ export interface FigureVideoTwicpicsProps extends BaseProps {
     step: number;
     mode: string;
   };
-}
-
-/**
- * Normalize the given size to the step option.
- */
-// eslint-disable-next-line no-use-before-define
-function normalizeSize(that: FigureVideoTwicpics, prop: string): number {
-  const { step } = that.$options;
-  return Math.ceil(that.$refs.video[prop] / step) * step;
 }
 
 /**
@@ -62,6 +54,14 @@ export class FigureVideoTwicpics<T extends BaseProps = BaseProps> extends Figure
   };
 
   /**
+   * Normalize the given video dimension to the step option.
+   * @private
+   */
+  __normalizeSize(prop: 'offsetWidth' | 'offsetHeight'): number {
+    return normalizeSize(this.$refs.video[prop], this.$options.step);
+  }
+
+  /**
    * Get the Twicpics path.
    */
   get path(): string {
@@ -94,8 +94,8 @@ export class FigureVideoTwicpics<T extends BaseProps = BaseProps> extends Figure
       url.pathname = `/${this.path}${url.pathname}`;
     }
 
-    const width = normalizeSize(this, 'offsetWidth');
-    const height = normalizeSize(this, 'offsetHeight');
+    const width = this.__normalizeSize('offsetWidth');
+    const height = this.__normalizeSize('offsetHeight');
 
     this.$log(this.$options.mode, width, height);
 
@@ -114,7 +114,7 @@ export class FigureVideoTwicpics<T extends BaseProps = BaseProps> extends Figure
   /**
    * Load poster
    */
-  loadPoster(): Promise<void|HTMLImageElement> {
+  loadPoster(): Promise<void> {
     const { video } = this.$refs;
 
     if (!video.dataset.poster) {
@@ -123,10 +123,14 @@ export class FigureVideoTwicpics<T extends BaseProps = BaseProps> extends Figure
 
     const twicPoster = this.formatSrc(video.dataset.poster);
 
-    return loadImage(twicPoster).then(() => {
-      video.poster = twicPoster;
-      this.$log('fresh poster loaded');
-    });
+    return loadImage(twicPoster)
+      .then(() => {
+        video.poster = twicPoster;
+        this.$log('fresh poster loaded');
+      })
+      .catch(() => {
+        this.$warn(`Failed to load poster "${twicPoster}".`);
+      });
   }
 
   /**
@@ -154,8 +158,8 @@ export class FigureVideoTwicpics<T extends BaseProps = BaseProps> extends Figure
 
       video.addEventListener('canplaythrough', loadHandler);
 
-      this.$refs.video.width = normalizeSize(this, 'offsetWidth');
-      this.$refs.video.height = normalizeSize(this, 'offsetHeight');
+      this.$refs.video.width = this.__normalizeSize('offsetWidth');
+      this.$refs.video.height = this.__normalizeSize('offsetHeight');
 
       video.load();
     });
@@ -165,8 +169,8 @@ export class FigureVideoTwicpics<T extends BaseProps = BaseProps> extends Figure
    * Reassign the source from the original on resize.
    */
   async resized() {
-    const width = normalizeSize(this, 'offsetWidth');
-    const height = normalizeSize(this, 'offsetHeight');
+    const width = this.__normalizeSize('offsetWidth');
+    const height = this.__normalizeSize('offsetHeight');
 
     if (width === this.$refs.video.width && height === this.$refs.video.height) {
       return;


### PR DESCRIPTION
Closes #518.

Following the audit in #491, several utilities were reimplemented locally while `@studiometa/js-toolkit` already ships more robust equivalents, and one helper was duplicated within the repo.

## Changes

### 1. Drop the local `loadImage` in favor of the toolkit's

`packages/ui/Figure/utils.ts` re-implemented `loadImage`. The toolkit's version (`@studiometa/js-toolkit/utils`) is used instead at all 4 call sites (`AbstractFigure`, `AbstractFigureDynamic`, `FigureVideo`, `FigureVideoTwicpics`).

The toolkit version **rejects on error** where the local one hung forever on a broken image — a real bug fix. Each call site now handles the rejection: figures `$warn` and bail out (no transition/emit), video posters `$warn` and continue. The resolved value was unused everywhere, so no adaptation was needed there.

### 2. Replace the hand-rolled kebab→camelCase regex with the toolkit's `camelCase`

`Data/formControl.ts` used `name.replace(/-([a-z])/g, …)`. Replaced with the memoized `camelCase` from the toolkit, which handles Unicode and more edge cases.

### 3. Deduplicate `normalizeSize`

`FigureVideoTwicpics` kept a private copy of the `Math.ceil(size / step) * step` math. It now delegates to the shared `Figure/utils.ts` export through a small private `__normalizeSize` method.

## Tests

- Updated the `mockImageLoad` test util to patch `HTMLImageElement.prototype` (the toolkit uses `document.createElement('img')`, not `new Image()`), and added a `mockImageLoadError` counterpart.
- Added a Figure test asserting the component warns and does not terminate when an image fails to load.
- Full suite green (`npm run test`): 411 passed, lint and types clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)