### PR TITLE
Add parse_playground_url MCP tool

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -21,6 +21,7 @@ POST https://ui.studiometa.dev/api/mcp
 | `get_component_api` | Twig parameters/blocks (and JS options/refs/events) of a component. |
 | `get_component_example` | Ready-to-use Twig and JS snippets for a component. |
 | `build_playground_url` | Turn Twig/HTML, JavaScript and CSS into a shareable, live playground URL. |
+| `parse_playground_url` | Decode a shared playground URL back into its Twig/HTML, JavaScript, CSS and theme. |
 
 The discovery tools read the built VitePress documentation (`llms.txt` and the per-page Markdown files), so they stay in sync with the docs on every build. `build_playground_url` encodes the whole playground state in the URL hash — the code fields are zlib-compressed then base64-encoded, mirroring the front-end `zip()` helper from `@studiometa/playground` — so nothing is stored server-side.
 

--- a/packages/api/src/Mcp/PlaygroundUrlBuilder.php
+++ b/packages/api/src/Mcp/PlaygroundUrlBuilder.php
@@ -51,6 +51,50 @@ final class PlaygroundUrlBuilder
     }
 
     /**
+     * Decode the content of a playground URL.
+     *
+     * The inverse of {@see build()}: reads the URL hash (or query), decompresses
+     * the `html`, `script` and `style` fields, and returns them alongside the
+     * plain `theme` and `header` values. The `style` field is exposed as `css`
+     * for symmetry with {@see build()}.
+     *
+     * @return array{html?: string, script?: string, css?: string, theme?: string, header?: string}
+     */
+    public function parse(string $url): array
+    {
+        // The state lives in the URL fragment; fall back to the query string, or
+        // treat the whole input as the parameter string.
+        if (str_contains($url, '#')) {
+            $fragment = substr($url, strpos($url, '#') + 1);
+        } elseif (str_contains($url, '?')) {
+            $fragment = substr($url, strpos($url, '?') + 1);
+        } else {
+            $fragment = $url;
+        }
+
+        parse_str($fragment, $params);
+
+        $result = [];
+        foreach (['html' => 'html', 'script' => 'script', 'style' => 'css'] as $key => $out) {
+            if (isset($params[$key]) && \is_string($params[$key]) && '' !== $params[$key]) {
+                $result[$out] = $this->unzip($params[$key]);
+            }
+        }
+
+        foreach (['theme', 'header'] as $key) {
+            if (isset($params[$key]) && \is_string($params[$key]) && '' !== $params[$key]) {
+                $result[$key] = $params[$key];
+            }
+        }
+
+        if ([] === $result) {
+            throw new \RuntimeException('No playground content found in the given URL.');
+        }
+
+        return $result;
+    }
+
+    /**
      * Compress a string the same way the playground front-end does.
      */
     private function zip(string $data): string
@@ -61,5 +105,32 @@ final class PlaygroundUrlBuilder
         }
 
         return base64_encode($compressed);
+    }
+
+    /**
+     * Decompress a value the same way the playground front-end `unzip()` does.
+     */
+    private function unzip(string $value): string
+    {
+        // `URLSearchParams` (and PHP's parse_str) turn a literal `+` into a
+        // space; valid base64 never contains a space, so restoring it makes the
+        // parser tolerant of URLs that were decoded once (e.g. copied from an
+        // address bar that shows the percent-decoded form).
+        $binary = base64_decode(strtr($value, ' ', '+'), true);
+        if (false === $binary) {
+            throw new \RuntimeException('A playground field is not valid base64.');
+        }
+
+        // zlib streams start with 0x78; anything else is stored uncompressed.
+        if (str_starts_with($binary, "\x78")) {
+            // Cap the decompressed size to guard against a decompression bomb in
+            // an attacker-supplied URL (playground content is tiny in practice).
+            $inflated = @gzuncompress($binary, 10_000_000);
+            if (false !== $inflated) {
+                return $inflated;
+            }
+        }
+
+        return $binary;
     }
 }

--- a/packages/api/src/Mcp/Tool/PlaygroundTools.php
+++ b/packages/api/src/Mcp/Tool/PlaygroundTools.php
@@ -4,6 +4,7 @@ namespace App\Mcp\Tool;
 
 use App\Mcp\PlaygroundUrlBuilder;
 use Mcp\Capability\Attribute\McpTool;
+use Mcp\Exception\ToolCallException;
 
 /**
  * MCP tools generating @studiometa/ui playgrounds.
@@ -40,5 +41,26 @@ final class PlaygroundTools
         $theme = 'dark' === $theme ? 'dark' : 'light';
 
         return $this->urlBuilder->build($html, $script, $css, $theme, $header);
+    }
+
+    /**
+     * Read the content of a shared playground URL.
+     *
+     * The inverse of `build_playground_url`: decode a link into its Twig/HTML,
+     * JavaScript, CSS and theme so you can inspect or edit an existing
+     * playground. Pass the full URL (the state lives in the part after `#`).
+     *
+     * @param string $url The playground URL to decode
+     *
+     * @return array{html?: string, script?: string, css?: string, theme?: string, header?: string}
+     */
+    #[McpTool(name: 'parse_playground_url')]
+    public function parsePlaygroundUrl(string $url): array
+    {
+        try {
+            return $this->urlBuilder->parse($url);
+        } catch (\RuntimeException $e) {
+            throw new ToolCallException($e->getMessage(), previous: $e);
+        }
     }
 }


### PR DESCRIPTION
## What

Adds `parse_playground_url` to the MCP server — the inverse of `build_playground_url`. An agent can hand it a shared playground link and get back the decoded Twig/HTML, JavaScript, CSS and theme, so it can read or edit an existing playground.

## How it works

Mirrors the front-end `unzip()` from `@studiometa/playground`: parse the URL fragment (falls back to the query string), then `base64_decode` + `gzuncompress` each code field (`html`, `script`, `style` → returned as `css`), and pass through the plain `theme`/`header`. Returns a JSON object (MCP structured content must be a record).

Robustness:
- **Tolerates once-decoded URLs.** `URLSearchParams`/`parse_str` turn a literal `+` into a space, and valid base64 never contains a space, so the parser restores space → `+` before decoding. A link that was URL-decoded once (e.g. copied from an address bar showing the percent-decoded form) still parses.
- **Caps decompressed size** (`gzuncompress($bin, 10_000_000)`) to guard against a decompression bomb in an attacker-supplied URL.

## Verified

- PHP round-trip: `build` → `parse` returns the exact original `html`/`script`/`css`/`theme`/`header`, including `+`, `/`, `=` and multibyte UTF-8.
- Same input parses identically whether the URL is percent-encoded or once-decoded.
- Over the live MCP endpoint: `tools/list` shows the new tool; `parse_playground_url` returns correct `structuredContent`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)