### PR TITLE
Standardize docs examples on registerComponent

### DIFF
--- a/packages/docs/components/Accordion/index.md
+++ b/packages/docs/components/Accordion/index.md
@@ -8,20 +8,11 @@ badges: [Twig, JS]
 
 After you install the [package](/guide/installation/), include the template in your project:
 
-```js{2,8}
-import { Base, createApp } from '@studiometa/js-toolkit';
+```js
+import { registerComponent } from '@studiometa/js-toolkit';
 import { Accordion } from '@studiometa/ui';
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      Accordion,
-    },
-  };
-}
-
-export default createApp(App, document.body);
+registerComponent(Accordion);
 ```
 
 ```twig{16}

--- a/packages/docs/components/Accordion/stories/app.js
+++ b/packages/docs/components/Accordion/stories/app.js
@@ -1,13 +1,4 @@
-import { Base, createApp } from '@studiometa/js-toolkit';
+import { registerComponent } from '@studiometa/js-toolkit';
 import { Accordion } from '@studiometa/ui';
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      Accordion,
-    },
-  };
-}
-
-export default createApp(App, document.body);
+registerComponent(Accordion);

--- a/packages/docs/components/Action/stories/basic/app.js
+++ b/packages/docs/components/Action/stories/basic/app.js
@@ -1,14 +1,5 @@
-import { Base, createApp } from '@studiometa/js-toolkit';
+import { registerComponent } from '@studiometa/js-toolkit';
 import { Action, Transition } from '@studiometa/ui';
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      Action,
-      Transition,
-    },
-  };
-}
-
-export default createApp(App, document.body);
+registerComponent(Action);
+registerComponent(Transition);

--- a/packages/docs/components/Action/stories/counter/app.js
+++ b/packages/docs/components/Action/stories/counter/app.js
@@ -1,15 +1,6 @@
-import { Base, createApp } from '@studiometa/js-toolkit';
+import { registerComponent } from '@studiometa/js-toolkit';
 import { Action, DataBind, DataComputed } from '@studiometa/ui';
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      Action,
-      DataBind,
-      DataComputed,
-    },
-  };
-}
-
-export default createApp(App);
+registerComponent(Action);
+registerComponent(DataBind);
+registerComponent(DataComputed);

--- a/packages/docs/components/Action/stories/debounce/app.js
+++ b/packages/docs/components/Action/stories/debounce/app.js
@@ -1,13 +1,4 @@
-import { Base, createApp } from '@studiometa/js-toolkit';
+import { registerComponent } from '@studiometa/js-toolkit';
 import { Action } from '@studiometa/ui';
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      Action,
-    },
-  };
-}
-
-export default createApp(App);
+registerComponent(Action);

--- a/packages/docs/components/Action/stories/multiple-events/app.js
+++ b/packages/docs/components/Action/stories/multiple-events/app.js
@@ -1,14 +1,5 @@
-import { Base, createApp } from '@studiometa/js-toolkit';
+import { registerComponent } from '@studiometa/js-toolkit';
 import { Action, Transition } from '@studiometa/ui';
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      Action,
-      Transition,
-    },
-  };
-}
-
-export default createApp(App, document.body);
+registerComponent(Action);
+registerComponent(Transition);

--- a/packages/docs/components/Action/stories/prevent-default/app.js
+++ b/packages/docs/components/Action/stories/prevent-default/app.js
@@ -1,4 +1,4 @@
-import { Base, createApp } from '@studiometa/js-toolkit';
+import { Base, registerComponent } from '@studiometa/js-toolkit';
 import { Action } from '@studiometa/ui';
 
 class Foo extends Base {
@@ -7,14 +7,5 @@ class Foo extends Base {
   };
 }
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      Action,
-      Foo,
-    },
-  };
-}
-
-export default createApp(App);
+registerComponent(Action);
+registerComponent(Foo);

--- a/packages/docs/components/Action/stories/target/app.js
+++ b/packages/docs/components/Action/stories/target/app.js
@@ -1,14 +1,5 @@
-import { Base, createApp } from '@studiometa/js-toolkit';
+import { registerComponent } from '@studiometa/js-toolkit';
 import { Action, Target } from '@studiometa/ui';
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      Action,
-      Target,
-    },
-  };
-}
-
-export default createApp(App);
+registerComponent(Action);
+registerComponent(Target);

--- a/packages/docs/components/AnchorNav/index.md
+++ b/packages/docs/components/AnchorNav/index.md
@@ -8,20 +8,11 @@ badges: [JS, Twig]
 
 This component can be directly imported and defined as a dependency of your application:
 
-```js{2,8}
-import { Base, createApp } from '@studiometa/js-toolkit';
+```js
+import { registerComponent } from '@studiometa/js-toolkit';
 import { AnchorNav } from '@studiometa/ui';
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      AnchorNav,
-    },
-  };
-}
-
-export default createApp(App, document.body);
+registerComponent(AnchorNav);
 ```
 
 Then in your html make sure to have similar id and href for the link and the target.

--- a/packages/docs/components/AnchorNav/stories/app.js
+++ b/packages/docs/components/AnchorNav/stories/app.js
@@ -1,16 +1,4 @@
-import { Base, createApp } from '@studiometa/js-toolkit';
+import { registerComponent } from '@studiometa/js-toolkit';
 import { AnchorNav } from '@studiometa/ui';
 
-/**
- *
- */
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      AnchorNav,
-    },
-  };
-}
-
-createApp(App, document.body);
+registerComponent(AnchorNav);

--- a/packages/docs/components/AnchorScrollto/index.md
+++ b/packages/docs/components/AnchorScrollto/index.md
@@ -14,16 +14,9 @@ It should be used on `<a>` elements only.
 
 This component can be directly imported and defined as a dependency of your application and set up to be instanciated on elements matching the `a[href^="#"]` selector:
 
-```js {2,8}
-import { Base, createApp } from '@studiometa/js-toolkit';
+```js
+import { registerComponent } from '@studiometa/js-toolkit';
 import { AnchorScrollTo } from '@studiometa/ui';
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      'a[href^="#"]': AnchorScrollTo,
-    },
-  };
-}
+registerComponent(AnchorScrollTo, 'a[href^="#"]');
 ```

--- a/packages/docs/components/AnchorScrollto/stories/app.js
+++ b/packages/docs/components/AnchorScrollto/stories/app.js
@@ -1,13 +1,4 @@
-import { Base, createApp } from '@studiometa/js-toolkit';
+import { registerComponent } from '@studiometa/js-toolkit';
 import { AnchorScrollTo } from '@studiometa/ui';
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      'a[href^="#"]': AnchorScrollTo,
-    },
-  };
-}
-
-export default createApp(App);
+registerComponent(AnchorScrollTo, 'a[href^="#"]');

--- a/packages/docs/components/CircularMarquee/index.md
+++ b/packages/docs/components/CircularMarquee/index.md
@@ -20,17 +20,8 @@ After you install the [package](/guide/installation/), include the Twig template
 ```
 
 ```js
