### PR TITLE
Add Timer and TimerProgress components

### DIFF
--- a/packages/docs/components/Timer/examples.md
+++ b/packages/docs/components/Timer/examples.md
@@ -1,0 +1,26 @@
+---
+title: Timer examples
+---
+
+# Examples
+
+## Looping progress bar
+
+`TimerProgress` emits a bubbling `timer-progress` event on every animation frame. A single routing [`Action`](/components/Action/) on an ancestor catches it and forwards the ratio to a [`DataBind`](/components/DataBind/) that lives in a separate subtree — so the progress bar and the timer never need to share an element. Hovering the label pauses the countdown, and the bar freezes with it.
+
+<llm-exclude>
+  <PreviewPlayground
+    :html="() => import('./stories/progress/app.twig')"
+    :script="() => import('./stories/progress/app.js?raw')"
+    />
+</llm-exclude>
+<llm-only>
+
+:::code-group
+
+<<< ./stories/progress/app.twig
+<<< ./stories/progress/app.js
+
+:::
+
+</llm-only>

--- a/packages/docs/components/Timer/index.md
+++ b/packages/docs/components/Timer/index.md
@@ -1,0 +1,34 @@
+---
+badges: [JS]
+---
+
+# Timer <Badges :texts="$frontmatter.badges" />
+
+The `Timer` atom is a headless countdown primitive. It emits DOM events for its lifecycle — `timer-start`, `timer-end`, `timer-tick`, `timer-pause`, `timer-resume`, `timer-stop` — and exposes imperative methods, holding no UI state of its own. Combine it with [`Action`](/components/Action/) to react to those events or call its methods, and with the [`Data*`](/components/DataScope/) family to turn them into reactive state.
+
+All events bubble, so an ancestor `Action` can catch and route them (see [the progress bar example](./examples.html)); use the `.stop` event modifier to contain them in nested setups.
+
+## Usage
+
+In the following example, a single element carries both `Action` and `Timer`: clicking it restarts a three-second countdown, and the `timer-start` / `timer-end` events update its label.
+
+<llm-exclude>
+<PreviewPlayground
+  :html="() => import('./stories/basic/app.twig')"
+  :script="() => import('./stories/basic/app.js?raw')"
+  />
+</llm-exclude>
+<llm-only>
+
+:::code-group
+
+<<< ./stories/basic/app.twig
+<<< ./stories/basic/app.js
+
+:::
+
+</llm-only>
+
+## Continuous progress
+
+The `TimerProgress` component extends `Timer` with a smooth, pause-aware `timer-progress` event (a `0 → 1` ratio) emitted on every animation frame. It is a separate component so the base `Timer` never pays the per-frame cost — mount `TimerProgress` only where a continuous indicator is needed. See the [examples](./examples.html) for a progress bar driven through `Action` and `DataBind`.

