### PR TITLE
Prepare 1.9.0-beta.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [v1.9.0-beta.2](https://github.com/studiometa/ui/compare/1.9.0-beta.1..1.9.0-beta.2) (2026-07-23)
+
+### Added
+
+- **InView:** add the `InView` primitive emitting directional `in-view`/`out-of-view` viewport events, together with an `InViewOnce` variant ([#535](https://github.com/studiometa/ui/pull/535))
+- **Fetch:** add a `src` option and a no-argument `fetch()` call ([#536](https://github.com/studiometa/ui/pull/536))
+- **ViewTransition:** add the `ViewTransition` component and its `viewTransition` helper ([#537](https://github.com/studiometa/ui/pull/537))
+- **Dialog:** add the `Dialog` component for accessible modal and drawer patterns ([#538](https://github.com/studiometa/ui/pull/538))
+- **Fetch:** add `FetchShopifyPartial`, an adapter targeting the Shopify Section Rendering API ([#529](https://github.com/studiometa/ui/pull/529), [#531](https://github.com/studiometa/ui/pull/531))
+- **Timer:** add the `Timer` and `TimerProgress` primitives — a headless countdown emitting bubbling lifecycle events, with a `requestAnimationFrame`-driven progress signal ([#545](https://github.com/studiometa/ui/pull/545))
+
+### Changed
+
+- Bump `@studiometa/js-toolkit` to `3.8.0` ([#546](https://github.com/studiometa/ui/pull/546))
+- **Docs:** standardise component registration on `registerComponent` across the usage guide and story files ([#542](https://github.com/studiometa/ui/pull/542), [#543](https://github.com/studiometa/ui/pull/543))
+
+### Deprecated
+
+- **Modal / Panel:** deprecate the `Modal` and `Panel` components in favour of `Dialog` ([#540](https://github.com/studiometa/ui/pull/540), [#541](https://github.com/studiometa/ui/pull/541))
+
 ## [v1.9.0-beta.1](https://github.com/studiometa/ui/compare/1.9.0-beta.0..1.9.0-beta.1) (2026-07-21)
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "studiometa/ui",
   "type": "composer-plugin",
-  "version": "1.9.0-beta.1",
+  "version": "1.9.0-beta.2",
   "description": "A set of opiniated, unstyled and accessible components.",
   "license": "MIT",
   "require": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@studiometa/ui-workspace",
-  "version": "1.9.0-beta.1",
+  "version": "1.9.0-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@studiometa/ui-workspace",
-      "version": "1.9.0-beta.1",
+      "version": "1.9.0-beta.2",
       "hasInstallScript": true,
       "workspaces": [
         "packages/*"
@@ -20682,11 +20682,11 @@
     },
     "packages/api": {
       "name": "@studiometa/ui-api",
-      "version": "1.9.0-beta.1"
+      "version": "1.9.0-beta.2"
     },
     "packages/docs": {
       "name": "@studiometa/ui-docs",
-      "version": "1.9.0-beta.1",
+      "version": "1.9.0-beta.2",
       "dependencies": {
         "@studiometa/js-toolkit": "3.8.0"
       },
@@ -20706,7 +20706,7 @@
     },
     "packages/eslint-plugin-ui": {
       "name": "@studiometa/eslint-plugin-ui",
-      "version": "1.9.0-beta.1",
+      "version": "1.9.0-beta.2",
       "license": "MIT",
       "dependencies": {
         "@oxlint/plugins": "1.63.0"
@@ -20735,7 +20735,7 @@
     },
     "packages/playground": {
       "name": "@studiometa/ui-playground",
-      "version": "1.9.0-beta.1",
+      "version": "1.9.0-beta.2",
       "dependencies": {
         "@studiometa/playground": "0.3.7"
       },
@@ -20906,7 +20906,7 @@
     },
     "packages/tests": {
       "name": "@studiometa/ui-tests",
-      "version": "1.9.0-beta.1",
+      "version": "1.9.0-beta.2",
       "license": "MIT",
       "dependencies": {
         "@happy-dom/global-registrator": "^20.8.8",
@@ -21159,7 +21159,7 @@
     },
     "packages/ui": {
       "name": "@studiometa/ui",
-      "version": "1.9.0-beta.1",
+      "version": "1.9.0-beta.2",
       "license": "MIT",
       "dependencies": {
         "alien-signals": "^3.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-workspace",
-  "version": "1.9.0-beta.1",
+  "version": "1.9.0-beta.2",
   "type": "module",
   "private": true,
   "workspaces": [

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-api",
-  "version": "1.9.0-beta.1",
+  "version": "1.9.0-beta.2",
   "private": true,
   "type": "commonjs"
 }

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-docs",
-  "version": "1.9.0-beta.1",
+  "version": "1.9.0-beta.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/eslint-plugin-ui/package.json
+++ b/packages/eslint-plugin-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/eslint-plugin-ui",
-  "version": "1.9.0-beta.1",
+  "version": "1.9.0-beta.2",
   "description": "ESLint plugin to help developers discover and use @studiometa/ui components",
   "publishConfig": {
     "access": "public"

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-playground",
-  "version": "1.9.0-beta.1",
+  "version": "1.9.0-beta.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-tests",
-  "version": "1.9.0-beta.1",
+  "version": "1.9.0-beta.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui",
-  "version": "1.9.0-beta.1",
+  "version": "1.9.0-beta.2",
   "description": "A set of opiniated, unstyled and accessible components",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary

Prepares the **1.9.0-beta.2** prerelease. Version-only prep — **no tag is pushed**, so nothing publishes yet (the `release` workflow triggers on a pushed `*.*.*` tag).

- Bumps the version `1.9.0-beta.1 → 1.9.0-beta.2` across the root, all workspaces (`api`, `docs`, `eslint-plugin-ui`, `playground`, `tests`, `ui`), `composer.json`, and `package-lock.json`.
- Compiles the `CHANGELOG.md` entry for everything merged since beta.1.

## Changelog entry

### Added
- `InView` / `InViewOnce` primitives (#535)
- `Fetch` `src` option + no-arg `fetch()` (#536)
- `ViewTransition` component + helper (#537)
- `Dialog` component for modal/drawer patterns (#538)
- `FetchShopifyPartial` adapter for the Shopify Section Rendering API (#529, #531)
- `Timer` / `TimerProgress` primitives (#545)

### Changed
- Bump `@studiometa/js-toolkit` to `3.8.0` (#546)
- Standardise docs/stories on `registerComponent` (#542, #543)

### Deprecated
- `Modal` / `Panel` in favour of `Dialog` (#540, #541)

## To publish (after merge)

Tag the merge commit on `main` and push the tag — this triggers the `release` workflow, which publishes to npm under the `next` dist-tag and creates a prerelease GitHub release:

```
git tag -a 1.9.0-beta.2 -m "v1.9.0-beta.2"
git push origin 1.9.0-beta.2
```

## Verification
- [x] `npm run test` → 481 passing
- [x] `npm run lint` → 0 errors
- [x] No stray `1.9.0-beta.1` outside the changelog compare link

🤖 Generated with [Claude Code](https://claude.com/claude-code)