-import { Base, createApp } from '@studiometa/js-toolkit';
+import { registerComponent } from '@studiometa/js-toolkit';
 import { CircularMarquee } from '@studiometa/ui';
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      CircularMarquee,
-    },
-  };
-}
-
-export default createApp(App);
+registerComponent(CircularMarquee);
 ```

--- a/packages/docs/components/CircularMarquee/stories/app.js
+++ b/packages/docs/components/CircularMarquee/stories/app.js
@@ -1,13 +1,4 @@
-import { Base, createApp } from '@studiometa/js-toolkit';
+import { registerComponent } from '@studiometa/js-toolkit';
 import { CircularMarquee } from '@studiometa/ui';
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      CircularMarquee,
-    },
-  };
-}
-
-export default createApp(App, document.body);
+registerComponent(CircularMarquee);

--- a/packages/docs/components/Cursor/index.md
+++ b/packages/docs/components/Cursor/index.md
@@ -10,20 +10,11 @@ Use the cursor component to add a custom cursor to your project.
 
 After you install the [package](/guide/installation/), include the template in your project:
 
-```js {2,8}
-import { Base, createApp } from '@studiometa/js-toolkit';
+```js
+import { registerComponent } from '@studiometa/js-toolkit';
 import { Cursor } from '@studiometa/ui';
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      Cursor,
-    },
-  };
-}
-
-export default createApp(App);
+registerComponent(Cursor);
 ```
 
 ```twig

--- a/packages/docs/components/Cursor/stories/app.js
+++ b/packages/docs/components/Cursor/stories/app.js
@@ -1,13 +1,4 @@
-import { Base, createApp } from '@studiometa/js-toolkit';
+import { registerComponent } from '@studiometa/js-toolkit';
 import { Cursor } from '@studiometa/ui';
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      Cursor,
-    },
-  };
-}
-
-export default createApp(App, document.body);
+registerComponent(Cursor);

--- a/packages/docs/components/Dialog/index.md
+++ b/packages/docs/components/Dialog/index.md
@@ -14,22 +14,13 @@ A drawer is not a separate component. It is a `Dialog` whose panel you anchor to
 
 Register the component, along with the [`Action`](/components/Action/) and [`Transition`](/components/Transition/) components used by the authored HTML:
 
-```js{2,8-10}
-import { Base, createApp } from '@studiometa/js-toolkit';
+```js
+import { registerComponent } from '@studiometa/js-toolkit';
 import { Action, Dialog, Transition } from '@studiometa/ui';
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      Action,
-      Dialog,
-      Transition,
-    },
-  };
-}
-
-export default createApp(App, document.body);
+registerComponent(Action);
+registerComponent(Dialog);
+registerComponent(Transition);
 ```
 
 The `<dialog>` becomes a transparent, full-viewport host. Inside it live an optional backdrop and the box, each a transition child with its own hidden/shown classes. Triggers are delegated to `Action`:

--- a/packages/docs/components/Dialog/stories/drawer/app.js
+++ b/packages/docs/components/Dialog/stories/drawer/app.js
@@ -1,15 +1,6 @@
-import { Base, createApp } from '@studiometa/js-toolkit';
+import { registerComponent } from '@studiometa/js-toolkit';
 import { Action, Dialog, ViewTransition } from '@studiometa/ui';
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      Action,
-      Dialog,
-      ViewTransition,
-    },
-  };
-}
-
-export default createApp(App);
+registerComponent(Action);
+registerComponent(Dialog);
+registerComponent(ViewTransition);

--- a/packages/docs/components/Dialog/stories/modal/app.js
+++ b/packages/docs/components/Dialog/stories/modal/app.js
@@ -1,15 +1,6 @@
-import { Base, createApp } from '@studiometa/js-toolkit';
+import { registerComponent } from '@studiometa/js-toolkit';
 import { Action, Dialog, Transition } from '@studiometa/ui';
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      Action,
-      Dialog,
-      Transition,
-    },
-  };
-}
-
-export default createApp(App);
+registerComponent(Action);
+registerComponent(Dialog);
+registerComponent(Transition);