--- a/packages/docs/components/Timer/js-api.md
+++ b/packages/docs/components/Timer/js-api.md
@@ -1,0 +1,132 @@
+---
+title: Timer JS API
+---
+
+# JS API
+
+## `Timer`
+
+The base countdown component.
+
+### Options
+
+#### `delay`
+
+- Type: `number`
+- Default: `0`
+
+The countdown duration, **in seconds**. `timer-end` is emitted once this delay has elapsed.
+
+<!-- prettier-ignore-start -->
+```html {3}
+<div
+  data-component="Timer"
+  data-option-delay="3">
+  …
+</div>
+```
+<!-- prettier-ignore-end -->
+
+#### `repeat`
+
+- Type: `boolean`
+- Default: `false`
+
+When enabled, the timer re-arms itself after each completion (interval mode), emitting `timer-tick` on every cycle in addition to `timer-end`.
+
+<!-- prettier-ignore-start -->
+```html {3}
+<div
+  data-component="Timer"
+  data-option-repeat>
+  …
+</div>
+```
+<!-- prettier-ignore-end -->
+
+#### `autostart`
+
+- Type: `boolean`
+- Default: `true`
+
+Whether the countdown starts automatically on mount. Since the default is `true`, use the negated `data-option-no-autostart` attribute to require an explicit `start()`.
+
+<!-- prettier-ignore-start -->
+```html {3}
+<div
+  data-component="Timer"
+  data-option-no-autostart>
+  …
+</div>
+```
+<!-- prettier-ignore-end -->
+
+### Events
+
+All events are dispatched as bubbling `CustomEvent`s on the component's element, so they can be listened to with [`Action`](/components/Action/)'s `data-on:<event>` attribute — either on the same element or on an ancestor. Use the `.stop` modifier to contain them.
+
+| Event          | Fired when                                                        |
+| -------------- | ----------------------------------------------------------------- |
+| `timer-start`  | the countdown starts (via `start()`, `restart()` or `autostart`). |
+| `timer-end`    | the countdown reaches zero.                                       |
+| `timer-tick`   | a cycle completes while `repeat` is enabled (after `timer-end`).  |
+| `timer-pause`  | the countdown is paused.                                          |
+| `timer-resume` | a paused countdown resumes.                                       |
+| `timer-stop`   | the countdown is stopped without completing.                      |
+
+<!-- prettier-ignore-start -->
+```html {4}
+<div
+  data-component="Action Timer"
+  data-option-delay="5"
+  data-on:timer-end="console.log('5 seconds elapsed')">
+  …
+</div>
+```
+<!-- prettier-ignore-end -->
+
+### Methods
+
+| Method      | Description                                                        |
+| ----------- | ----------------------------------------------------------------- |
+| `start()`   | Start — or restart — the countdown from the beginning.            |
+| `restart()` | Alias for `start()`.                                              |
+| `stop()`    | Stop the countdown without completing it.                         |
+| `pause()`   | Pause the countdown, preserving the remaining time.               |
+| `resume()`  | Resume a paused countdown from where it left off.                 |
+
+Methods are callable from an `Action` effect when the `Timer` is mounted on the same element:
+
+<!-- prettier-ignore-start -->
+```html {4}
+<button
+  data-component="Action Timer"
+  data-option-no-autostart
+  data-on:click="Timer.start()">
+  Start
+</button>
+```
+<!-- prettier-ignore-end -->
+
+## `TimerProgress`
+
+Extends `Timer` with a continuous progress signal. It inherits every option, event and method above, and adds one event. Mount it in place of `Timer` wherever a smooth indicator is needed; the base `Timer` stays free of the per-frame cost.
+
+### Events
+
+| Event            | Detail        | Fired when                                                    |
+| ---------------- | ------------- | ------------------------------------------------------------- |
+| `timer-progress` | `[ratio]`     | on every animation frame while running — `ratio` goes `0 → 1`, reaches `1` on completion and resets to `0` on `stop()`. |
+
+The ratio is read from `event.detail[0]`:
+
+<!-- prettier-ignore-start -->
+```html {3}
+<div
+  data-component="Action"
+  data-on:timer-progress="DataBind([data-role=progress])->target.set(event.detail[0])">
+  <div data-component="TimerProgress" data-option-delay="3">…</div>
+  <div data-role="progress" data-component="DataBind" data-bind:style.width="(Number(value || 0) * 100) + '%'"></div>
+</div>
+```
+<!-- prettier-ignore-end -->

--- a/packages/docs/components/Timer/stories/basic/app.js
+++ b/packages/docs/components/Timer/stories/basic/app.js
@@ -1,0 +1,5 @@
+import { registerComponent } from '@studiometa/js-toolkit';
+import { Action, Timer } from '@studiometa/ui';
+
+registerComponent(Action);
+registerComponent(Timer);

--- a/packages/docs/components/Timer/stories/basic/app.twig
+++ b/packages/docs/components/Timer/stories/basic/app.twig
@@ -1,0 +1,11 @@
+<button
+  type="button"
+  data-component="Action Timer"
+  data-option-delay="3"
+  data-option-no-autostart
+  data-on:click="Timer.restart()"
+  data-on:timer-start="this.textContent = 'Counting down… (click to restart)'"
+  data-on:timer-end="this.textContent = 'Time’s up! Click to run again.'"
+  class="px-4 py-2 rounded bg-blue-400 dark:bg-blue-600">
+  Click to start a 3s timer
+</button>

--- a/packages/docs/components/Timer/stories/progress/app.js
+++ b/packages/docs/components/Timer/stories/progress/app.js
@@ -1,0 +1,6 @@
+import { registerComponent } from '@studiometa/js-toolkit';
+import { Action, DataBind, TimerProgress } from '@studiometa/ui';
+
+registerComponent(Action);
+registerComponent(DataBind);
+registerComponent(TimerProgress);

