### PR TITLE
Add InView and InViewOnce viewport primitives

### DIFF
--- a/packages/docs/components/InView/index.md
+++ b/packages/docs/components/InView/index.md
@@ -1,0 +1,41 @@
+---
+badges: [JS]
+---
+
+# InView <Badges :texts="$frontmatter.badges" />
+
+The `InView` primitive emits directional viewport events, letting you react differently when an element **enters** or **leaves** the viewport.
+
+## Usage
+
+The `InView` primitive should be used as a child component to listen to its `in-view` and `out-of-view` events. Unlike the [`Sentinel` primitive](/components/Sentinel/) — whose single `intersected` event fires on both enter and leave — `InView` is its directional counterpart: it tells you which way the element crossed the viewport boundary.
+
+It is built on the [`withMountWhenInView` decorator](https://js-toolkit.studiometa.dev/api/decorators/withMountWhenInView.html): the component mounts when it enters the viewport (emitting `in-view`) and is destroyed when it leaves (emitting `out-of-view`), re-mounting on each re-entry.
+
+```js {2,8,12-18}
+import { Base } from '@studiometa/js-toolkit';
+import { InView } from '@studiometa/ui';
+
+export default class Component extends Base {
+  static config = {
+    name: 'Component',
+    components: {
+      InView,
+    },
+  };
+
+  onInViewInView() {
+    // the element entered the viewport
+  }
+
+  onInViewOutOfView() {
+    // the element left the viewport
+  }
+}
+```
+
+```html
+<div data-component="Component">
+  <div data-component="InView">...</div>
+</div>
+```

--- a/packages/docs/components/InView/index.md
+++ b/packages/docs/components/InView/index.md
@@ -10,7 +10,9 @@ The `InView` primitive emits directional viewport events, letting you react diff
 
 The `InView` primitive should be used as a child component to listen to its `in-view` and `out-of-view` events. Unlike the [`Sentinel` primitive](/components/Sentinel/) — whose single `intersected` event fires on both enter and leave — `InView` is its directional counterpart: it tells you which way the element crossed the viewport boundary.
 
-It is built on the [`withMountWhenInView` decorator](https://js-toolkit.studiometa.dev/api/decorators/withMountWhenInView.html): the component mounts when it enters the viewport (emitting `in-view`) and is destroyed when it leaves (emitting `out-of-view`). By default the primitive is one-shot — it emits `in-view` once and stops. Set the [`repeat` option](/components/InView/js-api.html#repeat) to keep reacting to every viewport crossing.
+It is built on the [`withMountWhenInView` decorator](https://js-toolkit.studiometa.dev/api/decorators/withMountWhenInView.html): the component mounts when it enters the viewport (emitting `in-view`) and is destroyed when it leaves (emitting `out-of-view`), re-firing on each re-entry.
+
+If you only need to react to the first entry, use the [`InViewOnce` variant](/components/InViewOnce/), which emits `in-view` a single time and never emits `out-of-view`.
 
 ```js {2,8,12-18}
 import { Base } from '@studiometa/js-toolkit';

--- a/packages/docs/components/InView/index.md
+++ b/packages/docs/components/InView/index.md
@@ -10,7 +10,7 @@ The `InView` primitive emits directional viewport events, letting you react diff
 
 The `InView` primitive should be used as a child component to listen to its `in-view` and `out-of-view` events. Unlike the [`Sentinel` primitive](/components/Sentinel/) — whose single `intersected` event fires on both enter and leave — `InView` is its directional counterpart: it tells you which way the element crossed the viewport boundary.
 
-It is built on the [`withMountWhenInView` decorator](https://js-toolkit.studiometa.dev/api/decorators/withMountWhenInView.html): the component mounts when it enters the viewport (emitting `in-view`) and is destroyed when it leaves (emitting `out-of-view`), re-mounting on each re-entry.
+It is built on the [`withMountWhenInView` decorator](https://js-toolkit.studiometa.dev/api/decorators/withMountWhenInView.html): the component mounts when it enters the viewport (emitting `in-view`) and is destroyed when it leaves (emitting `out-of-view`). By default the primitive is one-shot — it emits `in-view` once and stops. Set the [`repeat` option](/components/InView/js-api.html#repeat) to keep reacting to every viewport crossing.
 
 ```js {2,8,12-18}
 import { Base } from '@studiometa/js-toolkit';

--- a/packages/docs/components/InView/js-api.md
+++ b/packages/docs/components/InView/js-api.md
@@ -20,7 +20,7 @@ onInViewInView() {
 
 ### `out-of-view`
 
-Emitted when the element leaves the viewport (i.e. when the component is destroyed by the `withMountWhenInView` decorator). By default the element re-emits `in-view` on each re-entry.
+Emitted when the element leaves the viewport (i.e. when the component is destroyed by the `withMountWhenInView` decorator). Only emitted when the [`repeat` option](#repeat) is enabled — in the default one-shot mode the primitive terminates after the first `in-view` and never emits `out-of-view`.
 
 ```js
 onInViewOutOfView() {
@@ -29,6 +29,19 @@ onInViewOutOfView() {
 ```
 
 ## Options
+
+### `repeat`
+
+- Type: `boolean`
+- Default: `false`
+
+Configures whether the primitive should keep reacting to viewport crossings or only fire once.
+
+By default (`repeat: false`), the primitive is **one-shot**: it emits `in-view` a single time when the element first enters the viewport, then terminates — so it never emits `out-of-view` and never re-fires. Enable `repeat` to re-emit `in-view` on each entry and `out-of-view` on each leave.
+
+```html
+<div data-component="InView" data-option-repeat>...</div>
+```
 
 ### `intersectionObserver`
 

--- a/packages/docs/components/InView/js-api.md
+++ b/packages/docs/components/InView/js-api.md
@@ -1,0 +1,48 @@
+---
+title: InView JS API
+---
+
+# JS API
+
+The `InView` class extends the [`Base` class](https://js-toolkit.studiometa.dev/api/) with the [`withMountWhenInView` decorator](https://js-toolkit.studiometa.dev/api/decorators/withMountWhenInView.html). As it inherits their APIs, make sure to have a look at their own API references too.
+
+## Events
+
+### `in-view`
+
+Emitted when the element enters the viewport (i.e. when the component is mounted by the `withMountWhenInView` decorator).
+
+```js
+onInViewInView() {
+  // the element entered the viewport
+}
+```
+
+### `out-of-view`
+
+Emitted when the element leaves the viewport (i.e. when the component is destroyed by the `withMountWhenInView` decorator). By default the element re-emits `in-view` on each re-entry.
+
+```js
+onInViewOutOfView() {
+  // the element left the viewport
+}
+```
+
+## Options
+
+### `intersectionObserver`
+
+- Type: `object`
+- Default: `{ threshold: [0, 1] }`
+
+Options forwarded to the underlying [`IntersectionObserver`](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver/IntersectionObserver#options) instance created by the [`withMountWhenInView` decorator](https://js-toolkit.studiometa.dev/api/decorators/withMountWhenInView.html). Use it to adjust the `rootMargin`, `threshold` or `root` used to detect the viewport crossing.
+
+```html
+<div data-component="InView" data-option-intersection-observer='{ "rootMargin": "100px" }'>
+  ...
+</div>
+```
+
+## See also
+
+- The [`Sentinel` primitive](/components/Sentinel/) emits a single, non-directional `intersected` event on both enter and leave. `InView` is its directional counterpart.

--- a/packages/docs/components/InView/js-api.md
+++ b/packages/docs/components/InView/js-api.md
@@ -20,7 +20,9 @@ onInViewInView() {
 
 ### `out-of-view`
 
-Emitted when the element leaves the viewport (i.e. when the component is destroyed by the `withMountWhenInView` decorator). Only emitted when the [`repeat` option](#repeat) is enabled — in the default one-shot mode the primitive terminates after the first `in-view` and never emits `out-of-view`.
+Emitted when the element leaves the viewport (i.e. when the component is destroyed by the `withMountWhenInView` decorator). The primitive keeps reacting to every crossing, so `in-view` and `out-of-view` re-fire on each re-entry and leave.
+
+If you only care about the first entry, use the [`InViewOnce` variant](/components/InViewOnce/) instead, which emits `in-view` a single time and never emits `out-of-view`.
 
 ```js
 onInViewOutOfView() {
@@ -29,19 +31,6 @@ onInViewOutOfView() {
 ```
 
 ## Options
-
-### `repeat`
-
-- Type: `boolean`
-- Default: `false`
-
-Configures whether the primitive should keep reacting to viewport crossings or only fire once.
-
-By default (`repeat: false`), the primitive is **one-shot**: it emits `in-view` a single time when the element first enters the viewport, then terminates — so it never emits `out-of-view` and never re-fires. Enable `repeat` to re-emit `in-view` on each entry and `out-of-view` on each leave.
-
-```html
-<div data-component="InView" data-option-repeat>...</div>
-```
 
 ### `intersectionObserver`
 

--- a/packages/docs/components/InViewOnce/index.md
+++ b/packages/docs/components/InViewOnce/index.md
@@ -1,0 +1,37 @@
+---
+badges: [JS]
+---
+
+# InViewOnce <Badges :texts="$frontmatter.badges" />
+
+The `InViewOnce` primitive is a one-shot variant of the [`InView` primitive](/components/InView/): it emits `in-view` a single time when the element first enters the viewport, then stops. It never emits `out-of-view`.
+
+## Usage
+
+Use `InViewOnce` when you only care about the first time an element becomes visible — for example to trigger a one-off reveal, lazy-load or analytics impression. It is built on the [`withMountWhenInView` decorator](https://js-toolkit.studiometa.dev/api/decorators/withMountWhenInView.html): the component mounts on entry (emitting `in-view`) and then terminates, disconnecting its observer so the event never fires again.
+
+For a directional listener that keeps reacting to every viewport crossing (both enter and leave), use the [`InView` primitive](/components/InView/) instead.
+
+```js {2,8,12-14}
+import { Base } from '@studiometa/js-toolkit';
+import { InViewOnce } from '@studiometa/ui';
+
+export default class Component extends Base {
+  static config = {
+    name: 'Component',
+    components: {
+      InViewOnce,
+    },
+  };
+
+  onInViewOnceInView() {
+    // the element entered the viewport for the first time
+  }
+}
+```
+
+```html
+<div data-component="Component">
+  <div data-component="InViewOnce">...</div>
+</div>
+```

--- a/packages/docs/components/InViewOnce/js-api.md
+++ b/packages/docs/components/InViewOnce/js-api.md
@@ -1,0 +1,39 @@
+---
+title: InViewOnce JS API
+---
+
+# JS API
+
+The `InViewOnce` class extends the [`InView` primitive](/components/InView/js-api.html). As it inherits its API, make sure to have a look at its own API reference too. Unlike `InView`, it emits `in-view` only once and never emits `out-of-view`.
+
+## Events
+
+### `in-view`
+
+Emitted once, when the element first enters the viewport. The component then terminates and disconnects its observer, so the event never fires again.
+
+```js
+onInViewOnceInView() {
+  // the element entered the viewport for the first time
+}
+```
+
+## Options
+
+### `intersectionObserver`
+
+- Type: `object`
+- Default: `{ threshold: [0, 1] }`
+
+Options forwarded to the underlying [`IntersectionObserver`](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver/IntersectionObserver#options) instance created by the [`withMountWhenInView` decorator](https://js-toolkit.studiometa.dev/api/decorators/withMountWhenInView.html). Use it to adjust the `rootMargin`, `threshold` or `root` used to detect the viewport crossing.
+
+```html
+<div data-component="InViewOnce" data-option-intersection-observer='{ "rootMargin": "100px" }'>
+  ...
+</div>
+```
+
+## See also
+
+- The [`InView` primitive](/components/InView/) is the repeating counterpart: it emits `in-view` and `out-of-view` on every viewport crossing.
+- The [`Sentinel` primitive](/components/Sentinel/) emits a single, non-directional `intersected` event on both enter and leave.

--- a/packages/docs/components/Sentinel/index.md
+++ b/packages/docs/components/Sentinel/index.md
@@ -10,6 +10,8 @@ The `Sentinel` primitive — whose name is inspired by a [Google Developer artic
 
 The `Sentinel` should be used as a child component to be able to listen to its `intersected` event when the element enters or leaves the viewport. The main usage is for the detection of an element stickiness (see the [Sticky component](/components/Sticky/)).
 
+If you need to react differently depending on whether the element is entering or leaving the viewport, use the directional [`InView` primitive](/components/InView/) instead, which emits distinct `in-view` and `out-of-view` events.
+
 ```js {2,8,12-14}
 import { Base } from '@studiometa/js-toolkit';
 import { Sentinel } from '@studiometa/ui';

--- a/packages/tests/InView/index.spec.ts
+++ b/packages/tests/InView/index.spec.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeAll, afterEach, vi } from 'vitest';
+import { InView } from '@studiometa/ui';
+import {
+  h,
+  mount,
+  mockIsIntersecting,
+  intersectionObserverBeforeAllCallback,
+  intersectionObserverAfterEachCallback,
+} from '#test-utils';
+
+/**
+ * Instantiate and mount a single `InView` component from an HTML string.
+ */
+async function mountInView(html: string) {
+  const root = h('div');
+  root.innerHTML = html;
+  const el = root.querySelector('[data-component="InView"]') as HTMLElement;
+  const instance = new InView(el);
+  await mount(instance);
+
+  return { root, el, instance };
+}
+
+describe('InView component', () => {
+  beforeAll(() => {
+    intersectionObserverBeforeAllCallback();
+  });
+
+  afterEach(() => {
+    intersectionObserverAfterEachCallback();
+  });
+
+  it('should have the correct config', () => {
+    expect(InView.config.name).toBe('InView');
+    expect(InView.config.emits).toEqual(['in-view', 'out-of-view']);
+  });
+
+  it('should emit `in-view` when the element enters the viewport', async () => {
+    const { el, instance } = await mountInView(`<div data-component="InView"></div>`);
+    const fn = vi.fn();
+    instance.$on('in-view', fn);
+
+    await mockIsIntersecting(el, true);
+
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('should emit `out-of-view` when the element leaves the viewport', async () => {
+    const { el, instance } = await mountInView(`<div data-component="InView"></div>`);
+    const fn = vi.fn();
+    instance.$on('out-of-view', fn);
+
+    await mockIsIntersecting(el, true);
+    await mockIsIntersecting(el, false);
+
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('should re-emit `in-view` on each re-entry (repeat by default)', async () => {
+    const { el, instance } = await mountInView(`<div data-component="InView"></div>`);
+    const inView = vi.fn();
+    const outOfView = vi.fn();
+    instance.$on('in-view', inView);
+    instance.$on('out-of-view', outOfView);
+
+    await mockIsIntersecting(el, true);
+    await mockIsIntersecting(el, false);
+    await mockIsIntersecting(el, true);
+
+    expect(inView).toHaveBeenCalledTimes(2);
+    expect(outOfView).toHaveBeenCalledTimes(1);
+  });
+
+  it('should expose the configurable `intersectionObserver` option', async () => {
+    const { el } = await mountInView(
+      `<div data-component="InView" data-option-intersection-observer='{"rootMargin": "100px"}'></div>`,
+    );
+
+    const observer = globalThis.IntersectionObserver as unknown as { mock: { results: any[] } };
+    const created = observer.mock.results.at(-1)?.value as IntersectionObserver;
+
+    // The option is forwarded to the IntersectionObserver instance.
+    expect(created.rootMargin).toBe('100px');
+    expect(el).toBeInstanceOf(HTMLElement);
+  });
+});

--- a/packages/tests/InView/index.spec.ts
+++ b/packages/tests/InView/index.spec.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeAll, afterEach, vi } from 'vitest';
-import { InView } from '@studiometa/ui';
+import { InView, InViewOnce } from '@studiometa/ui';
+import type { Base } from '@studiometa/js-toolkit';
 import {
   h,
   mount,
@@ -10,16 +11,33 @@ import {
 } from '#test-utils';
 
 /**
- * Instantiate and mount a single `InView` component from an HTML string.
+ * Instantiate and mount a single component (`InView` or `InViewOnce`) from an
+ * HTML string.
  */
-async function mountInView(html: string) {
+async function mountComponent<T extends Base>(
+  Ctor: new (el: HTMLElement) => T,
+  html: string,
+): Promise<{ root: HTMLElement; el: HTMLElement; instance: T }> {
   const root = h('div');
   root.innerHTML = html;
-  const el = root.querySelector('[data-component="InView"]') as HTMLElement;
-  const instance = new InView(el);
+  const el = root.querySelector('[data-component]') as HTMLElement;
+  const instance = new Ctor(el);
   await mount(instance);
 
   return { root, el, instance };
+}
+
+/**
+ * Simulate the element leaving the viewport, tolerating the case where its
+ * observer has already been disconnected (e.g. after a one-shot terminate).
+ */
+async function tryLeave(el: HTMLElement) {
+  try {
+    await mockIsIntersecting(el, false);
+  } catch {
+    // The observer was disconnected: the leave can never be delivered, which
+    // is exactly the guarantee we are asserting.
+  }
 }
 
 describe('InView component', () => {
@@ -34,11 +52,10 @@ describe('InView component', () => {
   it('should have the correct config', () => {
     expect(InView.config.name).toBe('InView');
     expect(InView.config.emits).toEqual(['in-view', 'out-of-view']);
-    expect(InView.config.options).toHaveProperty('repeat', Boolean);
   });
 
   it('should emit `in-view` when the element enters the viewport', async () => {
-    const { el, instance } = await mountInView(`<div data-component="InView"></div>`);
+    const { el, instance } = await mountComponent(InView, `<div data-component="InView"></div>`);
     const fn = vi.fn();
     instance.$on('in-view', fn);
 
@@ -47,73 +64,111 @@ describe('InView component', () => {
     expect(fn).toHaveBeenCalledTimes(1);
   });
 
-  describe('default one-shot behavior', () => {
-    it('should emit `in-view` once and then terminate (disconnect the observer)', async () => {
-      const { el, instance } = await mountInView(`<div data-component="InView"></div>`);
-      const observer = intersectionMockInstance(el);
-      const terminateSpy = vi.spyOn(instance, '$terminate');
-      const fn = vi.fn();
-      instance.$on('in-view', fn);
+  it('should emit `out-of-view` when the element leaves the viewport', async () => {
+    const { el, instance } = await mountComponent(InView, `<div data-component="InView"></div>`);
+    const fn = vi.fn();
+    instance.$on('out-of-view', fn);
 
-      await mockIsIntersecting(el, true);
+    await mockIsIntersecting(el, true);
+    await mockIsIntersecting(el, false);
 
-      expect(fn).toHaveBeenCalledTimes(1);
-      expect(terminateSpy).toHaveBeenCalledTimes(1);
-      // The decorator disconnects the observer on `terminated`.
-      expect(observer.disconnect).toHaveBeenCalled();
-    });
-
-    it('should NOT emit `out-of-view` when terminating after a one-shot `in-view`', async () => {
-      const { el, instance } = await mountInView(`<div data-component="InView"></div>`);
-      const outOfView = vi.fn();
-      instance.$on('out-of-view', outOfView);
-
-      await mockIsIntersecting(el, true);
-
-      expect(outOfView).not.toHaveBeenCalled();
-    });
+    expect(fn).toHaveBeenCalledTimes(1);
   });
 
-  describe('with `repeat` option', () => {
-    it('should emit `out-of-view` when the element leaves the viewport', async () => {
-      const { el, instance } = await mountInView(
-        `<div data-component="InView" data-option-repeat></div>`,
-      );
-      const fn = vi.fn();
-      instance.$on('out-of-view', fn);
+  it('should re-emit `in-view` on each re-entry (repeating)', async () => {
+    const { el, instance } = await mountComponent(InView, `<div data-component="InView"></div>`);
+    const inView = vi.fn();
+    const outOfView = vi.fn();
+    instance.$on('in-view', inView);
+    instance.$on('out-of-view', outOfView);
 
-      await mockIsIntersecting(el, true);
-      await mockIsIntersecting(el, false);
+    await mockIsIntersecting(el, true);
+    await mockIsIntersecting(el, false);
+    await mockIsIntersecting(el, true);
 
-      expect(fn).toHaveBeenCalledTimes(1);
-    });
-
-    it('should re-emit `in-view` on each re-entry', async () => {
-      const { el, instance } = await mountInView(
-        `<div data-component="InView" data-option-repeat></div>`,
-      );
-      const inView = vi.fn();
-      const outOfView = vi.fn();
-      instance.$on('in-view', inView);
-      instance.$on('out-of-view', outOfView);
-
-      await mockIsIntersecting(el, true);
-      await mockIsIntersecting(el, false);
-      await mockIsIntersecting(el, true);
-
-      expect(inView).toHaveBeenCalledTimes(2);
-      expect(outOfView).toHaveBeenCalledTimes(1);
-    });
+    expect(inView).toHaveBeenCalledTimes(2);
+    expect(outOfView).toHaveBeenCalledTimes(1);
   });
 
   it('should expose the configurable `intersectionObserver` option', async () => {
-    const { el } = await mountInView(
-      `<div data-component="InView" data-option-repeat data-option-intersection-observer='{"rootMargin": "100px"}'></div>`,
+    const { el } = await mountComponent(
+      InView,
+      `<div data-component="InView" data-option-intersection-observer='{"rootMargin": "100px"}'></div>`,
     );
 
     const observer = intersectionMockInstance(el);
 
     // The option is forwarded to the IntersectionObserver instance.
     expect(observer.rootMargin).toBe('100px');
+  });
+});
+
+describe('InViewOnce component', () => {
+  beforeAll(() => {
+    intersectionObserverBeforeAllCallback();
+  });
+
+  afterEach(() => {
+    intersectionObserverAfterEachCallback();
+  });
+
+  it('should have the correct config, emitting only `in-view`', () => {
+    expect(InViewOnce.config.name).toBe('InViewOnce');
+    expect(InViewOnce.config.emits).toEqual(['in-view']);
+  });
+
+  it('should emit `in-view` exactly once and terminate (disconnect the observer)', async () => {
+    const { el, instance } = await mountComponent(
+      InViewOnce,
+      `<div data-component="InViewOnce"></div>`,
+    );
+    const observer = intersectionMockInstance(el);
+    const terminateSpy = vi.spyOn(instance, '$terminate');
+    const fn = vi.fn();
+    instance.$on('in-view', fn);
+
+    await mockIsIntersecting(el, true);
+
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(terminateSpy).toHaveBeenCalledTimes(1);
+    // The decorator disconnects the observer on `terminated`.
+    expect(observer.disconnect).toHaveBeenCalled();
+  });
+
+  it('should NOT emit `out-of-view`, even after leaving the viewport', async () => {
+    const { el, instance } = await mountComponent(
+      InViewOnce,
+      `<div data-component="InViewOnce"></div>`,
+    );
+    const outOfView = vi.fn();
+    instance.$on('out-of-view', outOfView);
+
+    await mockIsIntersecting(el, true);
+    // A leave after termination must not resurface an `out-of-view` event.
+    // The observer is disconnected on terminate, so the leave can never even
+    // be delivered — swallow the resulting "not observed" error.
+    await tryLeave(el);
+
+    expect(outOfView).not.toHaveBeenCalled();
+    // The observer was disconnected, so no further crossing can be delivered.
+    expect(() => intersectionMockInstance(el)).toThrow(
+      'Failed to find IntersectionObserver for element',
+    );
+  });
+
+  it('should not re-emit `in-view` on a later intersection', async () => {
+    const { el, instance } = await mountComponent(
+      InViewOnce,
+      `<div data-component="InViewOnce"></div>`,
+    );
+    const inView = vi.fn();
+    instance.$on('in-view', inView);
+
+    await mockIsIntersecting(el, true);
+    await tryLeave(el);
+    // Any further intersection cannot be delivered to a disconnected observer.
+    await tryLeave(el);
+
+    expect(inView).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/tests/InView/index.spec.ts
+++ b/packages/tests/InView/index.spec.ts
@@ -4,6 +4,7 @@ import {
   h,
   mount,
   mockIsIntersecting,
+  intersectionMockInstance,
   intersectionObserverBeforeAllCallback,
   intersectionObserverAfterEachCallback,
 } from '#test-utils';
@@ -33,6 +34,7 @@ describe('InView component', () => {
   it('should have the correct config', () => {
     expect(InView.config.name).toBe('InView');
     expect(InView.config.emits).toEqual(['in-view', 'out-of-view']);
+    expect(InView.config.options).toHaveProperty('repeat', Boolean);
   });
 
   it('should emit `in-view` when the element enters the viewport', async () => {
@@ -45,42 +47,73 @@ describe('InView component', () => {
     expect(fn).toHaveBeenCalledTimes(1);
   });
 
-  it('should emit `out-of-view` when the element leaves the viewport', async () => {
-    const { el, instance } = await mountInView(`<div data-component="InView"></div>`);
-    const fn = vi.fn();
-    instance.$on('out-of-view', fn);
+  describe('default one-shot behavior', () => {
+    it('should emit `in-view` once and then terminate (disconnect the observer)', async () => {
+      const { el, instance } = await mountInView(`<div data-component="InView"></div>`);
+      const observer = intersectionMockInstance(el);
+      const terminateSpy = vi.spyOn(instance, '$terminate');
+      const fn = vi.fn();
+      instance.$on('in-view', fn);
 
-    await mockIsIntersecting(el, true);
-    await mockIsIntersecting(el, false);
+      await mockIsIntersecting(el, true);
 
-    expect(fn).toHaveBeenCalledTimes(1);
+      expect(fn).toHaveBeenCalledTimes(1);
+      expect(terminateSpy).toHaveBeenCalledTimes(1);
+      // The decorator disconnects the observer on `terminated`.
+      expect(observer.disconnect).toHaveBeenCalled();
+    });
+
+    it('should NOT emit `out-of-view` when terminating after a one-shot `in-view`', async () => {
+      const { el, instance } = await mountInView(`<div data-component="InView"></div>`);
+      const outOfView = vi.fn();
+      instance.$on('out-of-view', outOfView);
+
+      await mockIsIntersecting(el, true);
+
+      expect(outOfView).not.toHaveBeenCalled();
+    });
   });
 
-  it('should re-emit `in-view` on each re-entry (repeat by default)', async () => {
-    const { el, instance } = await mountInView(`<div data-component="InView"></div>`);
-    const inView = vi.fn();
-    const outOfView = vi.fn();
-    instance.$on('in-view', inView);
-    instance.$on('out-of-view', outOfView);
+  describe('with `repeat` option', () => {
+    it('should emit `out-of-view` when the element leaves the viewport', async () => {
+      const { el, instance } = await mountInView(
+        `<div data-component="InView" data-option-repeat></div>`,
+      );
+      const fn = vi.fn();
+      instance.$on('out-of-view', fn);
 
-    await mockIsIntersecting(el, true);
-    await mockIsIntersecting(el, false);
-    await mockIsIntersecting(el, true);
+      await mockIsIntersecting(el, true);
+      await mockIsIntersecting(el, false);
 
-    expect(inView).toHaveBeenCalledTimes(2);
-    expect(outOfView).toHaveBeenCalledTimes(1);
+      expect(fn).toHaveBeenCalledTimes(1);
+    });
+
+    it('should re-emit `in-view` on each re-entry', async () => {
+      const { el, instance } = await mountInView(
+        `<div data-component="InView" data-option-repeat></div>`,
+      );
+      const inView = vi.fn();
+      const outOfView = vi.fn();
+      instance.$on('in-view', inView);
+      instance.$on('out-of-view', outOfView);
+
+      await mockIsIntersecting(el, true);
+      await mockIsIntersecting(el, false);
+      await mockIsIntersecting(el, true);
+
+      expect(inView).toHaveBeenCalledTimes(2);
+      expect(outOfView).toHaveBeenCalledTimes(1);
+    });
   });
 
   it('should expose the configurable `intersectionObserver` option', async () => {
     const { el } = await mountInView(
-      `<div data-component="InView" data-option-intersection-observer='{"rootMargin": "100px"}'></div>`,
+      `<div data-component="InView" data-option-repeat data-option-intersection-observer='{"rootMargin": "100px"}'></div>`,
     );
 
-    const observer = globalThis.IntersectionObserver as unknown as { mock: { results: any[] } };
-    const created = observer.mock.results.at(-1)?.value as IntersectionObserver;
+    const observer = intersectionMockInstance(el);
 
     // The option is forwarded to the IntersectionObserver instance.
-    expect(created.rootMargin).toBe('100px');
-    expect(el).toBeInstanceOf(HTMLElement);
+    expect(observer.rootMargin).toBe('100px');
   });
 });

--- a/packages/tests/index.spec.ts
+++ b/packages/tests/index.spec.ts
@@ -37,6 +37,7 @@ test('components exports', () => {
       "FrameTarget",
       "FrameTriggerLoader",
       "Hoverable",
+      "InView",
       "Indexable",
       "LargeText",
       "LazyInclude",

--- a/packages/tests/index.spec.ts
+++ b/packages/tests/index.spec.ts
@@ -38,6 +38,7 @@ test('components exports', () => {
       "FrameTriggerLoader",
       "Hoverable",
       "InView",
+      "InViewOnce",
       "Indexable",
       "LargeText",
       "LazyInclude",

--- a/packages/ui/InView/InView.ts
+++ b/packages/ui/InView/InView.ts
@@ -1,0 +1,36 @@
+import { Base, withMountWhenInView } from '@studiometa/js-toolkit';
+import type { BaseConfig } from '@studiometa/js-toolkit';
+
+/**
+ * InView class.
+ *
+ * A primitive emitting directional viewport events: `in-view` when the element
+ * enters the viewport and `out-of-view` when it leaves. It is built on the
+ * `withMountWhenInView` decorator, whose mount/destroy lifecycle maps directly
+ * to the enter/leave transitions.
+ *
+ * @link https://ui.studiometa.dev/components/InView/
+ */
+export class InView extends withMountWhenInView(Base) {
+  /**
+   * Config.
+   */
+  static config: BaseConfig = {
+    name: 'InView',
+    emits: ['in-view', 'out-of-view'],
+  };
+
+  /**
+   * Emit the `in-view` event when the element enters the viewport.
+   */
+  mounted() {
+    this.$emit('in-view');
+  }
+
+  /**
+   * Emit the `out-of-view` event when the element leaves the viewport.
+   */
+  destroyed() {
+    this.$emit('out-of-view');
+  }
+}

--- a/packages/ui/InView/InView.ts
+++ b/packages/ui/InView/InView.ts
@@ -7,11 +7,7 @@ import type { BaseConfig } from '@studiometa/js-toolkit';
  * A primitive emitting directional viewport events: `in-view` when the element
  * enters the viewport and `out-of-view` when it leaves. It is built on the
  * `withMountWhenInView` decorator, whose mount/destroy lifecycle maps directly
- * to the enter/leave transitions.
- *
- * By default the primitive is one-shot: it emits `in-view` once and terminates.
- * Set the `repeat` option to re-emit `in-view`/`out-of-view` on each viewport
- * crossing.
+ * to the enter/leave transitions, re-firing on each re-entry.
  *
  * @link https://ui.studiometa.dev/components/InView/
  */
@@ -22,40 +18,19 @@ export class InView extends withMountWhenInView(Base) {
   static config: BaseConfig = {
     name: 'InView',
     emits: ['in-view', 'out-of-view'],
-    options: {
-      repeat: Boolean,
-    },
   };
-
-  /**
-   * Whether the component is terminating after a one-shot `in-view` emission,
-   * used to skip the `out-of-view` emission triggered by `$terminate()`.
-   *
-   * @private
-   */
-  __oneShot = false;
 
   /**
    * Emit the `in-view` event when the element enters the viewport.
    */
   mounted() {
     this.$emit('in-view');
-
-    if (!this.$options.repeat) {
-      this.__oneShot = true;
-      this.$terminate();
-    }
   }
 
   /**
-   * Emit the `out-of-view` event when the element leaves the viewport, unless
-   * the destroy was triggered by the one-shot `$terminate()`.
+   * Emit the `out-of-view` event when the element leaves the viewport.
    */
   destroyed() {
-    if (this.__oneShot) {
-      return;
-    }
-
     this.$emit('out-of-view');
   }
 }

--- a/packages/ui/InView/InView.ts
+++ b/packages/ui/InView/InView.ts
@@ -9,6 +9,10 @@ import type { BaseConfig } from '@studiometa/js-toolkit';
  * `withMountWhenInView` decorator, whose mount/destroy lifecycle maps directly
  * to the enter/leave transitions.
  *
+ * By default the primitive is one-shot: it emits `in-view` once and terminates.
+ * Set the `repeat` option to re-emit `in-view`/`out-of-view` on each viewport
+ * crossing.
+ *
  * @link https://ui.studiometa.dev/components/InView/
  */
 export class InView extends withMountWhenInView(Base) {
@@ -18,19 +22,40 @@ export class InView extends withMountWhenInView(Base) {
   static config: BaseConfig = {
     name: 'InView',
     emits: ['in-view', 'out-of-view'],
+    options: {
+      repeat: Boolean,
+    },
   };
+
+  /**
+   * Whether the component is terminating after a one-shot `in-view` emission,
+   * used to skip the `out-of-view` emission triggered by `$terminate()`.
+   *
+   * @private
+   */
+  __oneShot = false;
 
   /**
    * Emit the `in-view` event when the element enters the viewport.
    */
   mounted() {
     this.$emit('in-view');
+
+    if (!this.$options.repeat) {
+      this.__oneShot = true;
+      this.$terminate();
+    }
   }
 
   /**
-   * Emit the `out-of-view` event when the element leaves the viewport.
+   * Emit the `out-of-view` event when the element leaves the viewport, unless
+   * the destroy was triggered by the one-shot `$terminate()`.
    */
   destroyed() {
+    if (this.__oneShot) {
+      return;
+    }
+
     this.$emit('out-of-view');
   }
 }

--- a/packages/ui/InView/InViewOnce.ts
+++ b/packages/ui/InView/InViewOnce.ts
@@ -1,0 +1,39 @@
+import type { BaseConfig } from '@studiometa/js-toolkit';
+import { InView } from './InView.js';
+
+/**
+ * InViewOnce class.
+ *
+ * A one-shot variant of the `InView` primitive: it emits `in-view` a single
+ * time when the element enters the viewport, then terminates. The
+ * `withMountWhenInView` decorator disconnects its observer on `terminated`, so
+ * the event never fires again and no `out-of-view` event is ever emitted.
+ *
+ * @link https://ui.studiometa.dev/components/InViewOnce/
+ */
+export class InViewOnce extends InView {
+  /**
+   * Config.
+   */
+  static config: BaseConfig = {
+    ...InView.config,
+    name: 'InViewOnce',
+    emits: ['in-view'],
+  };
+
+  /**
+   * Emit `in-view` once, then terminate so the event never fires again.
+   */
+  mounted() {
+    this.$emit('in-view');
+    this.$terminate();
+  }
+
+  /**
+   * Suppress the inherited `out-of-view` emission: `$terminate()` triggers the
+   * `destroyed()` hook, but a one-shot component must never emit `out-of-view`.
+   */
+  destroyed() {
+    // no-op
+  }
+}

--- a/packages/ui/InView/index.ts
+++ b/packages/ui/InView/index.ts
@@ -1,1 +1,2 @@
 export * from './InView.js';
+export * from './InViewOnce.js';

--- a/packages/ui/InView/index.ts
+++ b/packages/ui/InView/index.ts
@@ -1,0 +1,1 @@
+export * from './InView.js';

--- a/packages/ui/index.ts
+++ b/packages/ui/index.ts
@@ -13,6 +13,7 @@ export * from './FigureVideo/index.js';
 export * from './Frame/index.js';
 export * from './Hoverable/index.js';
 export * from './Indexable/index.js';
+export * from './InView/index.js';
 export * from './LargeText/index.js';
 export * from './LazyInclude/index.js';
 export * from './Menu/index.js';


### PR DESCRIPTION
## Summary

Adds two viewport primitives built on the [`withMountWhenInView`](https://js-toolkit.studiometa.dev/api/decorators/withMountWhenInView.html) decorator — the one-directional counterparts to [`Sentinel`](https://ui.studiometa.dev/components/Sentinel/) (whose `intersected` event fires on both enter and leave). They follow the same variant-component pattern as `Prefetch` (`PrefetchWhenOver`/`PrefetchWhenVisible`).

Closes #533.

## Components

- **`InView`** — repeating. Emits `in-view` when the element enters the viewport (on `mounted()`) and `out-of-view` when it leaves (on `destroyed()`); re-fires on every re-entry.
- **`InViewOnce`** — one-shot. Emits `in-view` once on first entry, then `$terminate()`s (the decorator disconnects the observer, so it never re-fires). Emits only `in-view` — no `out-of-view`, since the component is gone after the first view.

Composes with `Action` to drive any component method declaratively:

```html
<div
  data-component="Action InViewOnce Fetch"
  data-option-src="/path"
  data-on:in-view="Fetch.fetch()">
  …
</div>
```

## Design notes

- Two components rather than a `repeat` option: keeps each component's event surface coherent (an `out-of-view` that only exists in one mode is avoided), and matches the `Prefetch` variant precedent. `InViewOnce.destroyed()` is a documented no-op so `$terminate()` doesn't emit a spurious `out-of-view`.
- Both expose the decorator's `intersectionObserver` option (`data-option-intersection-observer`) for `threshold`/`rootMargin` tuning.
- Layout mirrors `Prefetch`: `packages/ui/InView/{InView,InViewOnce,index}.ts`; the existing `export * from './InView/index.js'` in `packages/ui/index.ts` covers both.

## Changes

- New `InView` and `InViewOnce` components + re-exporting `index.ts`.
- Tests: `packages/tests/InView/index.spec.ts` (InView: enter/leave/re-entry/option forwarding; InViewOnce: single emit + terminate/disconnect + never emits `out-of-view`) and exports-snapshot update.
- Docs: `packages/docs/components/InView/` and `packages/docs/components/InViewOnce/`, cross-referenced with each other and `Sentinel`.

## Verification

- `npm run test` — full suite green (440 tests), including the InView/InViewOnce specs.
- `npm run lint` — clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