--- a/packages/docs/components/Draggable/index.md
+++ b/packages/docs/components/Draggable/index.md
@@ -11,19 +11,10 @@ Use this component to add drag capabilities to an element.
 ::: code-group
 
 ```js twoslash [app.js]
-import { Base, createApp } from '@studiometa/js-toolkit';
+import { registerComponent } from '@studiometa/js-toolkit';
 import { Draggable } from '@studiometa/ui';
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      Draggable,
-    },
-  };
-}
-
-export default createApp(App);
+registerComponent(Draggable);
 ```
 
 ```html [index.html]

--- a/packages/docs/components/Draggable/stories/app.js
+++ b/packages/docs/components/Draggable/stories/app.js
@@ -1,13 +1,4 @@
-import { Base, createApp } from '@studiometa/js-toolkit';
+import { registerComponent } from '@studiometa/js-toolkit';
 import { Draggable } from '@studiometa/ui';
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      Draggable,
-    },
-  };
-}
-
-export default createApp(App);
+registerComponent(Draggable);

--- a/packages/docs/components/Draggable/stories/bounds/app.js
+++ b/packages/docs/components/Draggable/stories/bounds/app.js
@@ -1,13 +1,4 @@
-import { Base, createApp } from '@studiometa/js-toolkit';
+import { registerComponent } from '@studiometa/js-toolkit';
 import { Draggable } from '@studiometa/ui';
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      Draggable,
-    },
-  };
-}
-
-export default createApp(App);
+registerComponent(Draggable);

--- a/packages/docs/components/Draggable/stories/carousel/app.js
+++ b/packages/docs/components/Draggable/stories/carousel/app.js
@@ -1,14 +1,5 @@
-import { Base, createApp } from '@studiometa/js-toolkit';
+import { registerComponent } from '@studiometa/js-toolkit';
 import { Draggable, Figure } from '@studiometa/ui';
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      Draggable,
-      Figure,
-    },
-  };
-}
-
-export default createApp(App);
+registerComponent(Draggable);
+registerComponent(Figure);

--- a/packages/docs/components/Draggable/stories/dynamic-parent/app.js
+++ b/packages/docs/components/Draggable/stories/dynamic-parent/app.js
@@ -1,4 +1,4 @@
-import { Base, createApp } from '@studiometa/js-toolkit';
+import { registerComponent } from '@studiometa/js-toolkit';
 import { Draggable as DraggableCore, Action } from '@studiometa/ui';
 
 class Draggable extends DraggableCore {
@@ -7,14 +7,5 @@ class Draggable extends DraggableCore {
   }
 }
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      Draggable,
-      Action,
-    },
-  };
-}
-
-export default createApp(App);
+registerComponent(Draggable);
+registerComponent(Action);

--- a/packages/docs/components/Draggable/stories/margin/app.js
+++ b/packages/docs/components/Draggable/stories/margin/app.js
@@ -1,13 +1,4 @@
-import { Base, createApp } from '@studiometa/js-toolkit';
+import { registerComponent } from '@studiometa/js-toolkit';
 import { Draggable } from '@studiometa/ui';
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      Draggable,
-    },
-  };
-}
-
-export default createApp(App);
+registerComponent(Draggable);

--- a/packages/docs/components/Draggable/stories/strict-bounds/app.js
+++ b/packages/docs/components/Draggable/stories/strict-bounds/app.js
@@ -1,13 +1,4 @@
-import { Base, createApp } from '@studiometa/js-toolkit';
+import { registerComponent } from '@studiometa/js-toolkit';
 import { Draggable } from '@studiometa/ui';
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      Draggable,
-    },
-  };
-}
-
-export default createApp(App);
+registerComponent(Draggable);

--- a/packages/docs/components/Figure/index.md
+++ b/packages/docs/components/Figure/index.md
@@ -10,20 +10,11 @@ Use the `Figure` component to display images.
 
 Register the component in your JavaScript app and use the Twig template to display images.
 
-```js twoslash {2,8}
-import { Base, createApp } from '@studiometa/js-toolkit';
+```js twoslash
+import { registerComponent } from '@studiometa/js-toolkit';
 import { Figure } from '@studiometa/ui';
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      Figure,
-    },
-  };
-}
-
-export default createApp(App);
+registerComponent(Figure);
 ```
 
 ```twig

--- a/packages/docs/components/Figure/stories/lazyload/app.js
+++ b/packages/docs/components/Figure/stories/lazyload/app.js
@@ -1,13 +1,4 @@
-import { Base, createApp } from '@studiometa/js-toolkit';
+import { registerComponent } from '@studiometa/js-toolkit';
 import { Figure } from '@studiometa/ui';
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      Figure,
-    },
-  };
-}
-
-export default createApp(App, document.body);
+registerComponent(Figure);

--- a/packages/docs/components/FigureShopify/index.md
+++ b/packages/docs/components/FigureShopify/index.md
@@ -10,20 +10,11 @@ Use the `FigureShopify` component to display responsive images with [Shopify CDN
 
 Register the component in your JavaScript app and use it in your templates. The component will transform the `data-src` URL to load an image at the dimension of the `<img>` DOM element.
 
-```js {2,8}
-import { Base, createApp } from '@studiometa/js-toolkit';
+```js
+import { registerComponent } from '@studiometa/js-toolkit';
 import { FigureShopify } from '@studiometa/ui';
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      Figure: FigureShopify,
-    },
-  };
-}
-
-export default createApp(App);
+registerComponent(FigureShopify, 'Figure');
 ```
 
 ```liquid

--- a/packages/docs/components/FigureShopify/stories/app.js
+++ b/packages/docs/components/FigureShopify/stories/app.js
@@ -1,13 +1,4 @@
-import { Base, createApp } from '@studiometa/js-toolkit';
+import { registerComponent } from '@studiometa/js-toolkit';
 import { FigureShopify } from '@studiometa/ui';
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      Figure: FigureShopify,
-    },
-  };
-}
-
-export default createApp(App, document.body);
+registerComponent(FigureShopify, 'Figure');

--- a/packages/docs/components/FigureTwicpics/index.md
+++ b/packages/docs/components/FigureTwicpics/index.md
@@ -10,20 +10,11 @@ Use the `FigureTwicpics` component to display images with the Twicpics API.
 
 Register the component in your JavaScript app and use the Twig template to display images.
 
-```js {2,8}
-import { Base, createApp } from '@studiometa/js-toolkit';
+```js
+import { registerComponent } from '@studiometa/js-toolkit';
 import { FigureTwicpics } from '@studiometa/ui';
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      Figure: FigureTwicpics,
-    },
-  };
-}
-
-export default createApp(App);
+registerComponent(FigureTwicpics, 'Figure');
 ```
 
 ```twig

--- a/packages/docs/components/FigureTwicpics/stories/twicpics/app.js
+++ b/packages/docs/components/FigureTwicpics/stories/twicpics/app.js
@@ -1,4 +1,4 @@
-import { Base, createApp } from '@studiometa/js-toolkit';
+import { registerComponent } from '@studiometa/js-toolkit';
 import { FigureTwicpics } from '@studiometa/ui';
 
 class Figure extends FigureTwicpics {
@@ -11,13 +11,4 @@ class Figure extends FigureTwicpics {
   }
 }
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      Figure,
-    },
-  };
-}
-
-export default createApp(App, document.body);
+registerComponent(Figure, 'Figure');

--- a/packages/docs/components/FigureVideo/index.md
+++ b/packages/docs/components/FigureVideo/index.md
@@ -10,20 +10,11 @@ Use the `FigureVideo` component to display loop, muted & autoplay decorative vid
 
 Register the component in your JavaScript app and use the Twig template to display videos.
 
-```js {2,8}
-import { Base, createApp } from '@studiometa/js-toolkit';
+```js
+import { registerComponent } from '@studiometa/js-toolkit';
 import { FigureVideo } from '@studiometa/ui';
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      FigureVideo,
-    },
-  };
-}
-
-export default createApp(App);
+registerComponent(FigureVideo);
 ```
 
 ```twig

--- a/packages/docs/components/FigureVideo/stories/lazyload/app.js
+++ b/packages/docs/components/FigureVideo/stories/lazyload/app.js
@@ -1,13 +1,4 @@
-import { Base, createApp } from '@studiometa/js-toolkit';
+import { registerComponent } from '@studiometa/js-toolkit';
 import { FigureVideo } from '@studiometa/ui';
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      FigureVideo,
-    },
-  };
-}
-
-export default createApp(App, document.body);
+registerComponent(FigureVideo);

--- a/packages/docs/components/FigureVideoTwicpics/index.md
+++ b/packages/docs/components/FigureVideoTwicpics/index.md
@@ -10,20 +10,11 @@ Use the `FigureVideoTwicpics` component to display loop, muted & autoplay decora
 
 Register the component in your JavaScript app and use the Twig template to display videos.
 
-```js {2,8}
-import { Base, createApp } from '@studiometa/js-toolkit';
+```js
+import { registerComponent } from '@studiometa/js-toolkit';
 import { FigureVideoTwicpics } from '@studiometa/ui';
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      FigureVideo: FigureVideoTwicpics,
-    },
-  };
-}
-
-export default createApp(App);
+registerComponent(FigureVideoTwicpics, 'FigureVideo');
 ```
 
 ```twig

--- a/packages/docs/components/FigureVideoTwicpics/stories/twicpics/app.js
+++ b/packages/docs/components/FigureVideoTwicpics/stories/twicpics/app.js
@@ -1,4 +1,4 @@
-import { Base, createApp } from '@studiometa/js-toolkit';
+import { registerComponent } from '@studiometa/js-toolkit';
 import { FigureVideoTwicpics } from '@studiometa/ui';
 
 class FigureVideo extends FigureVideoTwicpics {
@@ -11,13 +11,4 @@ class FigureVideo extends FigureVideoTwicpics {
   }
 }
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      FigureVideo,
-    },
-  };
-}
-
-export default createApp(App, document.body);
+registerComponent(FigureVideo, 'FigureVideo');

--- a/packages/docs/components/Frame/index.md
+++ b/packages/docs/components/Frame/index.md
@@ -11,19 +11,10 @@ The `Frame` component and its children `FrameForm`, `FrameTarget`, `FrameAnchor`
 Only include the `Frame` component in your app, as it loads all the others automatically.
 
 ```js twoslash
-import { Base, createApp } from '@studiometa/js-toolkit';
+import { registerComponent } from '@studiometa/js-toolkit';
 import { Frame } from '@studiometa/ui';
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      Frame,
-    },
-  };
-}
-
-export default createApp(App);
+registerComponent(Frame);
 ```
 
 ### Frame

--- a/packages/docs/components/Frame/stories/modes/app.js
+++ b/packages/docs/components/Frame/stories/modes/app.js
@@ -1,13 +1,4 @@
-import { Base, createApp } from '@studiometa/js-toolkit';
+import { registerComponent } from '@studiometa/js-toolkit';
 import { Frame } from '@studiometa/ui';
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      Frame,
-    }
-  };
-}
-
-export default createApp(App);
+registerComponent(Frame);

--- a/packages/docs/components/Frame/stories/simple/app.js
+++ b/packages/docs/components/Frame/stories/simple/app.js
@@ -1,13 +1,4 @@
-import { Base, createApp } from '@studiometa/js-toolkit';
+import { registerComponent } from '@studiometa/js-toolkit';
 import { Frame } from '@studiometa/ui';
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      Frame,
-    },
-  };
-}
-
-export default createApp(App);
+registerComponent(Frame);

--- a/packages/docs/components/Hero/stories/app.js
+++ b/packages/docs/components/Hero/stories/app.js
@@ -1,4 +1,4 @@
-import { Base, createApp } from '@studiometa/js-toolkit';
+import { registerComponent } from '@studiometa/js-toolkit';
 import {
   Figure,
   Slider as SliderCore,
@@ -23,14 +23,5 @@ class Slider extends SliderCore {
   };
 }
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      Figure,
-      Slider,
-    },
-  };
-}
-
-export default createApp(App, document.body);
+registerComponent(Figure);
+registerComponent(Slider, 'Slider');

--- a/packages/docs/components/Hoverable/index.md
+++ b/packages/docs/components/Hoverable/index.md
@@ -11,19 +11,10 @@ Use this component to move an oversized element within its parent bounds.
 ::: code-group
 
 ```js twoslash [app.js]
