### PR TITLE
Add Action and Data* composition examples to the docs

### DIFF
--- a/packages/docs/components/Action/examples.md
+++ b/packages/docs/components/Action/examples.md
@@ -63,3 +63,24 @@ Use the `debounce` modifier to prevent firing the action's effect too often.
 :::
 
 </llm-only>
+
+## Side effects on a popover
+
+`Action` listens to real DOM events, so it can react to native ones too. Here a `<dialog>` uses the [Popover API](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API) for the whole modal mechanics — open, close, <kbd>Esc</kbd>, click-outside, focus and top-layer stacking — with no JavaScript. `Action` only wires the one thing the platform does not provide: locking the body scroll, by listening to the popover's `toggle` event and reading its `newState`.
+
+<llm-exclude>
+  <PreviewPlayground
+    :html="() => import('./stories/popover-toggle/app.twig')"
+    :script="() => import('./stories/popover-toggle/app.js?raw')"
+    />
+</llm-exclude>
+<llm-only>
+
+:::code-group
+
+<<< ./stories/popover-toggle/app.twig
+<<< ./stories/popover-toggle/app.js
+
+:::
+
+</llm-only>

--- a/packages/docs/components/Action/stories/popover-toggle/app.js
+++ b/packages/docs/components/Action/stories/popover-toggle/app.js
@@ -1,0 +1,6 @@
+import { registerComponent } from '@studiometa/js-toolkit';
+import { Action } from '@studiometa/ui';
+
+// No open/close logic: the Popover API handles it. Action only wires the
+// scroll-lock side effect to the native `toggle` event.
+registerComponent(Action);

