### PR TITLE
Add usage examples and Action recipes for InView, InViewOnce (and Fetch src)

### DIFF
--- a/packages/docs/components/Fetch/examples.md
+++ b/packages/docs/components/Fetch/examples.md
@@ -25,6 +25,27 @@ Intercepting clicks on links, displaying a loader and updating the targets' cont
 
 </llm-only>
 
+## Fetch from any element
+
+`Fetch` normally reads its URL from an `<a href>` or `<form action>`, but the [`src` option](./js-api.md#src) lets it be driven from **any** element and triggered programmatically. In the following example the panel is a `<div>`: it combines `Fetch` with the [`InViewOnce`](../InViewOnce/index.md) and [`Action`](../Action/index.md) components so that its content is lazy-loaded the first time it scrolls into view, with a bare [`Fetch.fetch()`](./js-api.md#fetch-url-url-string-requestinit-requestinit) call that resolves the `src` URL on its own.
+
+<llm-exclude>
+<PreviewPlayground
+  :html="() => import('./stories/src/app.twig')"
+  :script="() => import('./stories/src/app.ts?raw')"
+  />
+</llm-exclude>
+<llm-only>
+
+:::code-group
+
+<<< ./stories/src/app.twig
+<<< ./stories/src/app.ts
+
+:::
+
+</llm-only>
+
 ## Form
 
 In the following example, we intercept a form submission, display a loader and use a custom view transition to animate only the updated content once the request is finished.

--- a/packages/docs/components/Fetch/stories/src/app.ts
+++ b/packages/docs/components/Fetch/stories/src/app.ts
@@ -1,0 +1,6 @@
+import { registerComponent } from '@studiometa/js-toolkit';
+import { Action, Fetch, InViewOnce } from '@studiometa/ui';
+
+registerComponent(Action);
+registerComponent(Fetch);
+registerComponent(InViewOnce);

--- a/packages/docs/components/Fetch/stories/src/app.twig
+++ b/packages/docs/components/Fetch/stories/src/app.twig
@@ -1,0 +1,35 @@
+{%- set lazy_content -%}
+  <div id="lazy" class="rounded bg-emerald-500 p-6 text-white">
+    <h2 class="text-lg font-bold">Loaded on scroll</h2>
+    <p class="mt-2">
+      This markup was fetched from the URL defined by the <code>src</code> option the first time
+      the panel entered the viewport, with a bare <code>Fetch.fetch()</code> call.
+    </p>
+  </div>
+{%- endset -%}
+
+<div class="flex flex-col gap-8 py-8">
+  <p class="text-center text-sm text-zinc-500">
+    Scroll down — the panel fetches its content the first time it enters the viewport.
+  </p>
+
+  {# Spacer so the panel starts below the fold. #}
+  <div class="h-[70vh]"></div>
+
+  {#
+    The panel is neither a link nor a form, so `Fetch` reads the URL from the `src` option.
+    `InViewOnce` emits `in-view` once when the panel is scrolled into view, and the sibling
+    `Action` calls the no-argument `Fetch.fetch()`, which fetches `src` and swaps `#lazy` in place.
+  #}
+  <div
+    data-component="Action InViewOnce Fetch"
+    data-option-src="{{ twig_toolkit_url('/api/').withQueryParameter('content', lazy_content).withQueryParameter('wait', 1) }}"
+    data-on:in-view="Fetch.fetch()"
+    class="mx-auto w-full max-w-xl">
+    <div id="lazy" class="rounded border border-dashed border-zinc-300 p-6 text-center text-zinc-500">
+      Loading…
+    </div>
+  </div>
+
+  <div class="h-[40vh]"></div>
+</div>

--- a/packages/docs/components/InView/examples.md
+++ b/packages/docs/components/InView/examples.md
@@ -1,0 +1,66 @@
+---
+title: InView examples
+---
+
+# Examples
+
+Because [`$emit`](https://js-toolkit.studiometa.dev/api/methods/emit.html) dispatches a native `CustomEvent` on the component's root element, the [`Action` component](../Action/index.md) can catch the `in-view` and `out-of-view` events emitted by `InView` with its [`data-on:<event>` attributes](../Action/js-api.md#on-event-modifier). Putting both components on the same element (`data-component="Action InView"`) is therefore all it takes to react to viewport crossings declaratively — no custom JavaScript class required.
+
+## Reveal on scroll
+
+Each card carries both `Action` and `InView`. When it enters the viewport, `InView` emits `in-view` and the `Action` adds the `is-visible` class; when it leaves, `out-of-view` removes it again. Because `InView` re-fires on every crossing, the reveal replays each time you scroll a card back into view. The animation itself is plain CSS driven by the `is-visible` class.
+
+<llm-exclude>
+<PreviewPlayground
+  :html="() => import('./stories/reveal/app.twig')"
+  :script="() => import('./stories/reveal/app.js?raw')"
+  />
+</llm-exclude>
+<llm-only>
+
+:::code-group
+
+<<< ./stories/reveal/app.twig
+<<< ./stories/reveal/app.js
+
+:::
+
+</llm-only>
+
+## Playing a Transition on scroll
+
+For a more capable reveal, share the element with the [`Transition` component](../Transition/index.md) and let the `Action` drive it: `in-view` plays `Transition.enter()` and `out-of-view` plays `Transition.leave()`. The enter/leave states are described with the usual `data-option-enter-*` / `data-option-leave-*` attributes, and `data-option-enter-keep` / `data-option-leave-keep` hold the final state between crossings.
+
+<llm-exclude>
+<PreviewPlayground
+  :html="() => import('./stories/transition/app.twig')"
+  :script="() => import('./stories/transition/app.js?raw')"
+  />
+</llm-exclude>
+<llm-only>
+
+:::code-group
+
+<<< ./stories/transition/app.twig
+<<< ./stories/transition/app.js
+
+:::
+
+</llm-only>
+
+::: tip
+The `Action` component can also target a **sibling** component instead of one mounted on the same element, using its [`Name(#selector) -> target.method()` syntax](../Action/js-api.md#on-event-modifier). For example, `data-on:in-view="Transition(#panel) -> target.enter()"` lets an `InView` element play the `enter()` method of the `Transition` with the `panel` id.
+:::
+
+## Custom threshold and root margin
+
+The [`intersectionObserver` option](./js-api.md#intersectionobserver) is forwarded to the underlying `IntersectionObserver`, so you can tune when the crossing is detected. A negative `rootMargin` delays `in-view` until the element is comfortably inside the viewport:
+
+```html
+<div
+  data-component="Action InView"
+  data-option-intersection-observer='{ "rootMargin": "-15% 0px" }'
+  data-on:in-view="$el.classList.add('is-visible')">
+  …
+</div>
+```

--- a/packages/docs/components/InView/index.md
+++ b/packages/docs/components/InView/index.md
@@ -41,3 +41,18 @@ export default class Component extends Base {
   <div data-component="InView">...</div>
 </div>
 ```
+
+## Usage with the `Action` component
+
+Since [`$emit`](https://js-toolkit.studiometa.dev/api/methods/emit.html) dispatches a native `CustomEvent` on the component's root element, the [`Action` component](/components/Action/) can react to the `in-view` / `out-of-view` events without any custom class. Mount both on the same element and wire the events with `data-on:` attributes:
+
+```html
+<div
+  data-component="Action InView"
+  data-on:in-view="$el.classList.add('is-visible')"
+  data-on:out-of-view="$el.classList.remove('is-visible')">
+  ...
+</div>
+```
+
+See the [examples](./examples.md) for live reveal-on-scroll demos and the [JavaScript API](./js-api.md) for the full list of options and events.

--- a/packages/docs/components/InView/stories/reveal/app.js
+++ b/packages/docs/components/InView/stories/reveal/app.js
@@ -1,0 +1,5 @@
+import { registerComponent } from '@studiometa/js-toolkit';
+import { Action, InView } from '@studiometa/ui';
+
+registerComponent(Action);
+registerComponent(InView);

--- a/packages/docs/components/InView/stories/reveal/app.twig
+++ b/packages/docs/components/InView/stories/reveal/app.twig
@@ -1,0 +1,39 @@
+<div class="flex flex-col gap-8 py-8">
+  <p class="text-center text-sm text-zinc-500">Scroll down to reveal the cards, then scroll back up to replay.</p>
+
+  {# Spacer so the cards start below the fold and have to be scrolled into view. #}
+  <div class="h-[70vh]"></div>
+
+  {% for i in 1..4 %}
+    <div
+      data-component="Action InView"
+      data-on:in-view="$el.classList.add('is-visible')"
+      data-on:out-of-view="$el.classList.remove('is-visible')"
+      class="reveal mx-auto w-full max-w-md rounded bg-blue-500 p-6 text-white">
+      <h2 class="text-lg font-bold">Card {{ i }}</h2>
+      <p class="mt-2">
+        The <code>InView</code> primitive emits <code>in-view</code> when this card enters the
+        viewport and <code>out-of-view</code> when it leaves. The sibling <code>Action</code>
+        component catches both events and toggles the <code>is-visible</code> class, so the reveal
+        replays on every crossing.
+      </p>
+    </div>
+  {% endfor %}
+
+  <div class="h-[40vh]"></div>
+</div>
+
+{# The reveal animation is authored in CSS and driven by the `is-visible` class. #}
+<style>
+  .reveal {
+    opacity: 0;
+    transform: translateY(2rem);
+    transition:
+      opacity 500ms ease,
+      transform 500ms ease;
+  }
+  .reveal.is-visible {
+    opacity: 1;
+    transform: none;
+  }
+</style>

--- a/packages/docs/components/InView/stories/transition/app.js
+++ b/packages/docs/components/InView/stories/transition/app.js
@@ -1,0 +1,6 @@
+import { registerComponent } from '@studiometa/js-toolkit';
+import { Action, InView, Transition } from '@studiometa/ui';
+
+registerComponent(Action);
+registerComponent(InView);
+registerComponent(Transition);

--- a/packages/docs/components/InView/stories/transition/app.twig
+++ b/packages/docs/components/InView/stories/transition/app.twig
@@ -1,0 +1,32 @@
+<div class="flex flex-col gap-8 py-8">
+  <p class="text-center text-sm text-zinc-500">Scroll down to play each Transition, scroll back up to replay.</p>
+
+  {# Spacer so the panels start below the fold. #}
+  <div class="h-[70vh]"></div>
+
+  {% for i in 1..4 %}
+    <div
+      data-component="Action InView Transition"
+      data-option-enter-from="opacity-0 translate-y-8"
+      data-option-enter-active="transition duration-700 ease-out"
+      data-option-enter-to="opacity-100 translate-y-0"
+      data-option-enter-keep
+      data-option-leave-from="opacity-100 translate-y-0"
+      data-option-leave-active="transition duration-500 ease-in"
+      data-option-leave-to="opacity-0 translate-y-8"
+      data-option-leave-keep
+      data-on:in-view="Transition.enter()"
+      data-on:out-of-view="Transition.leave()"
+      class="mx-auto w-full max-w-md rounded bg-emerald-500 p-6 text-white opacity-0 translate-y-8">
+      <h2 class="text-lg font-bold">Panel {{ i }}</h2>
+      <p class="mt-2">
+        Here <code>InView</code> and <code>Action</code> share the element with a
+        <code>Transition</code>. On <code>in-view</code> the <code>Action</code> plays
+        <code>Transition.enter()</code>, and on <code>out-of-view</code> it plays
+        <code>Transition.leave()</code> — so the class-based transition runs both ways as you scroll.
+      </p>
+    </div>
+  {% endfor %}
+
+  <div class="h-[40vh]"></div>
+</div>

--- a/packages/docs/components/InViewOnce/examples.md
+++ b/packages/docs/components/InViewOnce/examples.md
@@ -1,0 +1,34 @@
+---
+title: InViewOnce examples
+---
+
+# Examples
+
+Like [`InView`](../InView/examples.md), `InViewOnce` emits its event as a native `CustomEvent` on the component's root element, so the [`Action` component](../Action/index.md) can react to it with a `data-on:in-view` attribute — no custom JavaScript class required. The difference is that `InViewOnce` fires **once** and never emits `out-of-view`.
+
+## One-shot reveal
+
+Each card carries both `Action` and `InViewOnce`. The first time it enters the viewport, `InViewOnce` emits `in-view`, the `Action` adds the `is-visible` class, and the component terminates. Scrolling the card out and back in does **not** replay the reveal, and no `out-of-view` event is ever emitted — which is exactly what makes it a good fit for one-off reveals, lazy loading or analytics impressions.
+
+This story also sets a custom [`intersectionObserver` option](./js-api.md#intersectionobserver) (`rootMargin: "-10% 0px"`) so the reveal only triggers once the card is comfortably inside the viewport.
+
+<llm-exclude>
+<PreviewPlayground
+  :html="() => import('./stories/reveal/app.twig')"
+  :script="() => import('./stories/reveal/app.js?raw')"
+  />
+</llm-exclude>
+<llm-only>
+
+:::code-group
+
+<<< ./stories/reveal/app.twig
+<<< ./stories/reveal/app.js
+
+:::
+
+</llm-only>
+
+::: tip
+Need the reveal to replay on every crossing, or a matching `out-of-view` reaction? Use the [`InView` primitive](../InView/index.md) instead — it is the repeating, directional counterpart.
+:::

--- a/packages/docs/components/InViewOnce/index.md
+++ b/packages/docs/components/InViewOnce/index.md
@@ -35,3 +35,17 @@ export default class Component extends Base {
   <div data-component="InViewOnce">...</div>
 </div>
 ```
+
+## Usage with the `Action` component
+
+Since [`$emit`](https://js-toolkit.studiometa.dev/api/methods/emit.html) dispatches a native `CustomEvent` on the component's root element, the [`Action` component](/components/Action/) can react to the `in-view` event without any custom class. Mount both on the same element to trigger a one-off effect:
+
+```html
+<div
+  data-component="Action InViewOnce"
+  data-on:in-view="$el.classList.add('is-visible')">
+  ...
+</div>
+```
+
+See the [examples](./examples.md) for a live one-shot reveal demo and the [JavaScript API](./js-api.md) for the full list of options and events.

--- a/packages/docs/components/InViewOnce/stories/reveal/app.js
+++ b/packages/docs/components/InViewOnce/stories/reveal/app.js
@@ -1,0 +1,5 @@
+import { registerComponent } from '@studiometa/js-toolkit';
+import { Action, InViewOnce } from '@studiometa/ui';
+
+registerComponent(Action);
+registerComponent(InViewOnce);

--- a/packages/docs/components/InViewOnce/stories/reveal/app.twig
+++ b/packages/docs/components/InViewOnce/stories/reveal/app.twig
@@ -1,0 +1,41 @@
+<div class="flex flex-col gap-8 py-8">
+  <p class="text-center text-sm text-zinc-500">
+    Scroll down to reveal the cards once. Scroll back up: they stay in place — the reveal never
+    replays and no <code>out-of-view</code> is ever emitted.
+  </p>
+
+  {# Spacer so the cards start below the fold. #}
+  <div class="h-[70vh]"></div>
+
+  {% for i in 1..4 %}
+    <div
+      data-component="Action InViewOnce"
+      data-option-intersection-observer='{ "rootMargin": "-10% 0px" }'
+      data-on:in-view="$el.classList.add('is-visible')"
+      class="reveal mx-auto w-full max-w-md rounded bg-violet-500 p-6 text-white">
+      <h2 class="text-lg font-bold">Card {{ i }}</h2>
+      <p class="mt-2">
+        <code>InViewOnce</code> emits <code>in-view</code> a single time, then terminates and
+        disconnects its observer. The <code>Action</code> reveals the card once and it stays
+        visible — ideal for a one-off reveal, a lazy load or an analytics impression.
+      </p>
+    </div>
+  {% endfor %}
+
+  <div class="h-[40vh]"></div>
+</div>
+
+{# The `-10%` root margin delays the reveal until the card is comfortably inside the viewport. #}
+<style>
+  .reveal {
+    opacity: 0;
+    transform: translateY(2rem);
+    transition:
+      opacity 500ms ease,
+      transform 500ms ease;
+  }
+  .reveal.is-visible {
+    opacity: 1;
+    transform: none;
+  }
+</style>

--- a/packages/docs/components/ViewTransition/examples.md
+++ b/packages/docs/components/ViewTransition/examples.md
@@ -24,3 +24,24 @@ Click **Enter** and **Leave** to toggle the element. The animation runs as a nat
 :::
 
 </llm-only>
+
+## Triggering with the `Action` component
+
+`ViewTransition` exposes the same `enter()`, `leave()` and `toggle()` methods as [`Transition`](/components/Transition/), so the [`Action` component](/components/Action/) can drive it declaratively — no custom `onClick` handlers required. Here the buttons target the `Togglable` instance and call its methods directly through `data-option-effect`.
+
+<llm-exclude>
+<PreviewPlayground
+  :html="() => import('./stories/action/app.twig')"
+  :script="() => import('./stories/action/app.js?raw')"
+  />
+</llm-exclude>
+<llm-only>
+
+:::code-group
+
+<<< ./stories/action/app.twig
+<<< ./stories/action/app.js
+
+:::
+
+</llm-only>

--- a/packages/docs/components/ViewTransition/stories/action/app.js
+++ b/packages/docs/components/ViewTransition/stories/action/app.js
@@ -1,0 +1,11 @@
+import { registerComponent } from '@studiometa/js-toolkit';
+import { Action, ViewTransition } from '@studiometa/ui';
+
+class Togglable extends ViewTransition {
+  static config = {
+    name: 'Togglable',
+  };
+}
+
+registerComponent(Action);
+registerComponent(Togglable);

--- a/packages/docs/components/ViewTransition/stories/action/app.twig
+++ b/packages/docs/components/ViewTransition/stories/action/app.twig
@@ -1,0 +1,50 @@
+<div class="flex flex-col items-start gap-8">
+  <div class="flex items-center gap-4">
+    {% include '@ui/Button/StyledButton.twig' with {
+      label: 'Enter',
+      attr: {
+        data_component: 'Action',
+        data_option_target: 'Togglable',
+        data_option_effect: 'target.enter()'
+      }
+    } %}
+    {% include '@ui/Button/StyledButton.twig' with {
+      label: 'Leave',
+      attr: {
+        data_component: 'Action',
+        data_option_target: 'Togglable',
+        data_option_effect: 'target.leave()'
+      }
+    } %}
+    {% include '@ui/Button/StyledButton.twig' with {
+      label: 'Toggle',
+      theme: 'secondary',
+      attr: {
+        data_component: 'Action',
+        data_option_target: 'Togglable',
+        data_option_effect: 'target.toggle()'
+      }
+    } %}
+  </div>
+
+  <div
+    data-component="Togglable"
+    data-option-view-transition-name="box"
+    data-option-leave-to="hidden"
+    class="max-w-md rounded bg-blue-500 p-6 text-white">
+    Lorem ipsum dolor sit amet, consectetur adipisicing elit. Dignissimos deleniti
+    repudiandae facilis eos facere iste voluptatum earum optio porro beatae.
+  </div>
+</div>
+
+{# The enter/leave animation is authored with the ::view-transition-* pseudo-elements. #}
+<style>
+  @keyframes view-transition-box-enter {
+    from { opacity: 0; transform: translateY(1rem); }
+  }
+  @keyframes view-transition-box-leave {
+    to { opacity: 0; transform: translateY(1rem); }
+  }
+  ::view-transition-new(box) { animation: 300ms ease-out both view-transition-box-enter; }
+  ::view-transition-old(box) { animation: 300ms ease-in both view-transition-box-leave; }
+</style>


### PR DESCRIPTION
## Summary

Adds the missing usage examples and recipes for recently-merged components, with a focus on the requested gap: their integration with the [`Action`](https://ui.studiometa.dev/components/Action/) component. Because js-toolkit's `$emit` dispatches a native `CustomEvent` on the component's root element, `Action`'s `data-on:<event>` attributes can catch component-emitted events — so `Action` + `InView` on the same element lets you write `data-on:in-view` / `data-on:out-of-view` declaratively.

## InView

- **Reveal on scroll** (`stories/reveal`) — `data-component="Action InView"` toggling an `is-visible` class on `in-view` / `out-of-view`; replays on every re-entry (CSS-driven animation).
- **Playing a Transition on scroll** (`stories/transition`) — `Action` drives a co-mounted `Transition`'s `enter()` / `leave()` from `in-view` / `out-of-view`.
- **Custom threshold / root margin** — snippet using the `intersectionObserver` option.
- Documented the `Action` usage in `index.md` and linked `examples.md`.

## InViewOnce

- **One-shot reveal** (`stories/reveal`) — `data-component="Action InViewOnce"` reveals once on entry, never replays, and never emits `out-of-view`; also demonstrates a custom `rootMargin`.
- Documented the `Action` usage in `index.md` and linked `examples.md`.

## Fetch

The `src` option (added in #536) was documented but had no example. Added a **Fetch from any element** section + `stories/src` story combining `Fetch` with `InViewOnce` and `Action` to lazy-load a `<div>` panel's content via a bare `fetch()` call resolving the `src` URL when it scrolls into view.

## ViewTransition

Added a small **Triggering with the `Action` component** recipe (`stories/action`), showing `enter()` / `leave()` / `toggle()` driven declaratively via `Action` without custom `onClick` handlers.

## Verification

- `npm run lint` passes (0 errors).
- `vitepress build` passes: all new example pages render and every `<<< ` story include resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)