### PR TITLE
Bump @studiometa/js-toolkit to 3.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4309,9 +4309,9 @@
       "link": true
     },
     "node_modules/@studiometa/js-toolkit": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@studiometa/js-toolkit/-/js-toolkit-3.7.0.tgz",
-      "integrity": "sha512-17T6MVrOMZh73KAXuIU91UIgL10+Xf2qD+twZ363WQanEL0TvxQ6FWaHkWpXdn3wIFNqfqKIUeiFUYeVXsN6dg==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/@studiometa/js-toolkit/-/js-toolkit-3.8.0.tgz",
+      "integrity": "sha512-m7UCx3tJv8tXLSNPTD/4J4RbIxwxORIfD568iL2oc39yXRWv0F71y0PwKMZW9ZFa7X4MjPFJhxkYMnpOSg1kww==",
       "license": "MIT",
       "dependencies": {
         "@motionone/easing": "^10.18.0",
@@ -20688,7 +20688,7 @@
       "name": "@studiometa/ui-docs",
       "version": "1.9.0-beta.1",
       "dependencies": {
-        "@studiometa/js-toolkit": "3.7.0"
+        "@studiometa/js-toolkit": "3.8.0"
       },
       "devDependencies": {
         "@iconify-json/octicon": "1.2.22",
@@ -20741,7 +20741,7 @@
       },
       "devDependencies": {
         "@motionone/easing": "^10.18.0",
-        "@studiometa/js-toolkit": "3.7.0",
+        "@studiometa/js-toolkit": "3.8.0",
         "deepmerge": "^4.3.1",
         "morphdom": "^2.7.8",
         "tsdown": "^0.21.5"
@@ -21167,11 +21167,11 @@
         "morphdom": "^2.7.8"
       },
       "devDependencies": {
-        "@studiometa/js-toolkit": "^3.7.0"
+        "@studiometa/js-toolkit": "^3.8.0"
       },
       "peerDependencies": {
         "@shopify/partial-rendering": "*",
-        "@studiometa/js-toolkit": "^3.7.0"
+        "@studiometa/js-toolkit": "^3.8.0"
       },
       "peerDependenciesMeta": {
         "@shopify/partial-rendering": {

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -12,7 +12,7 @@
     "postbuild": "ln -sf ../../../api/public .vitepress/dist/api"
   },
   "dependencies": {
-    "@studiometa/js-toolkit": "3.7.0"
+    "@studiometa/js-toolkit": "3.8.0"
   },
   "devDependencies": {
     "@iconify-json/octicon": "1.2.22",

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@motionone/easing": "^10.18.0",
-    "@studiometa/js-toolkit": "3.7.0",
+    "@studiometa/js-toolkit": "3.8.0",
     "deepmerge": "^4.3.1",
     "morphdom": "^2.7.8",
     "tsdown": "^0.21.5"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -34,11 +34,11 @@
     "morphdom": "^2.7.8"
   },
   "devDependencies": {
-    "@studiometa/js-toolkit": "^3.7.0"
+    "@studiometa/js-toolkit": "^3.8.0"
   },
   "peerDependencies": {
     "@shopify/partial-rendering": "*",
-    "@studiometa/js-toolkit": "^3.7.0"
+    "@studiometa/js-toolkit": "^3.8.0"
   },
   "peerDependenciesMeta": {
     "@shopify/partial-rendering": {


### PR DESCRIPTION
## Summary

Upgrades `@studiometa/js-toolkit` from `3.7.0` to `3.8.0` across the monorepo:

- `packages/ui` — `devDependencies` and `peerDependencies` → `^3.8.0`
- `packages/docs` — `dependencies` → `3.8.0`
- `packages/playground` — `devDependencies` → `3.8.0`
- `package-lock.json` regenerated.

Scope is intentionally limited to js-toolkit to keep the upgrade low-risk and bisectable; other dependency bumps (including the tailwind 4 / eslint 10 / typescript 7 majors) are deliberately left for separate PRs.

## Test plan

- [x] `npm install` resolves `@studiometa/js-toolkit@3.8.0`.
- [x] `npm run test` → 481 passing.
- [x] `npm run lint` → 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)