--- a/packages/docs/components/Action/stories/popover-toggle/app.twig
+++ b/packages/docs/components/Action/stories/popover-toggle/app.twig
@@ -1,0 +1,35 @@
+<button
+  type="button"
+  popovertarget="modal"
+  class="px-4 py-2 rounded bg-blue-500 text-white font-semibold">
+  Open modal
+</button>
+
+{# The native Popover API on a <dialog> handles open/close, Esc,
+   light-dismiss, focus and top-layer stacking. Action only adds the body
+   scroll-lock the platform does not provide, via the native `toggle` event. #}
+<dialog
+  id="modal"
+  popover
+  class="m-auto max-w-lg p-6 rounded bg-white dark:bg-zinc-800 shadow-xl backdrop:bg-black/50"
+  data-component="Action"
+  data-on:toggle="document.documentElement.style.overflow = event.newState === 'open' ? 'hidden' : ''">
+  <h2 class="text-xl font-bold mb-2">Modern modal</h2>
+  <p class="mb-4">
+    Open/close, <kbd>Esc</kbd>, click-outside, focus and top-layer stacking are
+    handled natively by the Popover API on a <code>&lt;dialog&gt;</code>. The only
+    JavaScript is an <code>Action</code> listening to the native
+    <code>toggle</code> event to lock body scroll.
+  </p>
+  <button
+    type="button"
+    popovertarget="modal"
+    popovertargetaction="hide"
+    class="px-4 py-2 rounded bg-blue-500 text-white font-semibold">
+    Close
+  </button>
+</dialog>
+
+<div class="mt-4 h-[150vh] opacity-50">
+  Scroll me — the body scroll locks while the modal is open.
+</div>

--- a/packages/docs/components/DataScope/examples.md
+++ b/packages/docs/components/DataScope/examples.md
@@ -67,6 +67,27 @@ This example uses the same mirrored-model pattern for two independent accordion 
 
 </llm-only>
 
+## Dropdown menu
+
+The same disclosure pattern powers a dropdown menu. Each `DataScope` isolates one menu, so the two below toggle independently despite sharing the `menu` group name. The button is a mirrored [`DataModel`](../DataModel/index.md) that toggles the `open` key with [`toggle()`](../DataBind/js-api.md) and mirrors it onto `aria-expanded`, while the list is a [`DataBind`](../DataBind/index.md) that shows or hides itself. <kbd>Esc</kbd> closes the menu while the button is focused. No `Menu` component is registered.
+
+<llm-exclude>
+<PreviewPlayground
+  :html="() => import('./stories/menu.twig')"
+  :script="() => import('./stories/menu.js?raw')"
+  />
+</llm-exclude>
+<llm-only>
+
+:::code-group
+
+<<< ./stories/menu.twig
+<<< ./stories/menu.js
+
+:::
+
+</llm-only>
+
 ## Nested and explicit groups
 
 A Data component without `data-option-group` inherits the group of its nearest `DataScope`. An explicit group creates another group inside the same scope instead of escaping the scope.

--- a/packages/docs/components/DataScope/stories/menu.js
+++ b/packages/docs/components/DataScope/stories/menu.js
@@ -1,0 +1,7 @@
+import { registerComponent } from '@studiometa/js-toolkit';
+import { Action, DataBind, DataModel, DataScope } from '@studiometa/ui';
+
+registerComponent(DataScope);
+registerComponent(DataBind);
+registerComponent(DataModel);
+registerComponent(Action);

--- a/packages/docs/components/DataScope/stories/menu.twig
+++ b/packages/docs/components/DataScope/stories/menu.twig
@@ -1,0 +1,35 @@
+<div class="flex gap-8">
+  {% for i in 1..2 %}
+    <nav
+      data-component="DataScope"
+      data-option-group="menu"
+      class="relative inline-block">
+      <button
+        type="button"
+        id="menu-{{ i }}-button"
+        aria-controls="menu-{{ i }}-list"
+        aria-expanded="false"
+        class="px-4 py-2 rounded bg-blue-500 text-white font-semibold"
+        data-component="Action DataModel"
+        data-option-key="open"
+        data-option-prop="value"
+        data-option-immediate
+        data-bind:attr.aria-expanded="String(value === 'open')"
+        data-on:click="DataModel.toggle('open', '')"
+        data-on:keydown="event.key === 'Escape' && DataModel.set('')">
+        Menu {{ i }} ▾
+      </button>
+      <ul
+        id="menu-{{ i }}-list"
+        hidden
+        class="absolute left-0 top-full mt-2 min-w-48 p-1 rounded ring bg-white dark:bg-zinc-800 shadow-lg"
+        data-component="DataBind"
+        data-option-key="open"
+        data-bind:attr.hidden="value !== 'open'">
+        <li><a href="#one" class="block px-3 py-2 rounded hover:bg-blue-500/10">Item one</a></li>
+        <li><a href="#two" class="block px-3 py-2 rounded hover:bg-blue-500/10">Item two</a></li>
+        <li><a href="#three" class="block px-3 py-2 rounded hover:bg-blue-500/10">Item three</a></li>
+      </ul>
+    </nav>
+  {% endfor %}
+</div>

--- a/packages/docs/components/Indexable/examples.md
+++ b/packages/docs/components/Indexable/examples.md
@@ -22,3 +22,24 @@ title: Indexable examples
 :::
 
 </llm-only>
+
+## Slider
+
+This example builds a slider without a dedicated component. `Indexable` owns the index — `total` sets the number of slides and `boundary="loop"` wraps around — while [`Action`](../Action/index.md) triggers `goPrev()`, `goNext()` and `goTo()`. A co-located `Action` bridges the reactive rendering: because [`$emit`](https://js-toolkit.studiometa.dev/api/instance-methods/#emit) dispatches a native event, `data-on:index` catches the `index` event and forwards `event.detail[0]` to every [`DataBind`](../DataBind/index.md) and [`DataComputed`](../DataComputed/index.md), which move the track, highlight the dots and update the counter. No `Slider` component is registered.
+
+<llm-exclude>
+<PreviewPlayground
+  :html="() => import('./stories/slider/app.twig')"
+  :script="() => import('./stories/slider/app.js?raw')"
+  />
+</llm-exclude>
+<llm-only>
+
+:::code-group
+
+<<< ./stories/slider/app.twig
+<<< ./stories/slider/app.js
+
+:::
+
+</llm-only>

--- a/packages/docs/components/Indexable/stories/slider/app.js
+++ b/packages/docs/components/Indexable/stories/slider/app.js
@@ -1,0 +1,10 @@
+import { registerComponent } from '@studiometa/js-toolkit';
+import { Indexable, Action, DataBind, DataComputed } from '@studiometa/ui';
+
+// No App and no subclass: Indexable owns the index (with `total` and
+// `boundary`), a co-located Action bridges its `index` event to the
+// DataBind/DataComputed renderers. No Slider component is registered.
+registerComponent(Indexable);
+registerComponent(Action);
+registerComponent(DataBind);
+registerComponent(DataComputed);

--- a/packages/docs/components/Indexable/stories/slider/app.twig
+++ b/packages/docs/components/Indexable/stories/slider/app.twig
@@ -1,0 +1,65 @@
+{% set total = 4 %}
+
+<div class="max-w-md mx-auto grid gap-4">
+  {# Indexable owns the index. The co-located Action forwards its `index`
+     event (event.detail[0]) to every DataBind/DataComputed renderer. #}
+  <span
+    hidden
+    data-component="Indexable Action"
+    data-option-total="{{ total }}"
+    data-option-boundary="loop"
+    data-on:index="DataBind DataComputed -> target.set(event.detail[0], false)"></span>
+
+  <div class="overflow-hidden rounded-lg ring">
+    <div
+      class="flex transition-transform duration-500 ease-out"
+      data-component="DataBind"
+      data-bind:style.transform="`translateX(-${(Number(value) || 0) * 100}%)`">
+      {% for i in 1..total %}
+        <div
+          class="flex-none w-full h-48 flex items-center justify-center text-2xl font-bold text-white"
+          style="background: hsl({{ (loop.index0 * 360 / total)|round }}, 70%, 55%)">
+          Slide {{ i }}
+        </div>
+      {% endfor %}
+    </div>
+  </div>
+
+  <div class="flex items-center justify-center gap-3">
+    <button
+      type="button"
+      class="px-4 py-2 rounded bg-blue-500 text-white font-semibold"
+      data-component="Action"
+      data-option-target="Indexable"
+      data-option-effect="target.goPrev()">
+      Previous
+    </button>
+
+    {% for i in 1..total %}
+      <button
+        type="button"
+        aria-label="Go to slide {{ i }}"
+        {% if loop.first %}aria-current="true"{% endif %}
+        class="size-3 rounded-full bg-gray-400 transition aria-[current=true]:bg-blue-500 aria-[current=true]:scale-125"
+        data-component="Action DataBind"
+        data-bind:attr.aria-current="String((Number(value) || 0) === {{ loop.index0 }})"
+        data-on:click="Indexable -> target.goTo({{ loop.index0 }})"></button>
+    {% endfor %}
+
+    <button
+      type="button"
+      class="px-4 py-2 rounded bg-blue-500 text-white font-semibold"
+      data-component="Action"
+      data-option-target="Indexable"
+      data-option-effect="target.goNext()">
+      Next
+    </button>
+  </div>
+
+  <p
+    class="text-center opacity-70"
+    data-component="DataComputed"
+    data-option-compute="`Slide ${(Number(value) || 0) + 1} of {{ total }}`">
+    Slide 1 of {{ total }}
+  </p>
+</div>


### PR DESCRIPTION
## Summary

Adds runnable documentation examples showing how the headless primitives (`Action`, `Indexable`, the `Data*` family) compose to rebuild common widgets without a dedicated component class. Each is a standard story (`PreviewPlayground` + `llm-only` code group).

### Indexable — **Slider** (`components/Indexable/examples.md`)
`Indexable` owns the index (`total` sets the count, `boundary="loop"` wraps), `Action` triggers `goPrev()`/`goNext()`/`goTo()`, and a co-located `Action` bridges the `index` event to `DataBind`/`DataComputed` — since `$emit` dispatches a native event, `data-on:index` forwards `event.detail[0]` to the renderers. No `Slider` component registered.

### DataScope — **Dropdown menu** (`components/DataScope/examples.md`)
Reuses the tabs/accordion disclosure pattern for two independently-scoped menus (mirrored `DataModel` toggling `open` + `DataBind` showing/hiding the list, `Esc` to close). No `Menu` component registered.

### Action — **Side effects on a popover** (`components/Action/examples.md`)
Uses the native [Popover API](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API) on a `<dialog>` for the entire modal mechanics (open/close, `Esc`, light-dismiss, focus, top-layer) with no JS; `Action` only locks body scroll by listening to the native `toggle` event. This demonstrates `Action` reacting to platform events, and favors modern HTML over re-implementing modal behavior.

## Test plan

- [x] `npm run docs:build` — builds successfully (all `<<<` story includes resolve)
- [x] `prettier --check` on the edited `examples.md` files

## Notes

The Slider example depends on the `total` option added in #526.

🤖 Generated with [Claude Code](https://claude.com/claude-code)