-import { Base, createApp } from '@studiometa/js-toolkit';
+import { registerComponent } from '@studiometa/js-toolkit';
 import { Hoverable } from '@studiometa/ui';
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      Hoverable,
-    },
-  };
-}
-
-export default createApp(App);
+registerComponent(Hoverable);
 ```
 
 ```html [index.html]

--- a/packages/docs/components/Hoverable/stories/app.js
+++ b/packages/docs/components/Hoverable/stories/app.js
@@ -1,14 +1,5 @@
-import { Base, createApp } from '@studiometa/js-toolkit';
+import { registerComponent } from '@studiometa/js-toolkit';
 import { Hoverable, Figure } from '@studiometa/ui';
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      Hoverable,
-      Figure,
-    },
-  };
-}
-
-export default createApp(App);
+registerComponent(Hoverable);
+registerComponent(Figure);

--- a/packages/docs/components/ImageGrid/stories/app.js
+++ b/packages/docs/components/ImageGrid/stories/app.js
@@ -1,13 +1,4 @@
-import { Base, createApp } from '@studiometa/js-toolkit';
+import { registerComponent } from '@studiometa/js-toolkit';
 import { Figure } from '@studiometa/ui';
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      Figure,
-    },
-  };
-}
-
-export default createApp(App);
+registerComponent(Figure);

--- a/packages/docs/components/ImageGrid/stories/block-image/app.js
+++ b/packages/docs/components/ImageGrid/stories/block-image/app.js
@@ -1,14 +1,5 @@
-import { Base, createApp } from '@studiometa/js-toolkit';
+import { registerComponent } from '@studiometa/js-toolkit';
 import { Figure, ScrollReveal } from '@studiometa/ui';
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      Figure,
-      ScrollReveal,
-    },
-  };
-}
-
-export default createApp(App);
+registerComponent(Figure);
+registerComponent(ScrollReveal);

--- a/packages/docs/components/LargeText/stories/app.js
+++ b/packages/docs/components/LargeText/stories/app.js
@@ -1,13 +1,4 @@
-import { Base, createApp } from '@studiometa/js-toolkit';
+import { registerComponent } from '@studiometa/js-toolkit';
 import { LargeText } from '@studiometa/ui';
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      LargeText,
-    },
-  };
-}
-
-export default createApp(App);
+registerComponent(LargeText);

--- a/packages/docs/components/LazyInclude/index.md
+++ b/packages/docs/components/LazyInclude/index.md
@@ -10,20 +10,11 @@ Use the `LazyInclude` component to load parts of your page lazily.
 
 ::: code-group
 
-```js [app.js] twoslash {2,8}
-import { Base, createApp } from '@studiometa/js-toolkit';
+```js [app.js] twoslash
+import { registerComponent } from '@studiometa/js-toolkit';
 import { LazyInclude } from '@studiometa/ui';
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      LazyInclude,
-    },
-  };
-}
-
-createApp(App);
+registerComponent(LazyInclude);
 ```
 
 ```html index.html

--- a/packages/docs/components/LazyInclude/stories/app.js
+++ b/packages/docs/components/LazyInclude/stories/app.js
@@ -1,13 +1,4 @@
-import { Base, createApp } from '@studiometa/js-toolkit';
+import { registerComponent } from '@studiometa/js-toolkit';
 import { LazyInclude } from '@studiometa/ui';
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      LazyInclude,
-    },
-  };
-}
-
-createApp(App);
+registerComponent(LazyInclude);

--- a/packages/docs/components/MapboxStaticMap/index.md
+++ b/packages/docs/components/MapboxStaticMap/index.md
@@ -10,20 +10,11 @@ The `MapboxStaticMap` component can be used to display custom maps anywhere, wit
 
 Register the [Figure](/components/Figure/) component in your JavaScript app and use the Twig template to display images.
 
-```js {2,8}
-import { Base, createApp } from '@studiometa/js-toolkit';
+```js
+import { registerComponent } from '@studiometa/js-toolkit';
 import { Figure } from '@studiometa/ui';
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      Figure,
-    },
-  };
-}
-
-export default createApp(App);
+registerComponent(Figure);
 ```
 
 ```twig{5}

--- a/packages/docs/components/MapboxStaticMap/stories/app.js
+++ b/packages/docs/components/MapboxStaticMap/stories/app.js
@@ -1,13 +1,4 @@
-import { Base, createApp } from '@studiometa/js-toolkit';
+import { registerComponent } from '@studiometa/js-toolkit';
 import { Figure } from '@studiometa/ui';
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      Figure,
-    },
-  };
-}
-
-export default createApp(App, document.body);
+registerComponent(Figure);

--- a/packages/docs/components/Menu/index.md
+++ b/packages/docs/components/Menu/index.md
@@ -10,20 +10,11 @@ The `Menu` component and its children `MenuBtn` and `MenuList` can be used to cr
 
 ::: code-group
 
-```js twoslash {2,8} [app.js]
-import { Base, createApp } from '@studiometa/js-toolkit';
+```js twoslash [app.js]
+import { registerComponent } from '@studiometa/js-toolkit';
 import { Menu } from '@studiometa/ui';
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      Menu,
-    },
-  };
-}
-
-export default createApp(App);
+registerComponent(Menu);
 ```
 
 ```html [index.html]

--- a/packages/docs/components/Menu/stories/burger/app.js
+++ b/packages/docs/components/Menu/stories/burger/app.js
@@ -1,13 +1,4 @@
-import { Base, createApp } from '@studiometa/js-toolkit';
+import { registerComponent } from '@studiometa/js-toolkit';
 import { Menu } from '@studiometa/ui';
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      Menu,
-    },
-  };
-}
-
-createApp(App);
+registerComponent(Menu);

--- a/packages/docs/components/Menu/stories/dropdown/app.js
+++ b/packages/docs/components/Menu/stories/dropdown/app.js
@@ -1,13 +1,4 @@
-import { Base, createApp } from '@studiometa/js-toolkit';
+import { registerComponent } from '@studiometa/js-toolkit';
 import { Menu } from '@studiometa/ui';
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      Menu,
-    },
-  };
-}
-
-createApp(App);
+registerComponent(Menu);

--- a/packages/docs/components/Menu/stories/mega-menu-responsive/app.js
+++ b/packages/docs/components/Menu/stories/mega-menu-responsive/app.js
@@ -1,4 +1,7 @@
-import { Base, createApp, withResponsiveOptions } from '@studiometa/js-toolkit';
+import {
+  registerComponent,
+  withResponsiveOptions,
+} from '@studiometa/js-toolkit';
 import { Menu as MenuCore } from '@studiometa/ui';
 
 class Menu extends withResponsiveOptions(MenuCore, {
@@ -13,13 +16,4 @@ class Menu extends withResponsiveOptions(MenuCore, {
   };
 }
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      Menu,
-    },
-  };
-}
-
-createApp(App);
+registerComponent(Menu);

--- a/packages/docs/components/Menu/stories/mega-menu/app.js
+++ b/packages/docs/components/Menu/stories/mega-menu/app.js
@@ -1,14 +1,5 @@
-import { Base, createApp } from '@studiometa/js-toolkit';
+import { registerComponent } from '@studiometa/js-toolkit';
 import { Menu, Action } from '@studiometa/ui';
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      Menu,
-      Action,
-    },
-  };
-}
-
-createApp(App, document.body);
+registerComponent(Menu);
+registerComponent(Action);

--- a/packages/docs/components/Modal/index.md
+++ b/packages/docs/components/Modal/index.md
@@ -14,20 +14,11 @@ The `Modal` component creates accessible modal dialogs with focus management, ke
 
 After you install the [package](/guide/installation/), include the template in your project:
 
