### PR TITLE
Add ShopifyPartialsFetch adapter for Shopify partial rendering

### DIFF
--- a/packages/docs/components/ShopifyPartialsFetch/examples.md
+++ b/packages/docs/components/ShopifyPartialsFetch/examples.md
@@ -1,0 +1,129 @@
+---
+title: ShopifyPartialsFetch examples
+---
+
+# Examples
+
+::: tip
+These examples run against a Shopify storefront using the [Liquid July&nbsp;'26 partial rendering preview](https://shopify.dev/docs/storefronts/themes/getting-started/developer-preview/partial), so they are shown as code rather than live playgrounds. See the [`Fetch` examples](../Fetch/examples.md) for runnable demonstrations of the inherited behaviour.
+:::
+
+## Sorting a collection
+
+Refresh the product grid and the results count when the customer picks a sort order, keeping their scroll position.
+
+::: code-group
+
+```liquid [collection.liquid]
+{% partial 'product-grid' %}
+  <ul id="product-grid" class="grid grid-cols-2 gap-4 md:grid-cols-4">
+    {% for product in collection.products %}
+      {% render 'product-card', product: product %}
+    {% endfor %}
+  </ul>
+{% endpartial %}
+
+{% partial 'product-count' %}
+  <p id="product-count">{{ collection.products_count }} products</p>
+{% endpartial %}
+
+<a
+  href="{{ collection.url }}?sort_by=price-ascending"
+  data-component="ShopifyPartialsFetch"
+  data-option-partials='["product-grid", "product-count"]'
+  data-option-history>
+  Sort by price
+</a>
+```
+
+```js [app.ts]
+import { registerComponent } from '@studiometa/js-toolkit';
+import { ShopifyPartialsFetch } from '@studiometa/ui';
+
+registerComponent(ShopifyPartialsFetch);
+```
+
+:::
+
+## Faceted filtering with a form
+
+Use a `<form method="get">` so the selected facets are appended to the URL automatically, and display a loader while the partials are refreshed with the inherited [`Action`](../Action/index.md) and [`Transition`](../Transition/index.md) components.
+
+::: code-group
+
+```liquid [collection.liquid]
+<form
+  action="{{ collection.url }}"
+  method="get"
+  data-component="ShopifyPartialsFetch Action"
+  data-option-partials='["product-grid", "active-filters"]'
+  data-on:fetch-before="Transition(#filters-loader) -> target.enter()"
+  data-on:fetch-after="Transition(#filters-loader) -> target.leave()">
+  {% for filter in collection.filters %}
+    {% render 'facet', filter: filter %}
+  {% endfor %}
+  <noscript><button type="submit">Apply</button></noscript>
+</form>
+
+<div
+  id="filters-loader"
+  data-component="Transition"
+  data-option-enter-from="opacity-0"
+  data-option-leave-to="opacity-0"
+  data-option-leave-keep
+  class="opacity-0">
+  Loading…
+</div>
+
+{% partial 'active-filters' %}
+  <div id="active-filters">{% render 'active-filters' %}</div>
+{% endpartial %}
+
+{% partial 'product-grid' %}
+  <ul id="product-grid">{% render 'product-list', products: collection.products %}</ul>
+{% endpartial %}
+```
+
+```js [app.ts]
+import { registerComponent } from '@studiometa/js-toolkit';
+import { Action, ShopifyPartialsFetch, Transition } from '@studiometa/ui';
+
+registerComponent(Action);
+registerComponent(ShopifyPartialsFetch);
+registerComponent(Transition);
+```
+
+:::
+
+::: tip
+Submitting a facet automatically triggers the request — no submit button is required when the form is enhanced. Keep a `<noscript>` submit button so filtering still works without JavaScript.
+:::
+
+## Reacting to the update event
+
+`ShopifyPartialsFetch` inherits the [`Fetch` events](../Fetch/js-api.md#events). Use the [`fetch-update-after` event](../Fetch/js-api.md#fetch-update-after) to run logic once the regions have been swapped — for example scrolling the refreshed grid back into view after paginating. As with the base component, events bubble, so the [`Action`](../Action/index.md) handler can live on a parent element.
+
+::: code-group
+
+```liquid [collection.liquid]
+<div
+  data-component="Action"
+  data-on:fetch-update-after="document.getElementById('product-grid').scrollIntoView()">
+  <a
+    href="{{ collection.url }}?page=2"
+    data-component="ShopifyPartialsFetch"
+    data-option-partials='["product-grid"]'>
+    Next page
+  </a>
+</div>
+```
+
+```js [app.ts]
+import { registerComponent } from '@studiometa/js-toolkit';
+import { Action, ShopifyPartialsFetch } from '@studiometa/ui';
+
+registerComponent(Action);
+registerComponent(ShopifyPartialsFetch);
+```
+
+:::

--- a/packages/docs/components/ShopifyPartialsFetch/index.md
+++ b/packages/docs/components/ShopifyPartialsFetch/index.md
@@ -1,0 +1,57 @@
+---
+badges: [JS]
+---
+
+# ShopifyPartialsFetch <Badges :texts="$frontmatter.badges" />
+
+The `ShopifyPartialsFetch` component extends the [`Fetch` component](../Fetch/index.md) to refresh a page with Shopify's [partial rendering](https://shopify.dev/docs/storefronts/themes/getting-started/developer-preview/partial) API (Liquid July&nbsp;'26 developer preview). Server-rendered regions marked with the `{% partial %}` tag are updated in place — preserving focus, text selection, form values and scroll position, with support for the View Transition API — without a full page reload.
+
+::: warning Developer preview
+Shopify partial rendering relies on the [`@shopify/partial-rendering`](https://www.npmjs.com/package/@shopify/partial-rendering) package, which is part of the Liquid July&nbsp;'26 developer preview. It is declared as an **optional** dependency: when it is not installed — or when no partial is configured — the component transparently falls back to the base [`Fetch`](../Fetch/index.md) behaviour (id-based full-page swap).
+:::
+
+## Installation
+
+Install the optional Shopify package alongside `@studiometa/ui`:
+
+```bash
+npm install @shopify/partial-rendering
+```
+
+## Usage
+
+Register the component in your JavaScript app:
+
+```js
+import { registerComponent } from '@studiometa/js-toolkit';
+import { ShopifyPartialsFetch } from '@studiometa/ui';
+
+registerComponent(ShopifyPartialsFetch);
+```
+
+Wrap the server-rendered region to refresh with the `{% partial %}` tag in your Liquid template:
+
+```liquid
+{% partial 'product-grid' %}
+  {% for product in collection.products %}
+    {% render 'product-card', product: product %}
+  {% endfor %}
+{% endpartial %}
+```
+
+Then trigger a refresh from a link or a form, listing the partials to update with the [`partials` option](./js-api.md#partials):
+
+```html
+<a
+  href="{{ collection.url }}?sort_by=price-ascending"
+  data-component="ShopifyPartialsFetch"
+  data-option-partials='["product-grid", "product-count"]'>
+  Sort by price
+</a>
+```
+
+Clicking the link fetches fresh HTML for the `product-grid` and `product-count` partials and swaps them in place. Because `ShopifyPartialsFetch` extends `Fetch`, it inherits every [option](./js-api.md), getter, method and event of the base component, including the loader, [`history`](../Fetch/js-api.md#history) and [`viewTransition`](../Fetch/js-api.md#viewtransition) features.
+
+## Choosing between the partials and Section Rendering APIs
+
+If you are not using the Liquid July&nbsp;'26 partial rendering preview, the base [`Fetch`](../Fetch/index.md) component can already consume Shopify's stable [Section Rendering API](../Fetch/examples.md#shopify-section-rendering-api) with no extra package. Reach for `ShopifyPartialsFetch` when you want the ergonomics and state preservation of the newer `{% partial %}` primitive.

--- a/packages/docs/components/ShopifyPartialsFetch/js-api.md
+++ b/packages/docs/components/ShopifyPartialsFetch/js-api.md
@@ -1,0 +1,41 @@
+---
+title: ShopifyPartialsFetch JS API
+outline: deep
+---
+
+# JS API
+
+The `ShopifyPartialsFetch` class extends the [`Fetch` class](../Fetch/js-api.md) and delegates fetching and DOM updates to Shopify's [`@shopify/partial-rendering`](https://www.npmjs.com/package/@shopify/partial-rendering) package when partials are configured. All [`Fetch` options](../Fetch/js-api.md#options), getters, methods and events are inherited; the additions and differences are documented below.
+
+## Options
+
+### `partials`
+
+- Type: `string[]`
+- Default: `[]`
+
+The names of the Shopify partials to refresh, matching the names used in the corresponding `{% partial %}` tags. Provide them as a JSON array in the `data-option-partials` attribute. When the list is empty, the component falls back to the base [`Fetch`](../Fetch/index.md) behaviour.
+
+```html
+<a
+  href="/collections/all"
+  data-component="ShopifyPartialsFetch"
+  data-option-partials='["product-grid", "product-count"]'>
+  Refresh
+</a>
+```
+
+## Behaviour
+
+### Fallback to Fetch
+
+The Shopify partial rendering path is used only when the [`partials` option](#partials) lists at least one name **and** the `@shopify/partial-rendering` package resolves. In every other case — no partial configured, or the package not installed — the component behaves exactly like the base [`Fetch`](../Fetch/index.md) component and swaps content by matching `id` attributes from a full response. The package is loaded lazily on the first request, so it never needs to be bundled when it is not used.
+
+### Events
+
+`ShopifyPartialsFetch` emits the same [events as `Fetch`](../Fetch/js-api.md#events), with two differences on the partial rendering path:
+
+- the [`fetch-response` event](../Fetch/js-api.md#fetch-response) is **not** emitted, as there is no `Response` object to expose;
+- the [`fetch-update` event](../Fetch/js-api.md#fetch-update) payload carries the opaque partials `update` object (as `event.detail[0].update`) instead of a parsed `Document` fragment.
+
+On the fallback path, all events — including `fetch-response` — behave exactly like the base [`Fetch`](../Fetch/js-api.md#events) component.

--- a/packages/docs/components/ShopifyPartialsFetch/js-api.md
+++ b/packages/docs/components/ShopifyPartialsFetch/js-api.md
@@ -29,7 +29,12 @@ The names of the Shopify partials to refresh, matching the names used in the cor
 
 ### Fallback to Fetch
 
-The Shopify partial rendering path is used only when the [`partials` option](#partials) lists at least one name **and** the `@shopify/partial-rendering` package resolves. In every other case — no partial configured, or the package not installed — the component behaves exactly like the base [`Fetch`](../Fetch/index.md) component and swaps content by matching `id` attributes from a full response. The package is loaded lazily on the first request, so it never needs to be bundled when it is not used.
+The Shopify partial rendering path is used only when the [`partials` option](#partials) lists at least one name **and** the `@shopify/partial-rendering` package resolves. In every other case the component behaves exactly like the base [`Fetch`](../Fetch/index.md) component and swaps content by matching `id` attributes from a full response. It falls back to `Fetch` when:
+
+- no partial is configured, or the package is not installed;
+- the request cannot be expressed as a plain `GET` — because the partials API only fetches a URL, a `method="post"` form (which carries a body), a [`headers`](../Fetch/js-api.md#headers) / [`requestInit`](../Fetch/js-api.md#requestinit) option or a [`headers[]` ref](../Fetch/js-api.md#headers-1) makes the component fall back so those request options are not silently dropped.
+
+The package is loaded lazily on the first request, so it never needs to be bundled when it is not used.
 
 ### Events
 

--- a/packages/docs/components/ShopifyPartialsFetch/js-api.md
+++ b/packages/docs/components/ShopifyPartialsFetch/js-api.md
@@ -32,7 +32,7 @@ The names of the Shopify partials to refresh, matching the names used in the cor
 The Shopify partial rendering path is used only when the [`partials` option](#partials) lists at least one name **and** the `@shopify/partial-rendering` package resolves. In every other case the component behaves exactly like the base [`Fetch`](../Fetch/index.md) component and swaps content by matching `id` attributes from a full response. It falls back to `Fetch` when:
 
 - no partial is configured, or the package is not installed;
-- the request cannot be expressed as a plain `GET` — because the partials API only fetches a URL, a `method="post"` form (which carries a body), a [`headers`](../Fetch/js-api.md#headers) / [`requestInit`](../Fetch/js-api.md#requestinit) option or a [`headers[]` ref](../Fetch/js-api.md#headers-1) makes the component fall back so those request options are not silently dropped.
+- the request cannot be expressed as a plain `GET` — because the partials API only fetches a URL, any request carrying a body, a non-`GET` method, custom headers or any other request option makes the component fall back so those options are not silently dropped. This covers the [`headers`](../Fetch/js-api.md#headers) / [`requestInit`](../Fetch/js-api.md#requestinit) options and [`headers[]` refs](../Fetch/js-api.md#headers-1), a `method="post"` form, and per-call overrides such as `fetch(url, { credentials: 'include' })`. Framework-internal headers are ignored, so the click, submit and history navigation flows still use partial rendering.
 
 The package is loaded lazily on the first request, so it never needs to be bundled when it is not used.
 

--- a/packages/tests/Fetch/ShopifyPartialsFetch.spec.ts
+++ b/packages/tests/Fetch/ShopifyPartialsFetch.spec.ts
@@ -93,6 +93,44 @@ describe('The ShopifyPartialsFetch class', () => {
     container.remove();
   });
 
+  it('should fall back to base Fetch for a POST form (body cannot be carried)', async () => {
+    const fakePartials = useFakePartials();
+    const windowFetchSpy = vi.spyOn(window, 'fetch');
+    windowFetchSpy.mockImplementation(() => Promise.resolve(new Response('<div id="test">ok</div>')));
+
+    const form = h('form', {
+      action: 'https://example.com/cart/add',
+      method: 'post',
+      dataOptionPartials: ['cart-items'],
+    });
+    const fetch = new ShopifyPartialsFetch(form);
+
+    await mount(fetch);
+    await fetch.fetch(new URL('https://example.com/cart/add'));
+
+    expect(fakePartials.fetch).not.toHaveBeenCalled();
+    expect(windowFetchSpy).toHaveBeenCalledOnce();
+  });
+
+  it('should fall back to base Fetch when custom headers are configured', async () => {
+    const fakePartials = useFakePartials();
+    const windowFetchSpy = vi.spyOn(window, 'fetch');
+    windowFetchSpy.mockImplementation(() => Promise.resolve(new Response('<div id="test">ok</div>')));
+
+    const anchor = h('a', {
+      href: 'https://example.com',
+      dataOptionPartials: ['product-grid'],
+      dataOptionHeaders: { 'x-foo': 'bar' },
+    });
+    const fetch = new ShopifyPartialsFetch(anchor);
+
+    await mount(fetch);
+    await fetch.fetch(new URL('https://example.com'));
+
+    expect(fakePartials.fetch).not.toHaveBeenCalled();
+    expect(windowFetchSpy).toHaveBeenCalledOnce();
+  });
+
   it('should fall back to base Fetch when the module has no partials export', async () => {
     ShopifyPartialsFetch.__loadPartialsModule = async () => ({}) as any;
     const windowFetchSpy = vi.spyOn(window, 'fetch');

--- a/packages/tests/Fetch/ShopifyPartialsFetch.spec.ts
+++ b/packages/tests/Fetch/ShopifyPartialsFetch.spec.ts
@@ -131,6 +131,24 @@ describe('The ShopifyPartialsFetch class', () => {
     expect(windowFetchSpy).toHaveBeenCalledOnce();
   });
 
+  it('should fall back to base Fetch when a per-call request init carries unsupported options', async () => {
+    const fakePartials = useFakePartials();
+    const windowFetchSpy = vi.spyOn(window, 'fetch');
+    windowFetchSpy.mockImplementation(() => Promise.resolve(new Response('<div id="test">ok</div>')));
+
+    const anchor = h('a', {
+      href: 'https://example.com',
+      dataOptionPartials: ['product-grid'],
+    });
+    const fetch = new ShopifyPartialsFetch(anchor);
+
+    await mount(fetch);
+    await fetch.fetch(new URL('https://example.com'), { credentials: 'include' });
+
+    expect(fakePartials.fetch).not.toHaveBeenCalled();
+    expect(windowFetchSpy).toHaveBeenCalledOnce();
+  });
+
   it('should fall back to base Fetch when the module has no partials export', async () => {
     ShopifyPartialsFetch.__loadPartialsModule = async () => ({}) as any;
     const windowFetchSpy = vi.spyOn(window, 'fetch');

--- a/packages/tests/Fetch/ShopifyPartialsFetch.spec.ts
+++ b/packages/tests/Fetch/ShopifyPartialsFetch.spec.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { ShopifyPartialsFetch } from '@studiometa/ui';
+import { h, mount } from '#test-utils';
+
+const FAKE_UPDATE = { partials: [{ name: 'product-grid', html: '<div>updated</div>' }] };
+
+const originalLoader = ShopifyPartialsFetch.__loadPartialsModule;
+
+/**
+ * Build a fake partials API and wire it into the static loader.
+ */
+function useFakePartials(overrides: Record<string, unknown> = {}) {
+  const fakePartials = {
+    fetch: vi.fn().mockResolvedValue(FAKE_UPDATE),
+    apply: vi.fn(),
+    ...overrides,
+  };
+  ShopifyPartialsFetch.__loadPartialsModule = async () => ({ partials: fakePartials }) as any;
+  return fakePartials;
+}
+
+describe('The ShopifyPartialsFetch class', () => {
+  afterEach(() => {
+    ShopifyPartialsFetch.__loadPartialsModule = originalLoader;
+    vi.restoreAllMocks();
+  });
+
+  it('should use Shopify partials when the `partials` option is set', async () => {
+    const fakePartials = useFakePartials();
+    const anchor = h('a', {
+      href: 'https://example.com/collections/all',
+      dataOptionPartials: ['product-grid', 'product-count'],
+    });
+    const fetch = new ShopifyPartialsFetch(anchor);
+
+    await mount(fetch);
+    anchor.dispatchEvent(new MouseEvent('click', { button: 0 }));
+    // Wait for the async fetch lifecycle to settle.
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(fakePartials.fetch).toHaveBeenCalledOnce();
+    const args = fakePartials.fetch.mock.calls[0];
+    expect(args.slice(0, 2)).toEqual(['product-grid', 'product-count']);
+    const options = args[args.length - 1];
+    expect(options.url).toBe('https://example.com/collections/all');
+    expect(options.signal).toBeInstanceOf(AbortSignal);
+
+    expect(fakePartials.apply).toHaveBeenCalledWith(FAKE_UPDATE);
+  });
+
+  it('should fall back to base Fetch when no `partials` option is set', async () => {
+    const fakePartials = useFakePartials();
+    const windowFetchSpy = vi.spyOn(window, 'fetch');
+    windowFetchSpy.mockImplementation(() => Promise.resolve(new Response('<div id="test">ok</div>')));
+
+    const anchor = h('a', { href: 'https://example.com' });
+    const fetch = new ShopifyPartialsFetch(anchor);
+
+    await mount(fetch);
+    await fetch.fetch(new URL('https://example.com'));
+
+    expect(fakePartials.fetch).not.toHaveBeenCalled();
+    expect(windowFetchSpy).toHaveBeenCalledOnce();
+  });
+
+  it('should fall back to base Fetch when the module fails to resolve', async () => {
+    ShopifyPartialsFetch.__loadPartialsModule = async () => {
+      throw new Error('Cannot find module @shopify/partial-rendering');
+    };
+    const windowFetchSpy = vi.spyOn(window, 'fetch');
+    windowFetchSpy.mockImplementation(() =>
+      Promise.resolve(new Response('<div id="test">new content</div>')),
+    );
+
+    const container = h('div', { id: 'container' }, [h('div', { id: 'test' }, ['old content'])]);
+    document.body.appendChild(container);
+
+    const anchor = h('a', {
+      href: 'https://example.com',
+      dataOptionPartials: ['product-grid'],
+    });
+    const fetch = new ShopifyPartialsFetch(anchor);
+
+    await mount(fetch);
+    await fetch.fetch(new URL('https://example.com'));
+    // Wait for the fire-and-forget update phase to settle.
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(windowFetchSpy).toHaveBeenCalledOnce();
+    // The base id-based full-page swap must actually run on the fallback path.
+    expect(document.getElementById('test')?.textContent).toBe('new content');
+
+    container.remove();
+  });
+
+  it('should fall back to base Fetch when the module has no partials export', async () => {
+    ShopifyPartialsFetch.__loadPartialsModule = async () => ({}) as any;
+    const windowFetchSpy = vi.spyOn(window, 'fetch');
+    windowFetchSpy.mockImplementation(() => Promise.resolve(new Response('<div id="test">ok</div>')));
+
+    const anchor = h('a', {
+      href: 'https://example.com',
+      dataOptionPartials: ['product-grid'],
+    });
+    const fetch = new ShopifyPartialsFetch(anchor);
+
+    await mount(fetch);
+    await fetch.fetch(new URL('https://example.com'));
+
+    expect(windowFetchSpy).toHaveBeenCalledOnce();
+  });
+
+  it('should emit lifecycle events in order without emitting RESPONSE', async () => {
+    useFakePartials();
+    const anchor = h('a', {
+      href: 'https://example.com',
+      dataOptionPartials: ['product-grid'],
+    });
+    const fetch = new ShopifyPartialsFetch(anchor);
+    const eventLog: string[] = [];
+
+    for (const event of Object.values(ShopifyPartialsFetch.FETCH_EVENTS)) {
+      fetch.$on(event as string, () => eventLog.push(event as string));
+    }
+
+    await mount(fetch);
+    await fetch.fetch(new URL('https://example.com'));
+
+    expect(eventLog).toEqual([
+      ShopifyPartialsFetch.FETCH_EVENTS.BEFORE_FETCH,
+      ShopifyPartialsFetch.FETCH_EVENTS.FETCH,
+      ShopifyPartialsFetch.FETCH_EVENTS.AFTER_FETCH,
+      ShopifyPartialsFetch.FETCH_EVENTS.BEFORE_UPDATE,
+      ShopifyPartialsFetch.FETCH_EVENTS.UPDATE,
+      ShopifyPartialsFetch.FETCH_EVENTS.AFTER_UPDATE,
+    ]);
+    expect(eventLog).not.toContain(ShopifyPartialsFetch.FETCH_EVENTS.RESPONSE);
+  });
+});

--- a/packages/tests/index.spec.ts
+++ b/packages/tests/index.spec.ts
@@ -56,6 +56,7 @@ test('components exports', () => {
       "ScrollAnimationWithEase",
       "ScrollReveal",
       "Sentinel",
+      "ShopifyPartialsFetch",
       "Slider",
       "SliderBtn",
       "SliderCount",

--- a/packages/ui/Fetch/ShopifyPartialsFetch.ts
+++ b/packages/ui/Fetch/ShopifyPartialsFetch.ts
@@ -119,13 +119,35 @@ export class ShopifyPartialsFetch<T extends BaseProps = BaseProps> extends Fetch
   }
 
   /**
+   * Whether the current request can be expressed through the partials API.
+   *
+   * The `@shopify/partial-rendering` API only performs a GET for the given URL, so any
+   * request carrying a body, a non-GET method, custom headers or a custom `requestInit`
+   * falls back to the base {@link Fetch} behaviour to preserve its contract — for example a
+   * `method="post"` form, or a `data-option-headers` / `data-option-request-init` usage.
+   * @protected
+   */
+  get __canUsePartials(): boolean {
+    const { headers, requestInit } = this.$options;
+    const method = (this.requestInit.method ?? 'get').toLowerCase();
+
+    return (
+      method === 'get' &&
+      !this.requestInit.body &&
+      Object.keys(headers).length === 0 &&
+      Object.keys(requestInit).length === 0 &&
+      this.$refs.headers.length === 0
+    );
+  }
+
+  /**
    * Fetch given url via Shopify partial rendering when configured, otherwise fall back to
    * the base fetch behaviour.
    * @inheritdoc
    */
   async fetch(url: URL, requestInit: RequestInit = {}) {
     const names = this.$options.partials;
-    const partials = names.length ? await this.__resolvePartials() : null;
+    const partials = names.length && this.__canUsePartials ? await this.__resolvePartials() : null;
 
     if (!partials) {
       return super.fetch(url, requestInit);

--- a/packages/ui/Fetch/ShopifyPartialsFetch.ts
+++ b/packages/ui/Fetch/ShopifyPartialsFetch.ts
@@ -1,0 +1,206 @@
+import { type BaseConfig, type BaseProps } from '@studiometa/js-toolkit';
+import { historyPush } from '@studiometa/js-toolkit/utils';
+import { Fetch, type FetchProps } from './Fetch.js';
+
+export interface ShopifyPartialsFetchProps extends FetchProps {
+  $options: FetchProps['$options'] & {
+    partials: string[];
+  };
+}
+
+export type ShopifyPartialsFetchConstructor<
+  T extends ShopifyPartialsFetch = ShopifyPartialsFetch,
+> = {
+  new (...args: any[]): T;
+  prototype: ShopifyPartialsFetch;
+} & Pick<typeof ShopifyPartialsFetch, keyof typeof ShopifyPartialsFetch>;
+
+/**
+ * Minimal shape of the `partials` API exposed by `@shopify/partial-rendering`.
+ * @internal
+ */
+interface PartialsApi {
+  fetch(...args: [...names: string[], options: { url: string; signal?: AbortSignal }]): Promise<unknown>;
+  apply(update: unknown): void | Promise<void>;
+}
+
+/**
+ * Minimal shape of the `@shopify/partial-rendering` module.
+ * @internal
+ */
+interface PartialsModule {
+  partials: PartialsApi;
+}
+
+/**
+ * ShopifyPartialsFetch class.
+ *
+ * Adapts the base {@link Fetch} component to Shopify's `@shopify/partial-rendering` API
+ * (Liquid July '26 preview). Shopify partial rendering is engaged only when partial names
+ * are configured via the `partials` option AND the preview package resolves; otherwise it
+ * transparently falls back to the base {@link Fetch} behaviour (id-based full-page swap).
+ *
+ * Compared to the base {@link Fetch} lifecycle, the partials path diverges in two ways:
+ * - the `RESPONSE` event is never emitted, as there is no `Response` object on this path;
+ * - the `UPDATE` event payload carries the opaque partials `update` object instead of a
+ *   parsed `Document` fragment, and `partials.apply` owns DOM swapping, View Transitions
+ *   and focus/selection/form/scroll preservation.
+ *
+ * @link https://ui.studiometa.dev/components/Fetch/
+ */
+export class ShopifyPartialsFetch<T extends BaseProps = BaseProps> extends Fetch<
+  T & { $options: { partials: string[] } }
+> {
+  /**
+   * Declare the `this.constructor` type
+   * @link https://github.com/microsoft/TypeScript/issues/3841#issuecomment-2381594311
+   */
+  declare ['constructor']: ShopifyPartialsFetchConstructor;
+
+  /**
+   * Config.
+   */
+  static config: BaseConfig = {
+    ...Fetch.config,
+    name: 'ShopifyPartialsFetch',
+    options: {
+      ...Fetch.config.options,
+      partials: Array,
+    },
+  };
+
+  /**
+   * Module specifier for the Shopify partial rendering package.
+   *
+   * Exposed as a static field so tests can override {@link __loadPartialsModule} without
+   * relying on the preview package being installed.
+   */
+  static __PARTIALS_MODULE = '@shopify/partial-rendering';
+
+  /**
+   * Load the Shopify partial rendering module.
+   *
+   * The package is imported lazily via a dynamic import so the module compiles and runs
+   * without the preview package being installed. Override this in tests to inject a fake.
+   * @protected
+   */
+  static async __loadPartialsModule(): Promise<PartialsModule> {
+    return import(this.__PARTIALS_MODULE);
+  }
+
+  /**
+   * Cached partials API resolution.
+   *
+   * `undefined` means resolution has not been attempted yet, `null` means it failed.
+   * @internal
+   */
+  __partialsModule: PartialsApi | null | undefined;
+
+  /**
+   * Resolve the partials API, memoising the result.
+   *
+   * Returns `null` on any failure (missing package, missing export, ...) so callers can
+   * transparently fall back to the base behaviour. This never rejects.
+   * @protected
+   */
+  async __resolvePartials(): Promise<PartialsApi | null> {
+    if (typeof this.__partialsModule !== 'undefined') {
+      return this.__partialsModule;
+    }
+
+    try {
+      const module = await this.constructor.__loadPartialsModule();
+      this.__partialsModule = module?.partials ?? null;
+    } catch {
+      this.__partialsModule = null;
+    }
+
+    return this.__partialsModule;
+  }
+
+  /**
+   * Fetch given url via Shopify partial rendering when configured, otherwise fall back to
+   * the base fetch behaviour.
+   * @inheritdoc
+   */
+  async fetch(url: URL, requestInit: RequestInit = {}) {
+    const names = this.$options.partials;
+    const partials = names.length ? await this.__resolvePartials() : null;
+
+    if (!partials) {
+      return super.fetch(url, requestInit);
+    }
+
+    const { FETCH_EVENTS } = this.constructor;
+    this.$emit(FETCH_EVENTS.BEFORE_FETCH, { instance: this, url, requestInit });
+
+    this.__abortController.abort();
+    const newController = new AbortController();
+    newController.signal.addEventListener('abort', () => {
+      this.$emit(FETCH_EVENTS.ABORT, {
+        instance: this,
+        url,
+        requestInit,
+        reason: newController.signal.reason,
+      });
+    });
+    this.__abortController = newController;
+    const init = {
+      ...this.requestInit,
+      ...requestInit,
+      headers: {
+        ...this.requestInit.headers,
+        ...requestInit.headers,
+      },
+      signal: newController.signal,
+    };
+
+    this.$log('fetch', url, init);
+    this.$emit(FETCH_EVENTS.FETCH, { instance: this, url, requestInit: init });
+
+    try {
+      const update = await partials.fetch(...names, {
+        url: url.toString(),
+        signal: init.signal,
+      });
+      this.$emit(FETCH_EVENTS.AFTER_FETCH, { instance: this, url, requestInit: init, content: update });
+      // Fire-and-forget the apply phase, matching the base `Fetch.fetch` lifecycle: an
+      // `apply()` failure must not be misattributed to the fetch phase and re-emit
+      // `AFTER_FETCH` a second time.
+      this.__applyPartials(url, init, update, partials);
+    } catch (error) {
+      this.$emit(FETCH_EVENTS.AFTER_FETCH, { instance: this, url, requestInit: init, error });
+      this.error(url, init, error);
+    }
+  }
+
+  /**
+   * Apply the partials update to the DOM.
+   *
+   * This is intentionally kept separate from the base {@link Fetch.update}: the base method
+   * is still used verbatim on the fallback path, where it parses an HTML string into a
+   * `Document` fragment and performs the id-based full-page swap. On the partials path,
+   * `partials.apply` owns DOM swapping, View Transitions and focus/selection/form/scroll
+   * preservation, so no fragment parsing nor `__updateDOM`/`startViewTransition` happens here.
+   * @protected
+   */
+  async __applyPartials(url: URL, requestInit: RequestInit, update: unknown, partials: PartialsApi) {
+    const { FETCH_EVENTS } = this.constructor;
+    const { history } = this.$options;
+
+    this.$log('content', url, update);
+    this.$emit(FETCH_EVENTS.BEFORE_UPDATE, { instance: this, url, requestInit, content: update });
+
+    if (history) {
+      if (requestInit?.headers?.[this.__headerNames.X_TRIGGERED_BY] !== 'popstate') {
+        historyPush({ path: url.pathname, search: url.searchParams });
+      }
+    }
+
+    this.$emit(FETCH_EVENTS.UPDATE, { instance: this, url, requestInit, update });
+
+    await partials.apply(update);
+
+    this.$emit(FETCH_EVENTS.AFTER_UPDATE, { instance: this, url, requestInit, update });
+  }
+}

--- a/packages/ui/Fetch/ShopifyPartialsFetch.ts
+++ b/packages/ui/Fetch/ShopifyPartialsFetch.ts
@@ -119,25 +119,47 @@ export class ShopifyPartialsFetch<T extends BaseProps = BaseProps> extends Fetch
   }
 
   /**
-   * Whether the current request can be expressed through the partials API.
+   * Whether the given request can be expressed through the partials API.
    *
-   * The `@shopify/partial-rendering` API only performs a GET for the given URL, so any
-   * request carrying a body, a non-GET method, custom headers or a custom `requestInit`
-   * falls back to the base {@link Fetch} behaviour to preserve its contract — for example a
-   * `method="post"` form, or a `data-option-headers` / `data-option-request-init` usage.
+   * The `@shopify/partial-rendering` API only performs a GET for the given URL (it receives
+   * nothing but `{ url, signal }`), so a request that carries a body, a non-GET method,
+   * custom headers or any other `RequestInit` field falls back to the base {@link Fetch}
+   * behaviour to preserve its contract — whether these come from the element options
+   * (a `method="post"` form, `data-option-headers`, `data-option-request-init`) or from the
+   * per-call `requestInit` argument (for example `fetch(url, { credentials: 'include' })`).
+   * Framework-internal headers (see {@link Fetch.__headerNames}) are ignored, so the
+   * declarative click, submit and popstate flows still use partial rendering.
    * @protected
    */
-  get __canUsePartials(): boolean {
-    const { headers, requestInit } = this.$options;
-    const method = (this.requestInit.method ?? 'get').toLowerCase();
+  __canUsePartials(requestInit: RequestInit): boolean {
+    const merged = {
+      ...this.requestInit,
+      ...requestInit,
+      headers: {
+        ...this.requestInit.headers,
+        ...requestInit.headers,
+      },
+    };
 
-    return (
-      method === 'get' &&
-      !this.requestInit.body &&
-      Object.keys(headers).length === 0 &&
-      Object.keys(requestInit).length === 0 &&
-      this.$refs.headers.length === 0
-    );
+    if ((merged.method ?? 'get').toLowerCase() !== 'get' || merged.body) {
+      return false;
+    }
+
+    const supportedKeys = new Set(['method', 'headers', 'body', 'signal']);
+    for (const key of Object.keys({ ...this.$options.requestInit, ...requestInit })) {
+      if (!supportedKeys.has(key)) {
+        return false;
+      }
+    }
+
+    const internalHeaders = new Set<string>(Object.values(this.__headerNames));
+    for (const header of Object.keys(merged.headers)) {
+      if (!internalHeaders.has(header.toLowerCase())) {
+        return false;
+      }
+    }
+
+    return true;
   }
 
   /**
@@ -147,7 +169,8 @@ export class ShopifyPartialsFetch<T extends BaseProps = BaseProps> extends Fetch
    */
   async fetch(url: URL, requestInit: RequestInit = {}) {
     const names = this.$options.partials;
-    const partials = names.length && this.__canUsePartials ? await this.__resolvePartials() : null;
+    const partials =
+      names.length && this.__canUsePartials(requestInit) ? await this.__resolvePartials() : null;
 
     if (!partials) {
       return super.fetch(url, requestInit);

--- a/packages/ui/Fetch/index.ts
+++ b/packages/ui/Fetch/index.ts
@@ -1,1 +1,2 @@
 export * from './Fetch.js';
+export * from './ShopifyPartialsFetch.js';

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -37,6 +37,12 @@
     "@studiometa/js-toolkit": "^3.7.0"
   },
   "peerDependencies": {
+    "@shopify/partial-rendering": "*",
     "@studiometa/js-toolkit": "^3.7.0"
+  },
+  "peerDependenciesMeta": {
+    "@shopify/partial-rendering": {
+      "optional": true
+    }
   }
 }


### PR DESCRIPTION
## Summary

Adds `ShopifyPartialsFetch`, a subclass of the `Fetch` component that adapts it to Shopify's [`@shopify/partial-rendering`](https://shopify.dev/docs/storefronts/themes/getting-started/developer-preview/partial) API (Liquid July '26 preview).

Shopify's new `{% partial 'name' %}` primitive marks server-rendered regions that JavaScript can refresh: `partials.fetch(...names, { url })` requests fresh HTML for named regions and `partials.apply(update)` swaps them in while preserving focus, selection, form values and scroll (with View Transitions). This differs from our `Fetch`, which identifies swap targets by element `id`. The adapter bridges the two without touching the base component.

## Behaviour

- Engages Shopify partial rendering **only** when partial names are configured via the `partials` option **and** the (optional, preview) package resolves.
- Otherwise **transparently falls back** to the base `Fetch` behaviour (id-based full-page swap) — so it degrades gracefully when the preview flag/package is absent.

```html
<a href="/collections/all?sort_by=price-ascending"
   data-component="ShopifyPartialsFetch"
   data-option-partials='["product-grid", "product-count"]'>
  Sort by price
</a>
```

## Implementation notes

- `partials` option (`string[]`) added on top of all inherited `Fetch` options; `config` is merged from `Fetch.config` so inherited options stay in sync.
- The package is loaded via a lazy dynamic `import()` behind a static `__loadPartialsModule` seam — no static import, so the library compiles and runs without the preview package installed. Added as an **optional** peer dependency (`peerDependenciesMeta`).
- `__resolvePartials()` memoises resolution and never rejects (returns `null` on failure).
- The partials path reuses the base fetch/abort/history/event machinery. Two documented lifecycle divergences: `RESPONSE` is not emitted (no `Response` object), and `UPDATE` carries the opaque partials `update` object. DOM swapping is delegated to `partials.apply` via a dedicated `__applyPartials` method, leaving the base `update()`/`__updateDOM` untouched for the fallback path.

## Testing

- `npm run test -- -- Fetch` → **66 passed** (5 new `ShopifyPartialsFetch` tests: partials path, no-option fallback, module-reject fallback with asserted DOM swap, missing-export fallback, event ordering with `RESPONSE` never emitted).
- `npm run lint` → **0 errors**.

This PR was built with a multi-agent workflow (implement → adversarial self-review → fix). The self-review caught and fixed a real defect where an earlier `update()` override silently broke the fallback DOM swap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)