### PR TITLE
Add anatomy sections to compound component docs

### DIFF
--- a/packages/docs/components/Accordion/anatomy.md
+++ b/packages/docs/components/Accordion/anatomy.md
@@ -1,0 +1,29 @@
+---
+title: Accordion anatomy
+---
+
+# Anatomy
+
+`Accordion` is a compound component: a root orchestrates one or more `AccordionItem` children, each wiring its parts through `data-ref` attributes. Use this map to see which parts exist and how they nest.
+
+## Structure
+
+```
+Accordion                                data-component="Accordion"
+└─ AccordionItem  (× n)                  data-component="AccordionItem"
+   ├─ button      [data-ref="btn"]       the toggle, controls the panel
+   └─ container   [data-ref="container"] the collapsible wrapper
+      └─ content  [data-ref="content"]   the panel content
+```
+
+## Parts
+
+| Part | Selector | Required | Role |
+| --- | --- | --- | --- |
+| Root | `data-component="Accordion"` | Yes | Groups the items, handles `autoclose`, forwards the shared `item` options. |
+| Item | `data-component="AccordionItem"` | Yes (× n) | A single expandable section. Holds the `isOpen` and `styles` options. |
+| Trigger | `data-ref="btn"` | Yes | The `<button>` that toggles its item. `aria-controls` / `aria-expanded` are set automatically. |
+| Container | `data-ref="container"` | Yes | The animated wrapper whose height transitions between open and closed. |
+| Content | `data-ref="content"` | Yes | The revealed content. `aria-hidden` / `aria-labelledby` are set automatically. |
+
+The [`Accordion.twig`](./twig-api.md) template renders this structure for you from an `items` array. See the [Twig API](./twig-api.md) for parameters and blocks.