-```js{2,8}
-import { Base, createApp } from '@studiometa/js-toolkit';
+```js
+import { registerComponent } from '@studiometa/js-toolkit';
 import { Modal } from '@studiometa/ui';
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      Modal,
-    },
-  };
-}
-
-export default createApp(App, document.body);
+registerComponent(Modal);
 ```
 
 ```twig

--- a/packages/docs/components/Modal/stories/simple/app.js
+++ b/packages/docs/components/Modal/stories/simple/app.js
@@ -1,13 +1,4 @@
-import { Base, createApp } from '@studiometa/js-toolkit';
+import { registerComponent } from '@studiometa/js-toolkit';
 import { Modal } from '@studiometa/ui';
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      Modal,
-    },
-  };
-}
-
-export default createApp(App, document.body);
+registerComponent(Modal);

--- a/packages/docs/components/Modal/stories/transition/app.js
+++ b/packages/docs/components/Modal/stories/transition/app.js
@@ -1,13 +1,4 @@
-import { Base, createApp } from '@studiometa/js-toolkit';
+import { registerComponent } from '@studiometa/js-toolkit';
 import { ModalWithTransition } from '@studiometa/ui';
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      Modal: ModalWithTransition,
-    },
-  };
-}
-
-export default createApp(App, document.body);
+registerComponent(ModalWithTransition, 'Modal');

--- a/packages/docs/components/Panel/index.md
+++ b/packages/docs/components/Panel/index.md
@@ -14,20 +14,11 @@ The `Panel` component extends the `Modal` component to create slide-in panels fr
 
 After you install the [package](/guide/installation/), include the template in your project:
 
-```js{2,8}
-import { Base, createApp } from '@studiometa/js-toolkit';
+```js
+import { registerComponent } from '@studiometa/js-toolkit';
 import { Panel } from '@studiometa/ui';
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      Panel,
-    },
-  };
-}
-
-export default createApp(App, document.body);
+registerComponent(Panel);
 ```
 
 ```twig

--- a/packages/docs/components/Panel/stories/app.js
+++ b/packages/docs/components/Panel/stories/app.js
@@ -1,13 +1,4 @@
-import { Base, createApp } from '@studiometa/js-toolkit';
+import { registerComponent } from '@studiometa/js-toolkit';
 import { Panel } from '@studiometa/ui';
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      Panel,
-    },
-  };
-}
-
-export default createApp(App, document.body);
+registerComponent(Panel);

--- a/packages/docs/components/Prefetch/index.md
+++ b/packages/docs/components/Prefetch/index.md
@@ -12,21 +12,12 @@ Import one of the available prefetch component in you app and use them in your H
 
 ::: code-group
 
-```js twoslash [app.js] {2,8-9}
-import { Base, createApp } from '@studiometa/js-toolkit';
+```js twoslash [app.js]
+import { registerComponent } from '@studiometa/js-toolkit';
 import { PrefetchWhenOver, PrefetchWhenVisible } from '@studiometa/ui';
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      PrefetchWhenOver,
-      PrefetchWhenVisible,
-    },
-  };
-}
-
-export default createApp(App);
+registerComponent(PrefetchWhenOver);
+registerComponent(PrefetchWhenVisible);
 ```
 
 ```html [index.html]

--- a/packages/docs/components/ScrollAnimation/index.md
+++ b/packages/docs/components/ScrollAnimation/index.md
@@ -10,21 +10,12 @@ The `ScrollAnimation` component creates scroll-driven animations that respond to
 
 For the best performance and flexibility, use `ScrollAnimationTimeline` with `ScrollAnimationTarget` children:
 
-```js {2,8-9}
-import { Base, createApp } from '@studiometa/js-toolkit';
+```js
+import { registerComponent } from '@studiometa/js-toolkit';
 import { ScrollAnimationTimeline, ScrollAnimationTarget } from '@studiometa/ui';
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      ScrollAnimationTimeline,
-      ScrollAnimationTarget,
-    },
-  };
-}
-
-export default createApp(App, document.body);
+registerComponent(ScrollAnimationTimeline);
+registerComponent(ScrollAnimationTarget);
 ```
 
 ```html

--- a/packages/docs/components/ScrollAnimation/stories/cards/app.js
+++ b/packages/docs/components/ScrollAnimation/stories/cards/app.js
@@ -1,14 +1,5 @@
-import { Base, createApp } from '@studiometa/js-toolkit';
+import { registerComponent } from '@studiometa/js-toolkit';
 import { ScrollAnimationTimeline, ScrollAnimationTarget } from '@studiometa/ui';
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      ScrollAnimationTimeline,
-      ScrollAnimationTarget,
-    },
-  };
-}
-
-export default createApp(App);
+registerComponent(ScrollAnimationTimeline);
+registerComponent(ScrollAnimationTarget);

--- a/packages/docs/components/ScrollAnimation/stories/damp-factor/app.js
+++ b/packages/docs/components/ScrollAnimation/stories/damp-factor/app.js
@@ -1,14 +1,5 @@
-import { Base, createApp } from '@studiometa/js-toolkit';
+import { registerComponent } from '@studiometa/js-toolkit';
 import { ScrollAnimationTimeline, ScrollAnimationTarget } from '@studiometa/ui';
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      ScrollAnimationTimeline,
-      ScrollAnimationTarget,
-    },
-  };
-}
-
-export default createApp(App);
+registerComponent(ScrollAnimationTimeline);
+registerComponent(ScrollAnimationTarget);

--- a/packages/docs/components/ScrollAnimation/stories/debug/app.js
+++ b/packages/docs/components/ScrollAnimation/stories/debug/app.js
@@ -1,18 +1,12 @@
-import { Base, createApp } from '@studiometa/js-toolkit';
+import { registerComponent } from '@studiometa/js-toolkit';
 import {
   ScrollAnimationTimeline,
   ScrollAnimationTarget,
   withScrollAnimationDebug,
 } from '@studiometa/ui';
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      ScrollAnimationTimeline: withScrollAnimationDebug(ScrollAnimationTimeline),
-      ScrollAnimationTarget,
-    },
-  };
-}
-
-export default createApp(App);
+registerComponent(
+  withScrollAnimationDebug(ScrollAnimationTimeline),
+  'ScrollAnimationTimeline',
+);
+registerComponent(ScrollAnimationTarget);

--- a/packages/docs/components/ScrollAnimation/stories/easing/app.js
+++ b/packages/docs/components/ScrollAnimation/stories/easing/app.js
@@ -1,14 +1,5 @@
-import { Base, createApp } from '@studiometa/js-toolkit';
+import { registerComponent } from '@studiometa/js-toolkit';
 import { ScrollAnimationTimeline, ScrollAnimationTarget } from '@studiometa/ui';
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      ScrollAnimationTimeline,
-      ScrollAnimationTarget,
-    },
-  };
-}
-
-export default createApp(App);
+registerComponent(ScrollAnimationTimeline);
+registerComponent(ScrollAnimationTarget);

--- a/packages/docs/components/ScrollAnimation/stories/from-to/app.js
+++ b/packages/docs/components/ScrollAnimation/stories/from-to/app.js
@@ -1,14 +1,5 @@
-import { Base, createApp } from '@studiometa/js-toolkit';
+import { registerComponent } from '@studiometa/js-toolkit';
 import { ScrollAnimationTimeline, ScrollAnimationTarget } from '@studiometa/ui';
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      ScrollAnimationTimeline,
-      ScrollAnimationTarget,
-    },
-  };
-}
-
-export default createApp(App);
+registerComponent(ScrollAnimationTimeline);
+registerComponent(ScrollAnimationTarget);