--- a/packages/docs/components/Timer/stories/progress/app.twig
+++ b/packages/docs/components/Timer/stories/progress/app.twig
@@ -1,0 +1,25 @@
+{# The routing Action catches the bubbling `timer-progress` and forwards the
+   ratio to the progress bar's DataBind, which lives in a separate subtree. #}
+<div
+  data-component="Action"
+  data-on:timer-progress="DataBind([data-role=progress])->target.set(event.detail[0])"
+  class="flex flex-col gap-4 w-full max-w-sm">
+
+  <div
+    data-component="Action TimerProgress"
+    data-option-delay="3"
+    data-option-repeat
+    data-on:mouseenter="TimerProgress.pause()"
+    data-on:mouseleave="TimerProgress.resume()"
+    class="text-sm text-current/60">
+    Loading… (hover to pause)
+  </div>
+
+  <div class="h-2 w-full overflow-hidden rounded-full bg-current/10">
+    <div
+      data-role="progress"
+      data-component="DataBind"
+      data-bind:style.width="(Number(value || 0) * 100) + '%'"
+      class="h-full w-0 rounded-full bg-blue-500"></div>
+  </div>
+</div>

--- a/packages/tests/Timer/Timer.spec.ts
+++ b/packages/tests/Timer/Timer.spec.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { Timer } from '@studiometa/ui';
+import { h, useFakeTimers, useRealTimers, advanceTimersByTimeAsync } from '#test-utils';
+
+/**
+ * Record how many times each named event fires on the element, keeping the
+ * `detail` payloads so bubbling `CustomEvent`s can be asserted like an `Action`
+ * would consume them.
+ */
+function listen(el: HTMLElement, ...names: string[]) {
+  const calls: Record<string, number> = {};
+  const details: Record<string, unknown[][]> = {};
+
+  for (const name of names) {
+    calls[name] = 0;
+    details[name] = [];
+    el.addEventListener(name, (event) => {
+      calls[name] += 1;
+      details[name].push((event as CustomEvent).detail);
+    });
+  }
+
+  return { calls, details };
+}
+
+/**
+ * Build a `Timer` element, attach listeners, then mount and flush the mount
+ * queue so `mounted()` (and its `autostart`) has run.
+ */
+async function mountTimer(attributes: Record<string, string> = {}, events: string[] = []) {
+  const el = h('div', { dataComponent: 'Timer', ...attributes });
+  const recorder = listen(el, ...events);
+  const instance = new Timer(el);
+  instance.$mount();
+  await advanceTimersByTimeAsync(50);
+
+  return { el, instance, ...recorder };
+}
+
+describe('Timer component', () => {
+  beforeEach(() => {
+    useFakeTimers();
+  });
+
+  afterEach(() => {
+    useRealTimers();
+  });
+
+  it('should have the correct config', () => {
+    expect(Timer.config.name).toBe('Timer');
+    expect(Timer.config.emits).toEqual([
+      'timer-start',
+      'timer-end',
+      'timer-tick',
+      'timer-pause',
+      'timer-resume',
+      'timer-stop',
+    ]);
+  });
+
+  it('should start on mount and emit `timer-start`', async () => {
+    const { calls } = await mountTimer({ dataOptionDelay: '2' }, ['timer-start', 'timer-end']);
+    expect(calls['timer-start']).toBe(1);
+    expect(calls['timer-end']).toBe(0);
+  });
+
+  it('should emit `timer-end` once the delay (in seconds) elapsed', async () => {
+    const { calls } = await mountTimer({ dataOptionDelay: '2' }, ['timer-end']);
+    await advanceTimersByTimeAsync(1000);
+    expect(calls['timer-end']).toBe(0);
+    await advanceTimersByTimeAsync(1500);
+    expect(calls['timer-end']).toBe(1);
+  });
+
+  it('should dispatch bubbling events', async () => {
+    const el = h('div', { dataComponent: 'Timer', dataOptionDelay: '1' });
+    const parent = h('div', [el]);
+    let bubbled = 0;
+    parent.addEventListener('timer-end', () => {
+      bubbled += 1;
+    });
+    const instance = new Timer(el);
+    instance.$mount();
+    await advanceTimersByTimeAsync(1050);
+    expect(bubbled).toBe(1);
+  });
+
+  it('should re-arm and keep emitting when `repeat` is enabled', async () => {
+    const { calls } = await mountTimer({ dataOptionDelay: '1', dataOptionRepeat: '' }, [
+      'timer-end',
+      'timer-tick',
+    ]);
+    await advanceTimersByTimeAsync(3200);
+    expect(calls['timer-end']).toBe(3);
+    expect(calls['timer-tick']).toBe(3);
+  });
+
+  it('should not autostart when disabled, and start on demand', async () => {
+    const { instance, calls } = await mountTimer(
+      { dataOptionDelay: '1', dataOptionNoAutostart: '' },
+      ['timer-start', 'timer-end'],
+    );
+    expect(instance.$options.autostart).toBe(false);
+    expect(calls['timer-start']).toBe(0);
+
+    instance.start();
+    await advanceTimersByTimeAsync(1050);
+    expect(calls['timer-start']).toBe(1);
+    expect(calls['timer-end']).toBe(1);
+  });
+
+  it('should stop without completing', async () => {
+    const { instance, calls } = await mountTimer({ dataOptionDelay: '2' }, [
+      'timer-stop',
+      'timer-end',
+    ]);
+    instance.stop();
+    expect(calls['timer-stop']).toBe(1);
+    await advanceTimersByTimeAsync(3000);
+    expect(calls['timer-end']).toBe(0);
+  });
+
+  it('should pause and resume, preserving the remaining time', async () => {
+    const { instance, calls } = await mountTimer({ dataOptionDelay: '2' }, [
+      'timer-pause',
+      'timer-resume',
+      'timer-end',
+    ]);
+
+    await advanceTimersByTimeAsync(1000);
+    instance.pause();
+    expect(calls['timer-pause']).toBe(1);
+
+    // Time passes while paused: the timer must not complete.
+    await advanceTimersByTimeAsync(5000);
+    expect(calls['timer-end']).toBe(0);
+
+    instance.resume();
+    expect(calls['timer-resume']).toBe(1);
+
+    // Only the ~1s that was left should be needed to complete.
+    await advanceTimersByTimeAsync(1100);
+    expect(calls['timer-end']).toBe(1);
+  });
+
+  it('should restart from the beginning', async () => {
+    const { instance, calls } = await mountTimer({ dataOptionDelay: '2' }, [
+      'timer-start',
+      'timer-end',
+    ]);
+
+    await advanceTimersByTimeAsync(1500);
+    instance.restart();
+    expect(calls['timer-start']).toBe(2);
+
+    // The elapsed 1.5s must have been discarded: no completion yet.
+    await advanceTimersByTimeAsync(1500);
+    expect(calls['timer-end']).toBe(0);
+
+    await advanceTimersByTimeAsync(600);
+    expect(calls['timer-end']).toBe(1);
+  });
+
+  it('should cancel a pending countdown on destroy', async () => {
+    const { instance, calls } = await mountTimer({ dataOptionDelay: '2' }, ['timer-end']);
+    await instance.$destroy();
+    await advanceTimersByTimeAsync(3000);
+    expect(calls['timer-end']).toBe(0);
+  });
+});

--- a/packages/tests/Timer/Timer.spec.ts
+++ b/packages/tests/Timer/Timer.spec.ts
@@ -161,6 +161,35 @@ describe('Timer component', () => {
     expect(calls['timer-end']).toBe(1);
   });
 
+  it('should not resume after being stopped', async () => {
+    const { instance, calls } = await mountTimer({ dataOptionDelay: '2' }, [
+      'timer-resume',
+      'timer-end',
+    ]);
+
+    instance.stop();
+    instance.resume();
+
+    expect(calls['timer-resume']).toBe(0);
+    await advanceTimersByTimeAsync(3000);
+    expect(calls['timer-end']).toBe(0);
+  });
+
+  it('should not resume after completing', async () => {
+    const { instance, calls } = await mountTimer({ dataOptionDelay: '1' }, [
+      'timer-resume',
+      'timer-end',
+    ]);
+
+    await advanceTimersByTimeAsync(1100);
+    expect(calls['timer-end']).toBe(1);
+
+    instance.resume();
+    expect(calls['timer-resume']).toBe(0);
+    await advanceTimersByTimeAsync(2000);
+    expect(calls['timer-end']).toBe(1);
+  });
+
   it('should cancel a pending countdown on destroy', async () => {
     const { instance, calls } = await mountTimer({ dataOptionDelay: '2' }, ['timer-end']);
     await instance.$destroy();

--- a/packages/tests/Timer/TimerProgress.spec.ts
+++ b/packages/tests/Timer/TimerProgress.spec.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { Timer, TimerProgress } from '@studiometa/ui';
+import { h, useFakeTimers, useRealTimers, advanceTimersByTimeAsync } from '#test-utils';
+
+function listen(el: HTMLElement, ...names: string[]) {
+  const calls: Record<string, number> = {};
+  const details: Record<string, unknown[][]> = {};
+
+  for (const name of names) {
+    calls[name] = 0;
+    details[name] = [];
+    el.addEventListener(name, (event) => {
+      calls[name] += 1;
+      details[name].push((event as CustomEvent).detail);
+    });
+  }
+
+  return { calls, details };
+}
+
+async function mountTimerProgress(
+  attributes: Record<string, string> = {},
+  events: string[] = [],
+) {
+  const el = h('div', { dataComponent: 'TimerProgress', ...attributes });
+  const recorder = listen(el, ...events);
+  const instance = new TimerProgress(el);
+  instance.$mount();
+  await advanceTimersByTimeAsync(50);
+
+  return { el, instance, ...recorder };
+}
+
+/** Flatten recorded single-argument `detail` arrays into their ratio values. */
+function ratios(details: unknown[][]): number[] {
+  return details.map((detail) => (detail as number[])[0]);
+}
+
+describe('TimerProgress component', () => {
+  beforeEach(() => {
+    useFakeTimers();
+  });
+
+  afterEach(() => {
+    useRealTimers();
+  });
+
+  it('should have the correct config and extend Timer', () => {
+    expect(TimerProgress.config.name).toBe('TimerProgress');
+    expect(TimerProgress.config.emits).toEqual(['timer-progress']);
+    expect(TimerProgress.prototype).toBeInstanceOf(Timer);
+  });
+
+  it('should merge the parent lifecycle events into its config', async () => {
+    const { instance } = await mountTimerProgress({ dataOptionDelay: '1' });
+    expect(instance.$config.emits).toContain('timer-start');
+    expect(instance.$config.emits).toContain('timer-end');
+    expect(instance.$config.emits).toContain('timer-progress');
+  });
+
+  it('should emit an increasing progress ratio during the countdown', async () => {
+    const { details } = await mountTimerProgress({ dataOptionDelay: '2' }, ['timer-progress']);
+    await advanceTimersByTimeAsync(1000);
+
+    const values = ratios(details['timer-progress']);
+    expect(values.length).toBeGreaterThan(1);
+    // Values stay within bounds and progress forward.
+    expect(Math.min(...values)).toBeGreaterThanOrEqual(0);
+    expect(values.at(-1)).toBeGreaterThan(values[0]);
+    expect(values.at(-1)).toBeLessThanOrEqual(1);
+  });
+
+  it('should report a final ratio of 1 when the countdown completes', async () => {
+    const { details, calls } = await mountTimerProgress({ dataOptionDelay: '1' }, [
+      'timer-progress',
+      'timer-end',
+    ]);
+    await advanceTimersByTimeAsync(1100);
+
+    expect(calls['timer-end']).toBe(1);
+    expect(ratios(details['timer-progress'])).toContain(1);
+  });
+
+  it('should reset progress to 0 on stop', async () => {
+    const { instance, details } = await mountTimerProgress({ dataOptionDelay: '2' }, [
+      'timer-progress',
+    ]);
+    await advanceTimersByTimeAsync(500);
+    instance.stop();
+
+    expect(ratios(details['timer-progress']).at(-1)).toBe(0);
+  });
+
+  it('should still emit the base lifecycle events', async () => {
+    const { calls } = await mountTimerProgress({ dataOptionDelay: '1' }, [
+      'timer-start',
+      'timer-end',
+    ]);
+    expect(calls['timer-start']).toBe(1);
+    await advanceTimersByTimeAsync(1100);
+    expect(calls['timer-end']).toBe(1);
+  });
+});

--- a/packages/tests/Timer/TimerProgress.spec.ts
+++ b/packages/tests/Timer/TimerProgress.spec.ts
@@ -91,6 +91,26 @@ describe('TimerProgress component', () => {
     expect(ratios(details['timer-progress']).at(-1)).toBe(0);
   });
 
+  it('should stop the progress loop when a listener stops it mid-dispatch', async () => {
+    const el = h('div', { dataComponent: 'TimerProgress', dataOptionDelay: '5' });
+    const instance = new TimerProgress(el);
+    let count = 0;
+    // A listener that tears the timer down synchronously on the first frame.
+    el.addEventListener('timer-progress', () => {
+      count += 1;
+      if (count === 1) {
+        instance.stop();
+      }
+    });
+    instance.$mount();
+
+    await advanceTimersByTimeAsync(2000);
+
+    // Without the guard the loop would resurrect itself and keep counting up;
+    // `stop()` also emits a final progress of 0, so at most two events fire.
+    expect(count).toBeLessThanOrEqual(2);
+  });
+
   it('should still emit the base lifecycle events', async () => {
     const { calls } = await mountTimerProgress({ dataOptionDelay: '1' }, [
       'timer-start',

--- a/packages/tests/index.spec.ts
+++ b/packages/tests/index.spec.ts
@@ -70,6 +70,8 @@ test('components exports', () => {
       "Sticky",
       "Tabs",
       "Target",
+      "Timer",
+      "TimerProgress",
       "Track",
       "TrackContext",
       "TrackShopify",

--- a/packages/ui/Timer/Timer.ts
+++ b/packages/ui/Timer/Timer.ts
@@ -1,0 +1,182 @@
+import { Base } from '@studiometa/js-toolkit';
+import type { BaseProps, BaseConfig } from '@studiometa/js-toolkit';
+
+export interface TimerProps extends BaseProps {
+  $options: {
+    delay: number;
+    repeat: boolean;
+    autostart: boolean;
+  };
+}
+
+/**
+ * Timer class.
+ *
+ * A headless, composable countdown primitive. It emits DOM events for its
+ * lifecycle and exposes imperative methods, holding no UI state of its own —
+ * combine it with `Action` (to react to `timer-*` events or call its methods)
+ * and the `Data*` family (to turn those events into reactive state).
+ *
+ * Events bubble, so an ancestor `Action` can catch and route them; use the
+ * `.stop` event modifier to contain them in nested setups.
+ *
+ * @link https://ui.studiometa.dev/components/Timer/
+ */
+export class Timer<T extends BaseProps = BaseProps> extends Base<TimerProps & T> {
+  /**
+   * Config.
+   */
+  static config: BaseConfig = {
+    name: 'Timer',
+    emits: ['timer-start', 'timer-end', 'timer-tick', 'timer-pause', 'timer-resume', 'timer-stop'],
+    options: {
+      delay: { type: Number, default: 0 },
+      repeat: Boolean,
+      autostart: { type: Boolean, default: true },
+    },
+  };
+
+  /**
+   * The pending `setTimeout` identifier, or `null` when idle.
+   * @private
+   */
+  __timer: number | null = null;
+
+  /**
+   * Timestamp (ms) at which the current countdown segment was armed.
+   * @protected
+   */
+  __armedAt = 0;
+
+  /**
+   * Time (ms) already consumed before the current segment, preserved across pauses.
+   * @protected
+   */
+  __elapsed = 0;
+
+  /**
+   * Time (ms) left to wait before the countdown completes.
+   * @private
+   */
+  __remaining = 0;
+
+  /**
+   * Start the countdown on mount unless `autostart` is disabled.
+   */
+  mounted() {
+    if (this.$options.autostart) {
+      this.start();
+    }
+  }
+
+  /**
+   * Cancel any pending countdown on destroy.
+   */
+  destroyed() {
+    this.__clear();
+  }
+
+  /**
+   * The total countdown duration in milliseconds (the `delay` option is in seconds).
+   * @protected
+   */
+  get __duration(): number {
+    return this.$options.delay * 1000;
+  }
+
+  /**
+   * Dispatch a bubbling event so an ancestor `Action` can catch and route it.
+   * @private
+   */
+  __dispatch(name: string, ...detail: unknown[]) {
+    this.$emit(new CustomEvent(name, { detail, bubbles: true }));
+  }
+
+  /**
+   * Start — or restart — the countdown from the beginning.
+   */
+  start() {
+    this.__clear();
+    this.__elapsed = 0;
+    this.__remaining = this.__duration;
+    this.__dispatch('timer-start');
+    this.__arm(this.__remaining);
+  }
+
+  /**
+   * Alias for `start()`, restarting the countdown from zero.
+   */
+  restart() {
+    this.start();
+  }
+
+  /**
+   * Stop the countdown without completing it.
+   */
+  stop() {
+    this.__clear();
+    this.__dispatch('timer-stop');
+  }
+
+  /**
+   * Pause the countdown, preserving the remaining time.
+   */
+  pause() {
+    if (this.__timer === null) {
+      return;
+    }
+
+    const consumed = performance.now() - this.__armedAt;
+    this.__elapsed += consumed;
+    this.__remaining -= consumed;
+    this.__clear();
+    this.__dispatch('timer-pause');
+  }
+
+  /**
+   * Resume a paused countdown from where it left off.
+   */
+  resume() {
+    if (this.__timer !== null || this.__remaining <= 0) {
+      return;
+    }
+
+    this.__dispatch('timer-resume');
+    this.__arm(this.__remaining);
+  }
+
+  /**
+   * Arm the countdown for the given duration in milliseconds.
+   * @protected
+   */
+  __arm(delay: number) {
+    this.__armedAt = performance.now();
+    this.__timer = window.setTimeout(() => this.__complete(), delay);
+  }
+
+  /**
+   * Handle the countdown reaching zero, re-arming when `repeat` is enabled.
+   * @protected
+   */
+  __complete() {
+    this.__timer = null;
+    this.__dispatch('timer-end');
+
+    if (this.$options.repeat) {
+      this.__dispatch('timer-tick');
+      this.start();
+    }
+  }
+
+  /**
+   * Cancel any pending countdown. Subclasses extend this to release extra resources.
+   * @protected
+   */
+  __clear() {
+    if (this.__timer !== null) {
+      window.clearTimeout(this.__timer);
+    }
+
+    this.__timer = null;
+  }
+}

--- a/packages/ui/Timer/Timer.ts
+++ b/packages/ui/Timer/Timer.ts
@@ -61,6 +61,12 @@ export class Timer<T extends BaseProps = BaseProps> extends Base<TimerProps & T>
   __remaining = 0;
 
   /**
+   * Whether a countdown is currently paused and can be resumed.
+   * @private
+   */
+  __paused = false;
+
+  /**
    * Start the countdown on mount unless `autostart` is disabled.
    */
   mounted() {
@@ -97,6 +103,7 @@ export class Timer<T extends BaseProps = BaseProps> extends Base<TimerProps & T>
    */
   start() {
     this.__clear();
+    this.__paused = false;
     this.__elapsed = 0;
     this.__remaining = this.__duration;
     this.__dispatch('timer-start');
@@ -115,6 +122,8 @@ export class Timer<T extends BaseProps = BaseProps> extends Base<TimerProps & T>
    */
   stop() {
     this.__clear();
+    this.__paused = false;
+    this.__remaining = 0;
     this.__dispatch('timer-stop');
   }
 
@@ -130,6 +139,7 @@ export class Timer<T extends BaseProps = BaseProps> extends Base<TimerProps & T>
     this.__elapsed += consumed;
     this.__remaining -= consumed;
     this.__clear();
+    this.__paused = true;
     this.__dispatch('timer-pause');
   }
 
@@ -137,10 +147,11 @@ export class Timer<T extends BaseProps = BaseProps> extends Base<TimerProps & T>
    * Resume a paused countdown from where it left off.
    */
   resume() {
-    if (this.__timer !== null || this.__remaining <= 0) {
+    if (!this.__paused) {
       return;
     }
 
+    this.__paused = false;
     this.__dispatch('timer-resume');
     this.__arm(this.__remaining);
   }

--- a/packages/ui/Timer/TimerProgress.ts
+++ b/packages/ui/Timer/TimerProgress.ts
@@ -1,0 +1,94 @@
+import { Timer } from './Timer.js';
+import type { BaseProps, BaseConfig } from '@studiometa/js-toolkit';
+
+/**
+ * TimerProgress class.
+ *
+ * A `Timer` that additionally emits a smooth, pause-aware `timer-progress`
+ * event on every animation frame, carrying a `0 → 1` ratio in its detail. It is
+ * a separate component so the base `Timer` never pays the per-frame cost: mount
+ * `TimerProgress` only where a continuous indicator (e.g. a progress bar) is
+ * needed.
+ *
+ * @link https://ui.studiometa.dev/components/Timer/
+ */
+export class TimerProgress<T extends BaseProps = BaseProps> extends Timer<T> {
+  /**
+   * Config.
+   */
+  static config: BaseConfig = {
+    name: 'TimerProgress',
+    emits: ['timer-progress'],
+  };
+
+  /**
+   * The pending `requestAnimationFrame` identifier, or `null` when idle.
+   * @private
+   */
+  __frame: number | null = null;
+
+  /**
+   * Start the progress loop alongside the countdown.
+   * @protected
+   */
+  __arm(delay: number) {
+    super.__arm(delay);
+    this.__loop();
+  }
+
+  /**
+   * Report full progress and stop the loop before the countdown completes.
+   * @protected
+   */
+  __complete() {
+    this.__stopFrame();
+    this.__dispatch('timer-progress', 1);
+    super.__complete();
+  }
+
+  /**
+   * Cancel the pending animation frame together with the countdown.
+   * @protected
+   */
+  __clear() {
+    super.__clear();
+    this.__stopFrame();
+  }
+
+  /**
+   * Stop the countdown and reset the reported progress to zero.
+   */
+  stop() {
+    super.stop();
+    this.__dispatch('timer-progress', 0);
+  }
+
+  /**
+   * Emit the current progress ratio on every animation frame.
+   * @private
+   */
+  __loop() {
+    this.__stopFrame();
+
+    const step = () => {
+      const consumed = this.__elapsed + (performance.now() - this.__armedAt);
+      const ratio = Math.min(1, Math.max(0, consumed / (this.__duration || 1)));
+      this.__dispatch('timer-progress', ratio);
+      this.__frame = window.requestAnimationFrame(step);
+    };
+
+    this.__frame = window.requestAnimationFrame(step);
+  }
+
+  /**
+   * Cancel the pending animation frame.
+   * @private
+   */
+  __stopFrame() {
+    if (this.__frame !== null) {
+      window.cancelAnimationFrame(this.__frame);
+    }
+
+    this.__frame = null;
+  }
+}

--- a/packages/ui/Timer/TimerProgress.ts
+++ b/packages/ui/Timer/TimerProgress.ts
@@ -10,6 +10,10 @@ import type { BaseProps, BaseConfig } from '@studiometa/js-toolkit';
  * `TimerProgress` only where a continuous indicator (e.g. a progress bar) is
  * needed.
  *
+ * The frame loop is the shared `ticked` RafService, enabled only while a
+ * countdown is armed — so it is throttled with every other component and torn
+ * down automatically on destroy.
+ *
  * @link https://ui.studiometa.dev/components/Timer/
  */
 export class TimerProgress<T extends BaseProps = BaseProps> extends Timer<T> {
@@ -22,18 +26,31 @@ export class TimerProgress<T extends BaseProps = BaseProps> extends Timer<T> {
   };
 
   /**
-   * The pending `requestAnimationFrame` identifier, or `null` when idle.
-   * @private
+   * Neutralize the RafService that auto-enables on mount because `ticked`
+   * exists: progress must only run while a countdown is armed, so `__arm` and
+   * `__clear` own the enabling from there on.
    */
-  __frame: number | null = null;
+  mounted() {
+    this.$services.disable('ticked');
+    super.mounted();
+  }
 
   /**
-   * Start the progress loop alongside the countdown.
+   * Emit the current progress ratio on every animation frame while running.
+   */
+  ticked() {
+    const consumed = this.__elapsed + (performance.now() - this.__armedAt);
+    const ratio = Math.min(1, Math.max(0, consumed / (this.__duration || 1)));
+    this.__dispatch('timer-progress', ratio);
+  }
+
+  /**
+   * Enable the progress loop alongside the countdown.
    * @protected
    */
   __arm(delay: number) {
     super.__arm(delay);
-    this.__loop();
+    this.$services.enable('ticked');
   }
 
   /**
@@ -41,18 +58,18 @@ export class TimerProgress<T extends BaseProps = BaseProps> extends Timer<T> {
    * @protected
    */
   __complete() {
-    this.__stopFrame();
+    this.$services.disable('ticked');
     this.__dispatch('timer-progress', 1);
     super.__complete();
   }
 
   /**
-   * Cancel the pending animation frame together with the countdown.
+   * Disable the progress loop together with the countdown.
    * @protected
    */
   __clear() {
     super.__clear();
-    this.__stopFrame();
+    this.$services.disable('ticked');
   }
 
   /**
@@ -61,34 +78,5 @@ export class TimerProgress<T extends BaseProps = BaseProps> extends Timer<T> {
   stop() {
     super.stop();
     this.__dispatch('timer-progress', 0);
-  }
-
-  /**
-   * Emit the current progress ratio on every animation frame.
-   * @private
-   */
-  __loop() {
-    this.__stopFrame();
-
-    const step = () => {
-      const consumed = this.__elapsed + (performance.now() - this.__armedAt);
-      const ratio = Math.min(1, Math.max(0, consumed / (this.__duration || 1)));
-      this.__dispatch('timer-progress', ratio);
-      this.__frame = window.requestAnimationFrame(step);
-    };
-
-    this.__frame = window.requestAnimationFrame(step);
-  }
-
-  /**
-   * Cancel the pending animation frame.
-   * @private
-   */
-  __stopFrame() {
-    if (this.__frame !== null) {
-      window.cancelAnimationFrame(this.__frame);
-    }
-
-    this.__frame = null;
   }
 }

--- a/packages/ui/Timer/index.ts
+++ b/packages/ui/Timer/index.ts
@@ -1,0 +1,2 @@
+export * from './Timer.js';
+export * from './TimerProgress.js';

--- a/packages/ui/index.ts
+++ b/packages/ui/index.ts
@@ -27,6 +27,7 @@ export * from './Sentinel/index.js';
 export * from './Slider/index.js';
 export * from './Sticky/index.js';
 export * from './Tabs/index.js';
+export * from './Timer/index.js';
 export * from './Track/index.js';
 export * from './Transition/index.js';
 export * from './ViewTransition/index.js';


### PR DESCRIPTION
## Summary

Adds a headless **`Timer`** countdown primitive and a **`TimerProgress`** subclass, designed to compose with [`Action`](https://ui.studiometa.dev/components/Action/) and the [`Data*`](https://ui.studiometa.dev/components/DataScope/) family the same way the other primitives do — no bespoke wiring required.

```html
<button
  data-component="Action Timer"
  data-option-delay="3"
  data-on:timer-end="console.log('3s elapsed')"
  data-on:click="Timer.restart()">…</button>
```

### `Timer` (base)

- **Options** (`delay` in **seconds**, `repeat`, `autostart`).
- **Events** (all bubbling `CustomEvent`s): `timer-start`, `timer-end`, `timer-tick`, `timer-pause`, `timer-resume`, `timer-stop`.
- **Methods**: `start()`, `restart()`, `stop()`, `pause()`, `resume()` — `pause()` preserves the remaining time.
- Zero per-frame cost: it's just `setTimeout` + DOM events.

### `TimerProgress` (extends `Timer`)

- Adds one event, `timer-progress`, carrying a pause-aware `0 → 1` ratio (`event.detail[0]`) emitted each `requestAnimationFrame`.
- Shipped as a **separate component** on purpose: DOM `CustomEvent`s expose no listener count, so a single timer can't know whether anyone wants progress. Making it a subclass turns "pay for a 60fps loop" into a mount-time choice, keeping the base free. (`config.emits` merges up the prototype chain; the base exposes `@protected` `__arm`/`__complete`/`__clear` seams.)

## Why events bubble

Bubbling lets a single routing `Action` on an ancestor catch `timer-progress` and forward it to a progress-bar `DataBind` in a **separate subtree** — sidestepping `Action`'s same-element scope limit — via the target-arrow syntax:

```html
<div data-on:timer-progress="DataBind([data-role=progress])->target.set(event.detail[0])">
```

This also aligns with js-toolkit v4, where all custom events bubble by default.

## Design decisions (agreed during exploration)

- **Seconds** as the `delay` unit (matches the original prototype); internally `__duration = delay * 1000`.
- **Bubbling by default** (no opt-in option); use the `.stop` modifier to contain.
- **Two components** rather than one component with a `progress` option.

## Test plan

- [x] `packages/tests/Timer/Timer.spec.ts` — config, autostart, delay-in-seconds, bubbling, `repeat`, `no-autostart`, `stop`, `pause`/`resume` remaining-time accuracy, `restart`, destroy cleanup.
- [x] `packages/tests/Timer/TimerProgress.spec.ts` — config + inheritance, emits merge, increasing ratio, final `1`, reset `0` on stop, base lifecycle still fires.
- [x] Updated the `components exports` inline snapshot.
- [x] `npm run test` → 478 passing. `npm run lint` → 0 errors.

## Docs

New `packages/docs/components/Timer/` page (index, JS API, examples) with two playground stories: a click-to-restart timer and a looping, hover-to-pause progress bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)