### PR TITLE
Add a total option to the Indexable component

### DIFF
--- a/packages/docs/components/Indexable/index.md
+++ b/packages/docs/components/Indexable/index.md
@@ -10,7 +10,20 @@ It is available as an `Indexable` component as well as a `withIndex(Base)` decor
 
 ## Usage
 
-As a primitive, the `Indexable` class should be used to create other components rather than being used directly in an application. The `length` property defaults to `0` and should be overridden to match the actual number of items.
+### Standalone
+
+For simple cases, the `Indexable` component can be used directly in your HTML by setting the number of items with the [`total`](./js-api#total) option. Its index can then be driven from other components such as [`Action`](../Action/):
+
+```html
+<div data-component="Indexable" data-option-total="3" data-option-boundary="loop">
+  <button type="button" data-component="Action" data-option-target="Indexable" data-option-effect="target.goPrev()">Previous</button>
+  <button type="button" data-component="Action" data-option-target="Indexable" data-option-effect="target.goNext()">Next</button>
+</div>
+```
+
+### As a base class
+
+As a primitive, the `Indexable` class can also be used to create other components. The `length` property defaults to the `total` option (`0` when unset) and can be overridden to derive the number of items from the component's content instead.
 
 ```js
 import { Indexable } from '@studiometa/ui';

--- a/packages/docs/components/Indexable/js-api.md
+++ b/packages/docs/components/Indexable/js-api.md
@@ -44,3 +44,20 @@ Defines the initial direction of the count.
 </div>
 ```
 <!-- prettier-ignore-end -->
+
+### `total`
+
+- Type: `number`
+- Default: `0`
+
+Defines the number of items to navigate through. It sets the `length` property, allowing the `Indexable` component to be used standalone without extending it. Subclasses may override the `length` getter to derive it from their content instead.
+
+<!-- prettier-ignore-start -->
+```html {2}
+<div
+  data-component="Indexable"
+  data-option-total="3">
+  ...
+</div>
+```
+<!-- prettier-ignore-end -->

--- a/packages/tests/Indexable/Indexable.spec.ts
+++ b/packages/tests/Indexable/Indexable.spec.ts
@@ -181,6 +181,25 @@ describe('The Indexable class', () => {
     });
   });
 
+  describe('total option', () => {
+    it('should derive the length from the `total` option when used standalone', async () => {
+      const instance = new Indexable(h('div', { dataOptionTotal: 3 }));
+      expect(instance.length).toBe(3);
+      expect(instance.maxIndex).toBe(2);
+    });
+
+    it('should let a standalone instance navigate within the configured bounds', async () => {
+      const instance = new Indexable(h('div', { dataOptionTotal: 3 }));
+
+      await instance.goTo(5);
+      expect(instance.currentIndex).toBe(2); // clamped to maxIndex
+
+      instance.boundary = Indexable.BOUNDARIES.LOOP;
+      await instance.goTo(3);
+      expect(instance.currentIndex).toBe(0); // wraps around
+    });
+  });
+
   describe('goTo method', () => {
     it('should go to specific index', async () => {
       const emitSpy = vi.spyOn(indexable, '$emit');

--- a/packages/ui/decorators/withIndex.ts
+++ b/packages/ui/decorators/withIndex.ts
@@ -30,6 +30,7 @@ export interface IndexableProps extends BaseProps {
   $options: {
     boundary: IndexableBoundary;
     reverse: boolean;
+    total: number;
   };
 }
 
@@ -52,7 +53,9 @@ export interface IndexableInterface extends BaseInterface {
   set boundary(value: IndexableBoundary);
 
   /**
-   * Get the length.
+   * Get the length. Defaults to the `total` option, which lets the primitive
+   * be used standalone; subclasses may override it to derive the length from
+   * their content (e.g. the number of child items).
    */
   get length(): number;
 
@@ -133,6 +136,10 @@ export function withIndex<S extends Base>(
           default: INDEXABLE_BOUNDARIES.CLAMP,
         },
         reverse: Boolean,
+        total: {
+          type: Number,
+          default: 0,
+        },
       },
     };
 
@@ -167,7 +174,7 @@ export function withIndex<S extends Base>(
     }
 
     get length() {
-      return 0;
+      return this.$options.total;
     }
 
     get minIndex() {


### PR DESCRIPTION
## Summary

The `Indexable` primitive's `length` property defaulted to `0` and had to be overridden in a subclass to set the number of items, so `Indexable` could not be used directly in HTML.

This adds a `total` option that feeds the `length` getter, letting the component be used standalone:

```html
<div data-component="Indexable" data-option-total="3" data-option-boundary="loop">
  <button type="button" data-component="Action" data-option-target="Indexable" data-option-effect="target.goPrev()">Previous</button>
  <button type="button" data-component="Action" data-option-target="Indexable" data-option-effect="target.goNext()">Next</button>
</div>
```

## Details

- `total` is a `Number` option defaulting to `0`, so existing behaviour is unchanged when it is not set.
- `get length()` now returns `this.$options.total` instead of a hardcoded `0`. Subclasses can still override `length` to derive it from their content (e.g. the number of child items).
- Added tests covering standalone usage (length/`maxIndex` derivation and navigation within the configured bounds).
- Documented the option in the Indexable `index.md` (standalone usage) and `js-api.md`.

## Test plan

- [x] `npm run test` — 423 passed, 3 skipped (pre-existing)
- [x] `npm run lint` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)