--- a/packages/docs/components/ScrollAnimation/stories/keyframes/app.js
+++ b/packages/docs/components/ScrollAnimation/stories/keyframes/app.js
@@ -1,14 +1,5 @@
-import { Base, createApp } from '@studiometa/js-toolkit';
+import { registerComponent } from '@studiometa/js-toolkit';
 import { ScrollAnimationTimeline, ScrollAnimationTarget } from '@studiometa/ui';
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      ScrollAnimationTimeline,
-      ScrollAnimationTarget,
-    },
-  };
-}
-
-export default createApp(App);
+registerComponent(ScrollAnimationTimeline);
+registerComponent(ScrollAnimationTarget);

--- a/packages/docs/components/ScrollAnimation/stories/offset-center/app.js
+++ b/packages/docs/components/ScrollAnimation/stories/offset-center/app.js
@@ -1,18 +1,12 @@
-import { Base, createApp } from '@studiometa/js-toolkit';
+import { registerComponent } from '@studiometa/js-toolkit';
 import {
   ScrollAnimationTimeline,
   ScrollAnimationTarget,
   withScrollAnimationDebug,
 } from '@studiometa/ui';
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      ScrollAnimationTimeline: withScrollAnimationDebug(ScrollAnimationTimeline),
-      ScrollAnimationTarget,
-    },
-  };
-}
-
-export default createApp(App);
+registerComponent(
+  withScrollAnimationDebug(ScrollAnimationTimeline),
+  'ScrollAnimationTimeline',
+);
+registerComponent(ScrollAnimationTarget);

--- a/packages/docs/components/ScrollAnimation/stories/offset-default/app.js
+++ b/packages/docs/components/ScrollAnimation/stories/offset-default/app.js
@@ -1,18 +1,12 @@
-import { Base, createApp } from '@studiometa/js-toolkit';
+import { registerComponent } from '@studiometa/js-toolkit';
 import {
   ScrollAnimationTimeline,
   ScrollAnimationTarget,
   withScrollAnimationDebug,
 } from '@studiometa/ui';
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      ScrollAnimationTimeline: withScrollAnimationDebug(ScrollAnimationTimeline),
-      ScrollAnimationTarget,
-    },
-  };
-}
-
-export default createApp(App);
+registerComponent(
+  withScrollAnimationDebug(ScrollAnimationTimeline),
+  'ScrollAnimationTimeline',
+);
+registerComponent(ScrollAnimationTarget);

--- a/packages/docs/components/ScrollAnimation/stories/offset-numbered/app.js
+++ b/packages/docs/components/ScrollAnimation/stories/offset-numbered/app.js
@@ -1,18 +1,12 @@
-import { Base, createApp } from '@studiometa/js-toolkit';
+import { registerComponent } from '@studiometa/js-toolkit';
 import {
   ScrollAnimationTimeline,
   ScrollAnimationTarget,
   withScrollAnimationDebug,
 } from '@studiometa/ui';
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      ScrollAnimationTimeline: withScrollAnimationDebug(ScrollAnimationTimeline),
-      ScrollAnimationTarget,
-    },
-  };
-}
-
-export default createApp(App);
+registerComponent(
+  withScrollAnimationDebug(ScrollAnimationTimeline),
+  'ScrollAnimationTimeline',
+);
+registerComponent(ScrollAnimationTarget);

--- a/packages/docs/components/ScrollAnimation/stories/offset-percentage/app.js
+++ b/packages/docs/components/ScrollAnimation/stories/offset-percentage/app.js
@@ -1,18 +1,12 @@
-import { Base, createApp } from '@studiometa/js-toolkit';
+import { registerComponent } from '@studiometa/js-toolkit';
 import {
   ScrollAnimationTimeline,
   ScrollAnimationTarget,
   withScrollAnimationDebug,
 } from '@studiometa/ui';
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      ScrollAnimationTimeline: withScrollAnimationDebug(ScrollAnimationTimeline),
-      ScrollAnimationTarget,
-    },
-  };
-}
-
-export default createApp(App);
+registerComponent(
+  withScrollAnimationDebug(ScrollAnimationTimeline),
+  'ScrollAnimationTimeline',
+);
+registerComponent(ScrollAnimationTarget);

--- a/packages/docs/components/ScrollAnimation/stories/offset-top/app.js
+++ b/packages/docs/components/ScrollAnimation/stories/offset-top/app.js
@@ -1,18 +1,12 @@
-import { Base, createApp } from '@studiometa/js-toolkit';
+import { registerComponent } from '@studiometa/js-toolkit';
 import {
   ScrollAnimationTimeline,
   ScrollAnimationTarget,
   withScrollAnimationDebug,
 } from '@studiometa/ui';
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      ScrollAnimationTimeline: withScrollAnimationDebug(ScrollAnimationTimeline),
-      ScrollAnimationTarget,
-    },
-  };
-}
-
-export default createApp(App);
+registerComponent(
+  withScrollAnimationDebug(ScrollAnimationTimeline),
+  'ScrollAnimationTimeline',
+);
+registerComponent(ScrollAnimationTarget);

--- a/packages/docs/components/ScrollAnimation/stories/parallax/app.js
+++ b/packages/docs/components/ScrollAnimation/stories/parallax/app.js
@@ -1,4 +1,4 @@
-import { Base, createApp, withScrolledInView } from '@studiometa/js-toolkit';
+import { registerComponent, withScrolledInView } from '@studiometa/js-toolkit';
 import { Figure, ScrollAnimationTarget } from '@studiometa/ui';
 
 class Parallax extends withScrolledInView(ScrollAnimationTarget) {
@@ -15,13 +15,4 @@ class Parallax extends withScrolledInView(ScrollAnimationTarget) {
   }
 }
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      Parallax,
-    },
-  };
-}
-
-export default createApp(App);
+registerComponent(Parallax);

--- a/packages/docs/components/ScrollAnimation/stories/play-range/app.js
+++ b/packages/docs/components/ScrollAnimation/stories/play-range/app.js
@@ -1,14 +1,5 @@
-import { Base, createApp } from '@studiometa/js-toolkit';
+import { registerComponent } from '@studiometa/js-toolkit';
 import { ScrollAnimationTimeline, ScrollAnimationTarget } from '@studiometa/ui';
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      ScrollAnimationTimeline,
-      ScrollAnimationTarget,
-    },
-  };
-}
-
-export default createApp(App);
+registerComponent(ScrollAnimationTimeline);
+registerComponent(ScrollAnimationTarget);

--- a/packages/docs/components/ScrollAnimation/stories/sequence/app.js
+++ b/packages/docs/components/ScrollAnimation/stories/sequence/app.js
@@ -1,14 +1,5 @@
-import { Base, createApp } from '@studiometa/js-toolkit';
+import { registerComponent } from '@studiometa/js-toolkit';
 import { ScrollAnimationTimeline, ScrollAnimationTarget } from '@studiometa/ui';
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      ScrollAnimationTimeline,
-      ScrollAnimationTarget,
-    },
-  };
-}
-
-createApp(App);
+registerComponent(ScrollAnimationTimeline);
+registerComponent(ScrollAnimationTarget);

--- a/packages/docs/components/ScrollAnimation/stories/staggered/app.js
+++ b/packages/docs/components/ScrollAnimation/stories/staggered/app.js
@@ -1,14 +1,5 @@
-import { Base, createApp } from '@studiometa/js-toolkit';
+import { registerComponent } from '@studiometa/js-toolkit';
 import { ScrollAnimationTimeline, ScrollAnimationTarget } from '@studiometa/ui';
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      ScrollAnimationTimeline,
-      ScrollAnimationTarget,
-    },
-  };
-}
-
-createApp(App);
+registerComponent(ScrollAnimationTimeline);
+registerComponent(ScrollAnimationTarget);

