### PR TITLE
Fetch: add `src` option and no-arg `fetch()`

### DIFF
--- a/packages/docs/components/Fetch/index.md
+++ b/packages/docs/components/Fetch/index.md
@@ -55,6 +55,35 @@ Clicking on the link will dispatch a background fetch request and will replace t
 We use `id` attributes to detect which content from the response should be used and injected in the DOM. Any content from the response not nested in a parent with an `id` attribute will be discarded.
 :::
 
+### From any element
+
+The `Fetch` component is not limited to `<a>` and `<form>` elements. Set the [`src` option](./js-api.md#src) to a URL and the component can be mounted on any element, then triggered programmatically with the [`fetch()` method](./js-api.md#fetch-url-url-string-requestinit-requestinit) — for example from an event via the [`Action`](../Action/index.md) component.
+
+::: code-group
+
+```html [index.html]
+<div
+  data-component="Action Fetch"
+  data-option-src="/some-content"
+  data-on:click="Fetch.fetch()">
+  Click me
+</div>
+
+<div id="content"></div>
+```
+
+```js twoslash [app.ts]
+import { registerComponent } from '@studiometa/js-toolkit';
+import { Action, Fetch } from '@studiometa/ui';
+
+registerComponent(Action);
+registerComponent(Fetch);
+```
+
+:::
+
+Calling `fetch()` without an argument uses the `src` option (or the element's `href` / `action` when it is a link or a form). You can also pass an explicit URL or a relative string, e.g. `Fetch.fetch('/other-content')`.
+
 ### With a loader
 
 Use the [`Action`](../Action/index.md) and [`Transition`](../Transition/index.md) components to display a loader while the fetch request is happening.

--- a/packages/docs/components/Fetch/js-api.md
+++ b/packages/docs/components/Fetch/js-api.md
@@ -102,6 +102,24 @@ The following element will be updated with HTML from the
 
 :::
 
+### `src`
+
+- Type: `string`
+- Default: `''`
+
+Defines the URL to fetch when the component is not mounted on a `<a>` or a `<form>` element. This makes it possible to drive the `Fetch` component from any element (e.g. a `<div>`) triggered by an event, a decorator or a programmatic call.
+
+The value is resolved against the current location, so both absolute and relative URLs are supported. It is only used as a fallback: on a `<a>` its `href` is used, on a `<form>` its `action` is used, and `src` is ignored.
+
+```html
+<div
+  data-component="Action InView Fetch"
+  data-option-src="/path"
+  data-on:in-view="Fetch.fetch()">
+  …
+</div>
+```
+
 ## Getters
 
 ### `client`
@@ -114,7 +132,7 @@ Returns the global `fetch` function.
 
 - Return: `URL`
 
-If the root element is a link, returns the `href` attribute, if it is a form, returns the `action` attribute, with the form data as URL parameters if the [`method`](#method) is `get`
+If the root element is a link, returns the `href` attribute, if it is a form, returns the `action` attribute, with the form data as URL parameters if the [`method`](#method) is `get`. For any other element, it falls back to the [`src` option](#src) resolved against the current location.
 
 ### `requestInit`
 
@@ -145,6 +163,26 @@ To avoid adding the header to the form data, use the `data-name` attribute to sp
 The example above will add a `x-my-token: some-not-sensible-token` header to the triggered request.
 
 ## Methods
+
+### `fetch(url?: URL | string, requestInit?: RequestInit)`
+
+Performs the fetch request and updates the DOM with the response.
+
+The declarative click, submit and popstate flows call this method for you, but it can also be triggered manually — from an event, a decorator or your own code.
+
+**Parameters**
+
+- `url` (`URL | string`, optional): the URL to fetch. Defaults to the [`url` getter](#url), so a bare `fetch()` call uses the element's `href`, `action` or [`src` option](#src). A `string` is coerced into a `URL` resolved against the current location.
+- `requestInit` ([`RequestInit`](https://developer.mozilla.org/en-US/docs/Web/API/RequestInit), optional): extra options merged into the [`requestInit` getter](#requestinit-1) for this call.
+
+```html
+<div
+  data-component="Action InView Fetch"
+  data-option-src="/path"
+  data-on:in-view="Fetch.fetch()">
+  …
+</div>
+```
 
 ### `abort(reason?: any)`
 

--- a/packages/tests/Fetch/Fetch.spec.ts
+++ b/packages/tests/Fetch/Fetch.spec.ts
@@ -42,6 +42,15 @@ describe('The Fetch class', () => {
       expect(fetch.url.href).toBe('https://example.com/submit?foo=bar');
     });
 
+    it('should fall back to the `src` option for the `url` getter on other elements', async () => {
+      (window as any).happyDOM.setURL('https://example.com/');
+      const div = h('div', { dataOptionSrc: '/src-path' });
+      const fetch = new Fetch(div);
+      await mount(fetch);
+
+      expect(fetch.url).toEqual(new URL('https://example.com/src-path'));
+    });
+
     it('should have a `requestInit` getter', async () => {
       const headers = { 'x-foo': 'bar' };
       const init = { method: 'post' };
@@ -264,6 +273,57 @@ describe('The Fetch class', () => {
   });
 
   describe('fetch method', () => {
+    it('should default to the `url` getter when called with no argument', async () => {
+      const anchor = h('a', { href: 'https://example.com/no-arg' });
+      const fetch = new Fetch(anchor);
+      const clientSpy = vi.fn(() => Promise.resolve(new Response('content')));
+      vi.spyOn(fetch, 'client', 'get').mockImplementation(() => clientSpy);
+
+      await mount(fetch);
+      await fetch.fetch();
+
+      expect(clientSpy).toHaveBeenCalledWith(
+        new URL('https://example.com/no-arg'),
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      );
+    });
+
+    it('should resolve and fetch the `src` option URL when mounted on a `<div>`', async () => {
+      (window as any).happyDOM.setURL('https://example.com/');
+      const div = h('div', { dataOptionSrc: '/src-path' });
+      const fetch = new Fetch(div);
+      const clientSpy = vi.fn(() => Promise.resolve(new Response('content')));
+      vi.spyOn(fetch, 'client', 'get').mockImplementation(() => clientSpy);
+
+      await mount(fetch);
+      await fetch.fetch();
+
+      expect(clientSpy).toHaveBeenCalledWith(
+        new URL('https://example.com/src-path'),
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      );
+    });
+
+    it('should coerce a string URL argument into a URL object', async () => {
+      (window as any).happyDOM.setURL('https://example.com/');
+      const anchor = h('a', { href: 'https://example.com' });
+      const fetch = new Fetch(anchor);
+      const clientSpy = vi.fn(() => Promise.resolve(new Response('content')));
+      vi.spyOn(fetch, 'client', 'get').mockImplementation(() => clientSpy);
+      const updateSpy = vi.spyOn(fetch, 'update');
+
+      await mount(fetch);
+      await fetch.fetch('/relative/path');
+
+      const expectedUrl = new URL('https://example.com/relative/path');
+      expect(clientSpy).toHaveBeenCalledWith(
+        expectedUrl,
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      );
+      // The normalized `URL` (not the raw string) is threaded through to `update`.
+      expect(updateSpy).toHaveBeenCalledWith(expectedUrl, expect.any(Object), 'content');
+    });
+
     it('should emit before-fetch event', async () => {
       const anchor = h('a', { href: 'https://example.com' });
       const fetch = new Fetch(anchor);

--- a/packages/ui/Fetch/Fetch.ts
+++ b/packages/ui/Fetch/Fetch.ts
@@ -16,6 +16,7 @@ export interface FetchProps extends BaseProps {
     selector: string;
     response: string;
     viewTransition: boolean;
+    src: string;
   };
 }
 
@@ -90,6 +91,7 @@ export class Fetch<T extends BaseProps = BaseProps>
         type: Boolean,
         default: true,
       },
+      src: String,
     },
   };
 
@@ -131,9 +133,13 @@ export class Fetch<T extends BaseProps = BaseProps>
 
   /**
    * The URL to use for the request.
+   *
+   * For a form, the URL is built from its `action` attribute (with the form data as search
+   * params for GET requests); for a link, from its `href` attribute. For any other element,
+   * it falls back to the `src` option resolved against the current location.
    */
   get url(): URL {
-    const { $el, isForm } = this;
+    const { $el, isForm, isLink } = this;
 
     if (isForm) {
       const { action, method } = this.$el as HTMLFormElement;
@@ -147,7 +153,11 @@ export class Fetch<T extends BaseProps = BaseProps>
       return url;
     }
 
-    return new URL($el.href);
+    if (isLink) {
+      return new URL($el.href);
+    }
+
+    return new URL(this.$options.src, window.location.href);
   }
 
   /**
@@ -256,17 +266,23 @@ export class Fetch<T extends BaseProps = BaseProps>
 
   /**
    * Fetch given url.
+   *
+   * The `url` parameter is optional and defaults to the {@link url} getter, allowing a bare
+   * `fetch()` call from an event or a decorator. String or relative inputs are coerced into a
+   * `URL` object resolved against the current location so the history and view-transition
+   * paths — which rely on `url.pathname` and `url.searchParams` — stay safe.
    */
-  async fetch(url: URL, requestInit: RequestInit = {}) {
+  async fetch(url: URL | string = this.url, requestInit: RequestInit = {}) {
+    const normalizedUrl = url instanceof URL ? url : new URL(url, window.location.href);
     const { FETCH_EVENTS } = this.constructor;
-    this.$emit(FETCH_EVENTS.BEFORE_FETCH, { instance: this, url, requestInit });
+    this.$emit(FETCH_EVENTS.BEFORE_FETCH, { instance: this, url: normalizedUrl, requestInit });
 
     this.__abortController.abort();
     const newController = new AbortController();
     newController.signal.addEventListener('abort', () => {
       this.$emit(FETCH_EVENTS.ABORT, {
         instance: this,
-        url,
+        url: normalizedUrl,
         requestInit,
         reason: newController.signal.reason,
       });
@@ -282,12 +298,17 @@ export class Fetch<T extends BaseProps = BaseProps>
       signal: newController.signal,
     };
 
-    this.$log('fetch', url, init);
-    this.$emit(FETCH_EVENTS.FETCH, { instance: this, url, requestInit: init });
+    this.$log('fetch', normalizedUrl, init);
+    this.$emit(FETCH_EVENTS.FETCH, { instance: this, url: normalizedUrl, requestInit: init });
 
     try {
-      const response = await this.client(url, init);
-      this.$emit(FETCH_EVENTS.RESPONSE, { instance: this, url, requestInit: init, response });
+      const response = await this.client(normalizedUrl, init);
+      this.$emit(FETCH_EVENTS.RESPONSE, {
+        instance: this,
+        url: normalizedUrl,
+        requestInit: init,
+        response,
+      });
 
       if (!response.ok) {
         throw new Error(`Fetch failed with status ${response.status}`);
@@ -300,12 +321,22 @@ export class Fetch<T extends BaseProps = BaseProps>
         'self',
         `return ${this.$options.response}`,
       );
-      const content = await fn.call(this, response, url, requestInit, self);
-      this.$emit(FETCH_EVENTS.AFTER_FETCH, { instance: this, url, requestInit: init, content });
-      this.update(url, init, content);
+      const content = await fn.call(this, response, normalizedUrl, requestInit, self);
+      this.$emit(FETCH_EVENTS.AFTER_FETCH, {
+        instance: this,
+        url: normalizedUrl,
+        requestInit: init,
+        content,
+      });
+      this.update(normalizedUrl, init, content);
     } catch (error) {
-      this.$emit(FETCH_EVENTS.AFTER_FETCH, { instance: this, url, requestInit: init, error });
-      this.error(url, init, error);
+      this.$emit(FETCH_EVENTS.AFTER_FETCH, {
+        instance: this,
+        url: normalizedUrl,
+        requestInit: init,
+        error,
+      });
+      this.error(normalizedUrl, init, error);
     }
   }
 

--- a/packages/ui/Fetch/FetchShopifyPartial.ts
+++ b/packages/ui/Fetch/FetchShopifyPartial.ts
@@ -167,24 +167,25 @@ export class FetchShopifyPartial<T extends BaseProps = BaseProps> extends Fetch<
    * the base fetch behaviour.
    * @inheritdoc
    */
-  async fetch(url: URL, requestInit: RequestInit = {}) {
+  async fetch(url: URL | string = this.url, requestInit: RequestInit = {}) {
+    const normalizedUrl = url instanceof URL ? url : new URL(url, window.location.href);
     const names = this.$options.partials;
     const partials =
       names.length && this.__canUsePartials(requestInit) ? await this.__resolvePartials() : null;
 
     if (!partials) {
-      return super.fetch(url, requestInit);
+      return super.fetch(normalizedUrl, requestInit);
     }
 
     const { FETCH_EVENTS } = this.constructor;
-    this.$emit(FETCH_EVENTS.BEFORE_FETCH, { instance: this, url, requestInit });
+    this.$emit(FETCH_EVENTS.BEFORE_FETCH, { instance: this, url: normalizedUrl, requestInit });
 
     this.__abortController.abort();
     const newController = new AbortController();
     newController.signal.addEventListener('abort', () => {
       this.$emit(FETCH_EVENTS.ABORT, {
         instance: this,
-        url,
+        url: normalizedUrl,
         requestInit,
         reason: newController.signal.reason,
       });
@@ -200,22 +201,32 @@ export class FetchShopifyPartial<T extends BaseProps = BaseProps> extends Fetch<
       signal: newController.signal,
     };
 
-    this.$log('fetch', url, init);
-    this.$emit(FETCH_EVENTS.FETCH, { instance: this, url, requestInit: init });
+    this.$log('fetch', normalizedUrl, init);
+    this.$emit(FETCH_EVENTS.FETCH, { instance: this, url: normalizedUrl, requestInit: init });
 
     try {
       const update = await partials.fetch(...names, {
-        url: url.toString(),
+        url: normalizedUrl.toString(),
         signal: init.signal,
       });
-      this.$emit(FETCH_EVENTS.AFTER_FETCH, { instance: this, url, requestInit: init, content: update });
+      this.$emit(FETCH_EVENTS.AFTER_FETCH, {
+        instance: this,
+        url: normalizedUrl,
+        requestInit: init,
+        content: update,
+      });
       // Fire-and-forget the apply phase, matching the base `Fetch.fetch` lifecycle: an
       // `apply()` failure must not be misattributed to the fetch phase and re-emit
       // `AFTER_FETCH` a second time.
-      this.__applyPartials(url, init, update, partials);
+      this.__applyPartials(normalizedUrl, init, update, partials);
     } catch (error) {
-      this.$emit(FETCH_EVENTS.AFTER_FETCH, { instance: this, url, requestInit: init, error });
-      this.error(url, init, error);
+      this.$emit(FETCH_EVENTS.AFTER_FETCH, {
+        instance: this,
+        url: normalizedUrl,
+        requestInit: init,
+        error,
+      });
+      this.error(normalizedUrl, init, error);
     }
   }
 


### PR DESCRIPTION
## Summary

Decouples `Fetch` from the `<a href>` / `<form action>` element contract so it can be driven by arbitrary triggers (an event, a decorator, a programmatic call). Two small, backward-compatible changes:

1. New optional **`src` option** used as a URL fallback, so `Fetch` works on any element (e.g. a `<div>`).
2. **`fetch()` is now callable with no argument**, defaulting to `this.url`, with string/relative URLs coerced into a `URL` object.

Closes #534. Unblocks the event-driven trigger composition with the `InView` primitive (#533 / #535):

```html
<div
  data-component="Action InView Fetch"
  data-option-src="/path"
  data-on:in-view="Fetch.fetch()">
  …
</div>
```

## Changes

- **`Fetch.ts`**: added `src: String` option (+ `FetchProps` type); the `url` getter falls back to `new URL(this.$options.src, location.href)` for non-link/non-form elements. `fetch(url = this.url, requestInit = {})` now normalises `url` to a `URL` and threads it through every event payload, `client()`, the `response` parser, `update()` and `error()` — payloads always carry a `URL`, never a raw string.
- **`FetchShopifyPartial.ts`**: same optional-arg + coercion treatment applied to its `fetch()` override, threaded through `super.fetch()`, `partials.fetch()`, `__applyPartials()` and the event payloads.
- Tests (`packages/tests/Fetch/Fetch.spec.ts`): `src` fallback on a `<div>`, no-arg `fetch()`, `src`-driven fetch on a `<div>`, and string/relative-URL coercion (asserting a `URL` reaches `update()`).
- Docs: `src` option + no-arg `fetch()` documented in `js-api.md`, with a usage note in `index.md`.

## Backward compatibility

- `<a>` / `<form>` usage unchanged — `src` is only consulted when the element is neither a link nor a form.
- `fetch(url, init)` with an explicit `URL` still works; the default and coercion are additive.

## Behaviour note for reviewers

- When an element has **neither** `href`/`action` **nor** `src`, `src` defaults to `''`, so the getter resolves to the current page URL instead of throwing. This is intentional graceful degradation aligned with the issue's goal (stop throwing on non-link/non-form elements). Flagging in case we'd prefer an explicit warning when `src` is empty.

## Verification

- `npm run test` (full) — 435 passed, 3 skipped, 1 todo (includes 73 Fetch/FetchShopifyPartial tests).
- `npm run lint` — clean on touched files; type-check and prettier pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