--- a/packages/docs/components/AnchorNav/anatomy.md
+++ b/packages/docs/components/AnchorNav/anatomy.md
@@ -1,0 +1,27 @@
+---
+title: AnchorNav anatomy
+---
+
+# Anatomy
+
+`AnchorNav` is a compound component pairing navigation links with the sections they point to. Each link is matched to a target through the anchor's `href` and the target's `id`. Use this map to see which parts exist and how they nest.
+
+## Structure
+
+```
+AnchorNav                                data-component="AnchorNav"
+├─ AnchorNavLink    (× n)                data-component="AnchorNavLink"    <a href="#item-1">
+└─ AnchorNavTarget  (× n)                data-component="AnchorNavTarget"  <div id="item-1">
+```
+
+## Parts
+
+| Part | Selector | Required | Role |
+| --- | --- | --- | --- |
+| Root | `data-component="AnchorNav"` | Yes | Connects each link to its target and toggles the active link. |
+| Link | `data-component="AnchorNavLink"` | Yes (× n) | An anchor whose `href="#id"` matches a target. Accepts [`withTransition`](../Transition/#transition) options. |
+| Target | `data-component="AnchorNavTarget"` | Yes (× n) | A section whose `id` matches a link. Accepts [`withMountWhenInView`](https://js-toolkit.studiometa.dev/api/decorators/withMountWhenInView.html) options. |
+
+A link and its target are paired when the link's `href` (minus the `#`) equals the target's `id`.
+
+See the [JavaScript API](./js-api.md) for the options exposed by each part.

--- a/packages/docs/components/DataScope/anatomy.md
+++ b/packages/docs/components/DataScope/anatomy.md
@@ -1,0 +1,31 @@
+---
+title: DataScope anatomy
+---
+
+# Anatomy
+
+`DataScope` is the container of the [Data family](../../guide/concepts/#the-data-family). It groups `DataModel`, `DataBind`, `DataComputed` and `DataEffect` descendants into one reactive widget, so they share a group without writing a JavaScript class. Use this map to see which parts belong inside a scope and how they nest.
+
+## Structure
+
+```
+DataScope                              data-component="DataScope"
+├─ DataModel      (× n)                data-component="DataModel"      reads form inputs
+├─ DataBind       (× n)                data-component="DataBind"       writes a value into the DOM
+├─ DataComputed   (× n)                data-component="DataComputed"   transforms values
+├─ DataEffect     (× n)                data-component="DataEffect"     runs on change
+└─ DataScope      (× n)                nested scope                    (optional)
+```
+
+## Parts
+
+| Part | Selector | Required | Role |
+| --- | --- | --- | --- |
+| Scope | `data-component="DataScope"` | Yes | The boundary. Descendants inherit its default group unless they set their own `data-option-group`. |
+| Model | [`data-component="DataModel"`](../DataModel/) | Optional | Reads values from form inputs into the scope. |
+| Bind | [`data-component="DataBind"`](../DataBind/) | Optional | Writes a scoped value into the DOM. |
+| Computed | [`data-component="DataComputed"`](../DataComputed/) | Optional | Derives a value from the scope. |
+| Effect | [`data-component="DataEffect"`](../DataEffect/) | Optional | Runs code when a scoped value changes. |
+| Nested scope | `data-component="DataScope"` | Optional | Descendants resolve to the nearest `DataScope` boundary. |
+
+Descendants inherit the scope's group unless they define their own `data-option-group`. See the [JavaScript API](./js-api.md) for group inheritance, keys and scoped data snapshots.

--- a/packages/docs/components/Menu/anatomy.md
+++ b/packages/docs/components/Menu/anatomy.md
@@ -1,0 +1,45 @@
+---
+title: Menu anatomy
+---
+
+# Anatomy
+
+`Menu` is a compound component built from a trigger and a list. A menu can also nest other menus to build multi-level navigation. Use this map to see which parts exist and how they nest.
+
+## Structure
+
+```
+Menu                     data-component="Menu"
+├─ MenuBtn               data-component="MenuBtn"    the trigger  (exactly one direct child)
+└─ MenuList              data-component="MenuList"   the panel    (exactly one direct child)
+   └─ Menu  (× n)        nested submenus                          (optional)
+```
+
+## Parts
+
+| Part | Selector | Required | Role |
+| --- | --- | --- | --- |
+| Root | `data-component="Menu"` | Yes | Wires the button to the list, handles the `click` / `hover` mode, keyboard and click-outside. |
+| Button | `data-component="MenuBtn"` | Yes | The trigger. `aria-controls` is set automatically. |
+| List | `data-component="MenuList"` | Yes | The collapsible panel. Extends [`Transition`](../Transition/), manages focus and `aria-hidden`. |
+| Submenu | `data-component="Menu"` | Optional | A `Menu` nested inside a `MenuList` for multi-level navigation. |
+
+::: warning HTML structure
+A `Menu` must have **exactly one** direct `MenuBtn` and **one** direct `MenuList`. For deeper menus, nest additional `Menu` components inside the parent's `MenuList`.
+:::
+
+## Nested example
+
+```
+┌ Menu
+├─ MenuBtn
+├─ MenuList
+├───┬ Menu
+│   ├─ MenuBtn
+│   └─ MenuList
+└───┬ Menu
+    ├─ MenuBtn
+    └─ MenuList
+```
+
+See the [JavaScript API](./js-api.md) for the options exposed by each part.

--- a/packages/docs/components/Modal/anatomy.md
+++ b/packages/docs/components/Modal/anatomy.md
@@ -1,0 +1,34 @@
+---
+title: Modal anatomy
+---
+
+# Anatomy
+
+`Modal` is a single JavaScript component driving a structured piece of markup. It reads a set of `data-ref` elements — triggers, the dialog, the overlay and the content — to open, close and trap focus. Use this map to see which parts exist and how they nest.
+
+## Structure
+
+```
+Modal                                  data-component="Modal"
+├─ trigger      [data-ref="open"]      (× n)  opens the modal
+└─ modal        [data-ref="modal"]     role="dialog", the dialog root
+   ├─ overlay   [data-ref="overlay"]   click-to-close backdrop
+   └─ wrapper                          centering layer
+      └─ container [data-ref="container"]  the scrollable dialog box
+         └─ content [data-ref="content"]   the dialog content
+            └─ close  [data-ref="close"]  (× n)  closes the modal
+```
+
+## Parts
+
+| Part | Selector | Required | Role |
+| --- | --- | --- | --- |
+| Root | `data-component="Modal"` | Yes | Owns the open / closed state, focus management and keyboard handling. |
+| Open trigger | `data-ref="open"` | Optional (× n) | Any element that opens the modal on click. |
+| Dialog | `data-ref="modal"` | Yes | The `role="dialog"` element toggled between shown and hidden. |
+| Overlay | `data-ref="overlay"` | Optional | The backdrop; clicking it closes the modal. |
+| Container | `data-ref="container"` | Yes | The scrollable dialog box. |
+| Content | `data-ref="content"` | Yes | The dialog's content. |
+| Close trigger | `data-ref="close"` | Optional (× n) | Any element that closes the modal on click. |
+
+The [`Modal.twig`](./twig-api.md) template renders this structure for you, exposing `open`, `close` and `content` blocks. See the [Twig API](./twig-api.md) for parameters and blocks and the [JavaScript API](./js-api.md) for options.

--- a/packages/docs/components/Slider/anatomy.md
+++ b/packages/docs/components/Slider/anatomy.md
@@ -1,0 +1,62 @@
+---
+title: Slider anatomy
+---
+
+# Anatomy
+
+`Slider` is a compound component. The root coordinates a track of items and any number of optional controls, all declared as child components. Use this map to see which parts exist and how they nest.
+
+## Structure
+
+```
+Slider                                 data-component="Slider"
+├─ SliderDrag       [data-ref="wrapper"]   the draggable track      (required)
+│  └─ SliderItem    (× n)                  a single slide           (required)
+├─ SliderBtn        (× 2, prev / next)     navigation buttons       (optional)
+├─ SliderCount                             current / total index    (optional)
+├─ SliderDots                              secondary navigation     (optional)
+└─ SliderProgress                          progress bar             (optional)
+```
+
+## Parts
+
+| Part | Selector | Required | Role |
+| --- | --- | --- | --- |
+| Root | `data-component="Slider"` | Yes | Owns the index and drives every child. |
+| Track | `data-component="SliderDrag"` | Yes | The `data-ref="wrapper"` element holding the slides; enables drag. |
+| Item | `data-component="SliderItem"` | Yes (× n) | One slide. |
+| Button | `data-component="SliderBtn"` | Optional | Previous / next control. |
+| Count | `data-component="SliderCount"` | Optional | Displays the current index. |
+| Dots | `data-component="SliderDots"` | Optional | Secondary dot navigation. |
+| Progress | `data-component="SliderProgress"` | Optional | Progress indicator. |
+
+## Registering the parts
+
+`SliderItem` and `SliderDrag` are registered on `Slider` by default. To use any of the optional controls you must extend `Slider` and register the extra children yourself:
+
+```js twoslash [Slider.js]
+import {
+  Slider as SliderCore,
+  SliderBtn,
+  SliderCount,
+  SliderDots,
+  SliderDrag,
+  SliderItem,
+  SliderProgress,
+} from '@studiometa/ui';
+
+export class Slider extends SliderCore {
+  static config = {
+    components: {
+      SliderBtn,
+      SliderCount,
+      SliderDots,
+      SliderDrag,
+      SliderItem,
+      SliderProgress,
+    },
+  };
+}
+```
+
+See the [JavaScript API](./js-api/) for the options exposed by each part.

--- a/packages/docs/components/Tabs/anatomy.md
+++ b/packages/docs/components/Tabs/anatomy.md
@@ -1,0 +1,27 @@
+---
+title: Tabs anatomy
+---
+
+# Anatomy
+
+`Tabs` is a single JavaScript component driving a structured piece of markup. It pairs each tab button with its panel through matching `data-ref` collections. Use this map to see which parts exist and how they nest.
+
+## Structure
+
+```
+Tabs                                   data-component="Tabs"
+├─ btn      [data-ref="btn"]      (× n)   a tab button
+└─ content  [data-ref="content"]  (× n)   the matching panel
+```
+
+## Parts
+
+| Part | Selector | Required | Role |
+| --- | --- | --- | --- |
+| Root | `data-component="Tabs"` | Yes | Owns the active index, toggles panels and handles keyboard navigation. |
+| Button | `data-ref="btn"` | Yes (× n) | A tab trigger. Paired with the panel at the same position. |
+| Panel | `data-ref="content"` | Yes (× n) | The panel shown when its button is active. Transitions between states. |
+
+The button and panel at the same index are paired together, so the `btn` and `content` refs must appear in matching order.
+
+The [`Tabs.twig`](./twig-api.md) template renders this structure for you from an `items` array. See the [Twig API](./twig-api.md) for parameters and the [JavaScript API](./js-api.md) for options.

--- a/packages/docs/components/Track/anatomy.md
+++ b/packages/docs/components/Track/anatomy.md
@@ -1,0 +1,29 @@
+---
+title: Track anatomy
+---
+
+# Anatomy
+
+The `Track` family declares analytics entirely in markup. A tracked element carries `data-track:<event>` attributes, and an optional `TrackContext` ancestor factors out data shared by every descendant. Use this map to see which parts exist and how they nest.
+
+## Structure
+
+```
+TrackContext                           data-component="TrackContext"   shared, inherited data   (optional)
+└─ Track | TrackShopify                data-component="Track"          one tracked element
+   ├─ data-track:<event>="…"           the events to dispatch
+   └─ <script data-ref="payload">      shared payload for this element  (optional)
+```
+
+## Parts
+
+| Part | Selector | Required | Role |
+| --- | --- | --- | --- |
+| Tracker | `data-component="Track"` | Yes | Resolves each `data-track:<event>` payload and pushes it to `window.dataLayer`. |
+| Tracker (Shopify) | `data-component="TrackShopify"` | Yes* | Same as `Track`, but publishes through `window.Shopify.analytics.publish`. |
+| Context | `data-component="TrackContext"` | Optional | Provides data inherited by every descendant tracker, deep-merged up the ancestor chain. |
+| Payload | `data-ref="payload"` | Optional | A `<script>` (or `data-option-payload`) holding data shared by every event on the element. |
+
+<small>\* `Track` and `TrackShopify` are alternative providers — pick the one matching your destination. The provider is chosen by the component name, so switching is a one-token change in the markup.</small>
+
+Context is deep-merged from the whole ancestor chain, with the nearest `TrackContext` winning. See the [JavaScript API](./js-api.md) for payload resolution, providers and event modifiers.


### PR DESCRIPTION
## What

Adds an **"Anatomy"** page to each compound component's documentation, addressing #436. Each page documents the component's parts, how they nest, and which are required vs. optional — inspired by [Base UI](https://base-ui.com/)'s anatomy sections.

Covered components:

- **Accordion** (`Accordion` → `AccordionItem`)
- **Slider** (`Slider` → `SliderDrag`, `SliderItem`, `SliderBtn`, `SliderCount`, `SliderDots`, `SliderProgress`)
- **Menu** (`Menu` → `MenuBtn`, `MenuList`, nestable)
- **AnchorNav** (`AnchorNav` → `AnchorNavLink`, `AnchorNavTarget`)
- **Modal** (single JS component, structured `data-ref` markup)
- **Tabs** (single JS component, structured `data-ref` markup)
- **Track** (`TrackContext` → `Track` / `TrackShopify`)
- **DataScope** (`DataScope` → `DataModel`, `DataBind`, `DataComputed`, `DataEffect`)

## Format

Each `anatomy.md` follows a consistent template:

1. A short intro describing the compound structure.
2. A **Structure** tree (box-drawing) showing nesting and the `data-component` / `data-ref` wiring, reusing the tree style already present in the Menu docs.
3. A **Parts** table: part, selector, required/optional, and role.

## Notes

- Pages are additive markdown only — no source or behavior changes.
- The sidebar is auto-generated from sibling `*.md` files (`.vitepress/config.ts`), so the pages appear automatically with **no config change**. They sort first ("Anatomy") within each component group.
- Verified with a local `vitepress build` (dead-link check passes).

Closes #436

🤖 Generated with [Claude Code](https://claude.com/claude-code)