--- a/packages/docs/components/ScrollAnimation/stories/sticky/app.js
+++ b/packages/docs/components/ScrollAnimation/stories/sticky/app.js
@@ -1,14 +1,5 @@
-import { Base, createApp } from '@studiometa/js-toolkit';
+import { registerComponent } from '@studiometa/js-toolkit';
 import { ScrollAnimationTimeline, ScrollAnimationTarget } from '@studiometa/ui';
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      ScrollAnimationTimeline,
-      ScrollAnimationTarget,
-    },
-  };
-}
-
-export default createApp(App);
+registerComponent(ScrollAnimationTimeline);
+registerComponent(ScrollAnimationTarget);

--- a/packages/docs/components/ScrollAnimation/stories/text/app.js
+++ b/packages/docs/components/ScrollAnimation/stories/text/app.js
@@ -1,14 +1,5 @@
-import { Base, createApp } from '@studiometa/js-toolkit';
+import { registerComponent } from '@studiometa/js-toolkit';
 import { ScrollAnimationTimeline, ScrollAnimationTarget } from '@studiometa/ui';
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      ScrollAnimationTimeline,
-      ScrollAnimationTarget,
-    },
-  };
-}
-
-export default createApp(App);
+registerComponent(ScrollAnimationTimeline);
+registerComponent(ScrollAnimationTarget);

--- a/packages/docs/components/ScrollReveal/index.md
+++ b/packages/docs/components/ScrollReveal/index.md
@@ -11,19 +11,10 @@ The `ScrollReveal` component should be used when you want to apply classes to an
 This component can directly be used in an application. It is based on the [`Transition` primitive](/components/Transition/) to manage its transition states under the hood.
 
 ```js
-import { Base, createApp } from '@studiometa/js-toolkit';
+import { registerComponent } from '@studiometa/js-toolkit';
 import { ScrollReveal } from '@studiometa/ui';
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      ScrollReveal,
-    },
-  };
-}
-
-export default createApp(App);
+registerComponent(ScrollReveal);
 ```
 
 ```html

--- a/packages/docs/components/ScrollReveal/stories/nested/app.js
+++ b/packages/docs/components/ScrollReveal/stories/nested/app.js
@@ -1,14 +1,5 @@
-import { Base, createApp } from '@studiometa/js-toolkit';
+import { registerComponent } from '@studiometa/js-toolkit';
 import { Figure, ScrollReveal } from '@studiometa/ui';
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      Figure,
-      ScrollReveal,
-    },
-  };
-}
-
-export default createApp(App);
+registerComponent(Figure);
+registerComponent(ScrollReveal);

--- a/packages/docs/components/ScrollReveal/stories/no-target-ref/app.js
+++ b/packages/docs/components/ScrollReveal/stories/no-target-ref/app.js
@@ -1,14 +1,5 @@
-import { Base, createApp } from '@studiometa/js-toolkit';
+import { registerComponent } from '@studiometa/js-toolkit';
 import { Figure, ScrollReveal } from '@studiometa/ui';
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      Figure,
-      ScrollReveal,
-    },
-  };
-}
-
-export default createApp(App);
+registerComponent(Figure);
+registerComponent(ScrollReveal);

--- a/packages/docs/components/ScrollReveal/stories/repeat/app.js
+++ b/packages/docs/components/ScrollReveal/stories/repeat/app.js
@@ -1,14 +1,5 @@
-import { Base, createApp } from '@studiometa/js-toolkit';
+import { registerComponent } from '@studiometa/js-toolkit';
 import { Figure, ScrollReveal } from '@studiometa/ui';
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      Figure,
-      ScrollReveal,
-    },
-  };
-}
-
-export default createApp(App);
+registerComponent(Figure);
+registerComponent(ScrollReveal);

--- a/packages/docs/components/ScrollReveal/stories/simple/app.js
+++ b/packages/docs/components/ScrollReveal/stories/simple/app.js
@@ -1,14 +1,5 @@
-import { Base, createApp } from '@studiometa/js-toolkit';
+import { registerComponent } from '@studiometa/js-toolkit';
 import { Figure, ScrollReveal } from '@studiometa/ui';
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      Figure,
-      ScrollReveal,
-    },
-  };
-}
-
-export default createApp(App);
+registerComponent(Figure);
+registerComponent(ScrollReveal);

--- a/packages/docs/components/Slider/index.md
+++ b/packages/docs/components/Slider/index.md
@@ -11,19 +11,10 @@ Use the `Slider` component to display items on the X axis and enable indexed nav
 ::: code-group
 
 ```js twoslash [app.js]
-import { Base, createApp } from '@studiometa/js-toolkit';
+import { registerComponent } from '@studiometa/js-toolkit';
 import { Slider } from '@studiometa/ui';
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      Slider,
-    },
-  };
-}
-
-export default createApp(App);
+registerComponent(Slider);
 ```
 
 ```twig [slider.twig]

--- a/packages/docs/components/Slider/stories/center/app.js
+++ b/packages/docs/components/Slider/stories/center/app.js
@@ -1,5 +1,4 @@
-/* eslint-disable max-classes-per-file */
-import { Base, createApp } from '@studiometa/js-toolkit';
+import { registerComponent } from '@studiometa/js-toolkit';
 import {
   Figure,
   Slider as SliderCore,
@@ -11,9 +10,6 @@ import {
   SliderProgress,
 } from '@studiometa/ui';
 
-/**
- *
- */
 class Slider extends SliderCore {
   static config = {
     components: {
@@ -27,17 +23,5 @@ class Slider extends SliderCore {
   };
 }
 
-/**
- *
- */
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      Figure,
-      Slider,
-    },
-  };
-}
-
-createApp(App, document.body);
+registerComponent(Figure);
+registerComponent(Slider, 'Slider');

--- a/packages/docs/components/Slider/stories/left/app.js
+++ b/packages/docs/components/Slider/stories/left/app.js
@@ -1,4 +1,4 @@
-import { Base, createApp } from '@studiometa/js-toolkit';
+import { registerComponent } from '@studiometa/js-toolkit';
 import { Figure } from '@studiometa/ui';
 
 import {
@@ -25,14 +25,5 @@ class Slider extends SliderCore {
   };
 }
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      Figure,
-      Slider,
-    },
-  };
-}
-
-createApp(App);
+registerComponent(Figure);
+registerComponent(Slider);

--- a/packages/docs/components/Slider/stories/right/app.js
+++ b/packages/docs/components/Slider/stories/right/app.js
@@ -1,7 +1,6 @@
 /* eslint-disable require-jsdoc */
 /* eslint-disable import/no-extraneous-dependencies */
-/* eslint-disable max-classes-per-file */
-import { Base, createApp } from '@studiometa/js-toolkit';
+import { registerComponent } from '@studiometa/js-toolkit';
 import { Figure } from '@studiometa/ui';
 
 import {
@@ -27,14 +26,5 @@ class Slider extends SliderCore {
   };
 }
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      Figure,
-      Slider,
-    },
-  };
-}
-
-createApp(App, document.body);
+registerComponent(Figure);
+registerComponent(Slider, 'Slider');

