### PR TITLE
Name the deprecated component in its deprecation warning

### DIFF
--- a/packages/ui/Modal/Modal.ts
+++ b/packages/ui/Modal/Modal.ts
@@ -49,7 +49,7 @@ export interface ModalProps extends BaseProps {
  */
 export class Modal<T extends BaseProps = BaseProps> extends withDeprecation(
   Base,
-  'The Modal component is deprecated, use the Dialog component instead: https://ui.studiometa.dev/components/Dialog/',
+  'Use the Dialog component instead: https://ui.studiometa.dev/components/Dialog/',
 )<T & ModalProps> {
   /**
    * Config.

--- a/packages/ui/decorators/withDeprecation.ts
+++ b/packages/ui/decorators/withDeprecation.ts
@@ -42,7 +42,8 @@ export function withDeprecation<S extends Base>(
       super(...args);
       this.$on('after-mounted', () => {
         if (isDev) {
-          console.warn(message ?? `The ${this.$options.name} component is deprecated.`);
+          const notice = `The ${this.$options.name} component is deprecated.`;
+          console.warn(message ? `${notice} ${message}` : notice);
         }
       });
     }


### PR DESCRIPTION
## Summary

Small follow-up to #540. The deprecation warning now names the actual component that emitted it.

`withDeprecation` was warning with the passed message verbatim, so `Panel` and `ModalWithTransition` (which extend `Modal` and inherit its message) logged *"The Modal component is deprecated…"* even though the author was using `Panel`.

- `withDeprecation` now builds a name-aware notice from the instance's own name — `The ${this.$options.name} component is deprecated.` — and appends the optional message (the replacement pointer).
- `Modal`'s message drops the now-redundant `"The Modal component is deprecated,"` prefix, keeping just `"Use the Dialog component instead: …"`.

Result:
- `Modal` → `The Modal component is deprecated. Use the Dialog component instead: …`
- `Panel` → `The Panel component is deprecated. Use the Dialog component instead: …`

Dev-only (`isDev`), single concatenated string — the existing Modal deprecation spec (which asserts both the notice and the URL against the same call) passes unchanged.

## Test plan
- `npm run test` — 462 passed / 3 skipped / 1 todo.
- `npm run lint` — 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)