--- a/packages/docs/components/Sticky/index.md
+++ b/packages/docs/components/Sticky/index.md
@@ -11,19 +11,10 @@ Use the `Sticky` component to keep an element fixed in place while its container
 Register the JavaScript component in your app and include the Twig template:
 
 ```js
-import { Base, createApp } from '@studiometa/js-toolkit';
+import { registerComponent } from '@studiometa/js-toolkit';
 import { Sticky } from '@studiometa/ui';
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      Sticky,
-    },
-  };
-}
-
-export default createApp(App, document.body);
+registerComponent(Sticky);
 ```
 
 ```twig

--- a/packages/docs/components/Sticky/stories/app.js
+++ b/packages/docs/components/Sticky/stories/app.js
@@ -1,13 +1,4 @@
-import { Base, createApp } from '@studiometa/js-toolkit';
+import { registerComponent } from '@studiometa/js-toolkit';
 import { Sticky } from '@studiometa/ui';
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      Sticky,
-    },
-  };
-}
-
-export default createApp(App, document.body);
+registerComponent(Sticky);

--- a/packages/docs/components/Tabs/index.md
+++ b/packages/docs/components/Tabs/index.md
@@ -10,20 +10,11 @@ The `Tabs` component creates accessible tab interfaces with transitions and keyb
 
 After you install the [package](/guide/installation/), include the template in your project:
 
-```js{2,8}
-import { Base, createApp } from '@studiometa/js-toolkit';
+```js
+import { registerComponent } from '@studiometa/js-toolkit';
 import { Tabs } from '@studiometa/ui';
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      Tabs,
-    },
-  };
-}
-
-export default createApp(App, document.body);
+registerComponent(Tabs);
 ```
 
 ```twig

--- a/packages/docs/components/Tabs/stories/app.js
+++ b/packages/docs/components/Tabs/stories/app.js
@@ -1,13 +1,4 @@
-import { Base, createApp } from '@studiometa/js-toolkit';
+import { registerComponent } from '@studiometa/js-toolkit';
 import { Tabs } from '@studiometa/ui';
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      Tabs,
-    },
-  };
-}
-
-export default createApp(App, document.body);
+registerComponent(Tabs);

--- a/packages/docs/components/Track/index.md
+++ b/packages/docs/components/Track/index.md
@@ -16,21 +16,12 @@ The `Track` components provide declarative analytics tracking, defined entirely 
 Register the components you need in your application:
 
 ```js
-import { Base, createApp } from '@studiometa/js-toolkit';
+import { registerComponent } from '@studiometa/js-toolkit';
 import { Track, TrackShopify, TrackContext } from '@studiometa/ui';
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      Track,
-      TrackShopify,
-      TrackContext,
-    },
-  };
-}
-
-createApp(App);
+registerComponent(Track);
+registerComponent(TrackShopify);
+registerComponent(TrackContext);
 ```
 
 Then declare what to track with `data-track:<event>` attributes. The value can be a bare event name (`data-track:click="add_to_cart"`) or, when an event needs its own structured data, a JSON payload whose `event` key holds the name. Data shared by every event on the element can be provided through a `<script data-ref="payload">` child or a `data-option-payload` attribute.

--- a/packages/docs/components/Track/stories/basic/app.js
+++ b/packages/docs/components/Track/stories/basic/app.js
@@ -1,4 +1,4 @@
-import { Base, createApp } from '@studiometa/js-toolkit';
+import { registerComponent } from '@studiometa/js-toolkit';
 import { Track as TrackCore, TrackContext } from '@studiometa/ui';
 
 /**
@@ -25,14 +25,5 @@ class Track extends TrackCore {
   }
 }
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      Track,
-      TrackContext,
-    },
-  };
-}
-
-export default createApp(App);
+registerComponent(Track);
+registerComponent(TrackContext);

--- a/packages/docs/components/Transition/stories/group/app.js
+++ b/packages/docs/components/Transition/stories/group/app.js
@@ -1,14 +1,5 @@
-import { Base, createApp } from '@studiometa/js-toolkit';
+import { registerComponent } from '@studiometa/js-toolkit';
 import { Action, Transition } from '@studiometa/ui';
 
-class App extends Base {
-  static config = {
-    name: 'App',
-    components: {
-      Action,
-      Transition,
-    },
-  };
-}
-
-export default createApp(App);
+registerComponent(Action);
+registerComponent(Transition);

--- a/packages/docs/guide/usage/index.md
+++ b/packages/docs/guide/usage/index.md
@@ -7,9 +7,9 @@ Import the [JS Toolkit](https://github.com/studiometa/js-toolkit) components fro
 ```js
 // app.js
 import { registerComponent } from '@studiometa/js-toolkit';
-import { Modal, Cursor } from '@studiometa/ui';
+import { Accordion, Cursor } from '@studiometa/ui';
 
-registerComponent(Modal);
+registerComponent(Accordion);
 registerComponent(Cursor);
 ```
 
@@ -19,9 +19,9 @@ Use [`registerComponent`](https://js-toolkit.studiometa.dev/api/helpers/register
 
 ```js
 import { registerComponent } from '@studiometa/js-toolkit';
-import { Modal } from '@studiometa/ui';
+import { Accordion } from '@studiometa/ui';
 
-registerComponent(Modal);
+registerComponent(Accordion);
 ```
 
 Pass a name or selector as the second argument when the DOM uses a different `data-component` value, or to bind a component to a CSS selector:

--- a/packages/docs/guide/usage/index.md
+++ b/packages/docs/guide/usage/index.md
@@ -6,17 +6,55 @@ Import the [JS Toolkit](https://github.com/studiometa/js-toolkit) components fro
 
 ```js
 // app.js
-import { Base, createApp } from '@studiometa/js-toolkit';
+import { registerComponent } from '@studiometa/js-toolkit';
 import { Modal, Cursor } from '@studiometa/ui';
+
+registerComponent(Modal);
+registerComponent(Cursor);
+```
+
+## Registering components
+
+Use [`registerComponent`](https://js-toolkit.studiometa.dev/api/helpers/registerComponent.html) to mount a component on every matching `data-component` element. It is the default way to register components, with no `App` boilerplate:
+
+```js
+import { registerComponent } from '@studiometa/js-toolkit';
+import { Modal } from '@studiometa/ui';
+
+registerComponent(Modal);
+```
+
+Pass a name or selector as the second argument when the DOM uses a different `data-component` value, or to bind a component to a CSS selector:
+
+```js
+import { registerComponent } from '@studiometa/js-toolkit';
+import { AnchorScrollTo } from '@studiometa/ui';
+
+registerComponent(AnchorScrollTo, 'a[href^="#"]');
+```
+
+Reach for [`createApp`](https://js-toolkit.studiometa.dev/api/helpers/createApp.html) only when you need app-level orchestration, such as shared `refs`, `on*` handlers or methods that coordinate across children:
+
+```js
+import { Base, createApp } from '@studiometa/js-toolkit';
+import { Transition } from '@studiometa/ui';
 
 class App extends Base {
   static config = {
     name: 'App',
+    refs: ['enterBtn', 'leaveBtn'],
     components: {
-      Modal,
-      Cursor,
+      Transition,
     },
   };
+
+  onEnterBtnClick() {
+    this.$children.Transition[0].enter();
+  }
+
+  onLeaveBtnClick() {
+    this.$children.Transition[0].leave();
+  }
 }
 
 export default createApp(App, document.body);


### PR DESCRIPTION
## Summary

Standardize the documentation examples on the `registerComponent` helper instead of the heavier `createApp(App, …)` boilerplate, for examples that only register components.

- **68 story files** (`packages/docs/components/**/app.{js,ts}`) migrated from bare-container `createApp(App, …)` to `registerComponent`. Local subclasses (e.g. `Slider extends SliderCore`, `Figure extends FigureTwicpics`, `Parallax`, custom `Track`) are preserved and registered; renamed/selector/HOC keys keep their exact matcher via the `registerComponent(C, nameOrSelector)` second argument.
- **26 `index.md` Usage snippets** aligned to the `registerComponent` form to match the migrated stories.
- **4 orchestrated stories intentionally kept on `createApp`** because they rely on app-level orchestration (`refs`, `on*` handlers, cross-child methods): `Transition/stories/toggle`, `ViewTransition/stories/toggle`, `Frame/stories/form`, `Indexable/stories/counter`. Their `index.md` orchestration snippets (Transition, Indexable) were likewise left untouched.
- **New guide section** in `packages/docs/guide/usage/index.md` ("Registering components") documenting `registerComponent` as the default and `createApp` for orchestration, with a short example of each.

## Verification

- `npm run lint` passes (0 errors).
- `npm run docs:build` passes (twoslash snippets type-check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012yveKSZ7iCEDL9Ybe2Nsdg