### PR TITLE
Add descriptions to bare class docblocks

### DIFF
--- a/packages/ui/Accordion/Accordion.ts
+++ b/packages/ui/Accordion/Accordion.ts
@@ -5,6 +5,12 @@ import { AccordionItem } from './AccordionItem.js';
 
 /**
  * Accordion class.
+ *
+ * The ready-to-use accordion component. It extends `AccordionCore` with the
+ * default `AccordionItem` child implementation, so declaring `data-component="Accordion"`
+ * on a container with nested `AccordionItem` elements yields a fully working,
+ * optionally auto-closing accordion without any custom item class.
+ *
  * @link https://ui.studiometa.dev/components/Accordion/
  */
 export class Accordion<T extends BaseProps = BaseProps> extends AccordionCore<T & AccordionProps> {

--- a/packages/ui/Accordion/AccordionCore.ts
+++ b/packages/ui/Accordion/AccordionCore.ts
@@ -18,6 +18,13 @@ export interface AccordionProps extends BaseProps {
 
 /**
  * Accordion class.
+ *
+ * The base orchestrator for a group of `AccordionItem` children. It relays each
+ * item's open/close into the `open` and `close` events and, when the `autoclose`
+ * option (`data-option-autoclose`) is set, closes every other item as soon as
+ * one opens. The `item` option is forwarded to each child so item defaults can be
+ * configured from the parent. It carries no child component itself and is meant
+ * to be extended (see `Accordion`).
  */
 export class AccordionCore<T extends BaseProps = BaseProps> extends Base<T & AccordionProps> {
   /**

--- a/packages/ui/Accordion/AccordionItem.ts
+++ b/packages/ui/Accordion/AccordionItem.ts
@@ -22,6 +22,13 @@ export interface AccordionItemProps extends BaseProps {
 
 /**
  * AccordionItem class.
+ *
+ * A single collapsible panel driven by its `btn`, `content` and `container` refs.
+ * It toggles open and closed on button click, animating the container height (and
+ * any other ref styles declared via the `styles` option) with the toolkit
+ * `transition` helper, emits `open`/`close`, and keeps the relevant ARIA
+ * attributes (`aria-expanded`, `aria-controls`, `aria-hidden`, `aria-labelledby`)
+ * in sync. Its initial state is set with the `isOpen` option (`data-option-is-open`).
  */
 export class AccordionItem<T extends BaseProps = BaseProps> extends Base<T & AccordionItemProps> {
   /**

--- a/packages/ui/Action/Action.ts
+++ b/packages/ui/Action/Action.ts
@@ -13,6 +13,14 @@ export interface ActionProps extends BaseProps {
 
 /**
  * Action class.
+ *
+ * A declarative bridge that wires DOM events on its element to effects run on
+ * targeted components. Bindings come from `data-on:<event>` attributes (e.g.
+ * `data-on:click="target.$el.textContent = 'Clicked'"`) and/or the `on`, `target`
+ * and `effect` options, each parsed into an `ActionEvent` that is attached on
+ * mount and detached on destroy. This lets HTML trigger methods or property
+ * changes on other components without writing any JavaScript.
+ *
  * @link https://ui.studiometa.dev/components/Action/
  */
 export class Action<T extends BaseProps = BaseProps> extends Base<ActionProps & T> {

--- a/packages/ui/Action/Target.ts
+++ b/packages/ui/Action/Target.ts
@@ -5,6 +5,11 @@ export interface TargetProps extends BaseProps {}
 
 /**
  * Target class.
+ *
+ * A minimal marker component that exposes its element as an addressable target for
+ * the `Action` component. It defines no behaviour of its own; declaring
+ * `data-component="Target"` simply lets `Action` bindings resolve and act on this
+ * element by name.
  */
 export class Target extends Base<TargetProps> {
   /**

--- a/packages/ui/AnchorNav/AnchorNav.ts
+++ b/packages/ui/AnchorNav/AnchorNav.ts
@@ -12,6 +12,13 @@ export interface AnchorNavProps extends BaseProps {
 
 /**
  * AnchorNav class.
+ *
+ * Coordinates a set of `AnchorNavLink` children with their matching
+ * `AnchorNavTarget` sections. As each target enters or leaves (its
+ * mount/destroy is reported to the parent), the links whose `targetId` matches
+ * the target's element id are toggled active via their `enter()`/`leave()`
+ * methods, keeping the navigation highlight in sync with the visible section.
+ *
  * @link https://ui.studiometa.dev/components/AnchorNav/
  */
 export class AnchorNav<T extends BaseProps = BaseProps> extends Base<T & AnchorNavProps> {

--- a/packages/ui/AnchorScrollTo/AnchorScrollTo.ts
+++ b/packages/ui/AnchorScrollTo/AnchorScrollTo.ts
@@ -8,6 +8,13 @@ export interface AnchorScrollToProps extends BaseProps {
 
 /**
  * AnchorScrollTo class.
+ *
+ * Enhances an anchor element so that clicking it smoothly scrolls to the element
+ * referenced by its `href` hash instead of jumping. It reads the target from the
+ * link's `hash`, delegates the animation to the toolkit `scrollTo` helper and
+ * prevents the default jump; if the target cannot be resolved the click is left
+ * untouched.
+ *
  * @link https://ui.studiometa.dev/components/AnchorScrollto/
  */
 export class AnchorScrollTo<T extends BaseProps = BaseProps> extends Base<AnchorScrollToProps & T> {

--- a/packages/ui/CircularMarquee/CircularMarquee.ts
+++ b/packages/ui/CircularMarquee/CircularMarquee.ts
@@ -9,6 +9,13 @@ export interface CircularMarqueeProps extends BaseProps {
 
 /**
  * CircularMarquee class.
+ *
+ * Continuously rotates its element in response to scrolling, turning page scroll
+ * into a spinning marquee. Each scroll event feeds the vertical delta into a
+ * rotation accumulated on every animation frame, damped for smoothness and scaled
+ * by the `sensitivity` option (`data-option-sensitivity`, default `0.1`), then
+ * applied through a CSS transform.
+ *
  * @link https://ui.studiometa.dev/components/CircularMarquee/
  */
 export class CircularMarquee extends Base<CircularMarqueeProps> {

--- a/packages/ui/Cursor/Cursor.ts
+++ b/packages/ui/Cursor/Cursor.ts
@@ -17,6 +17,13 @@ export interface CursorProps extends BaseProps {
 
 /**
  * Cursor class.
+ *
+ * Custom cursor that follows the pointer, damping its position each frame for a
+ * smooth trail. It grows over elements matching `growSelectors` and shrinks over
+ * `shrinkSelectors` or while the pointer is down, interpolating between the
+ * `scale`, `growTo` and `shrinkTo` factors with per-transition damping options
+ * and applying the result as a `transform` on the root element.
+ *
  * @link https://ui.studiometa.dev/components/Cursor/
  */
 export class Cursor<T extends BaseProps = BaseProps> extends Base<CursorProps & T> {

--- a/packages/ui/Data/DataBind.ts
+++ b/packages/ui/Data/DataBind.ts
@@ -32,6 +32,17 @@ type VirtualBinding =
 
 /**
  * DataBind class.
+ *
+ * Part of the reactive Data* family. It creates a binding between a DOM element
+ * and a shared value within its Data group — optionally scoped by an enclosing
+ * `DataScope` — reflecting values published by the other members of the group
+ * onto the element. The bound target defaults to a form control's value or the
+ * element's `textContent`, can be overridden with the `prop` option, keyed with
+ * the `key` option, and propagated on mount with `immediate`; `data-bind:*`
+ * attributes additionally drive an element's property, attribute, class, style
+ * or text from the same value. It also exposes `set`, `toggle`, `increment` and
+ * `cycle` helpers to publish changes back to the group.
+ *
  * @link https://ui.studiometa.dev/components/DataBind/
  */
 export class DataBind<T extends BaseProps = BaseProps> extends withGroup<Base, DataScope>(

--- a/packages/ui/Draggable/Draggable.ts
+++ b/packages/ui/Draggable/Draggable.ts
@@ -26,6 +26,15 @@ export interface DraggableProps extends BaseProps {
 
 /**
  * Draggable class.
+ *
+ * Makes a `target` ref draggable within its parent element using the `withDrag`
+ * decorator. Dragging can be constrained to the `x` and/or `y` axes, is damped
+ * via the `sensitivity` and `dropSensitivity` options, and the target can be
+ * kept inside the parent bounds (plus a configurable `margin`) with `fitBounds`
+ * or `strictFitBounds`. It emits `drag-start`, `drag-drag`, `drag-drop`,
+ * `drag-inertia`, `drag-stop`, `drag-fit` and `drag-render` events across the
+ * drag lifecycle.
+ *
  * @link https://ui.studiometa.dev/components/Draggable/
  */
 export class Draggable<T extends BaseProps = BaseProps> extends withDrag(Base, {

--- a/packages/ui/Fetch/Fetch.ts
+++ b/packages/ui/Fetch/Fetch.ts
@@ -27,6 +27,14 @@ export type FetchConstructor<T extends Fetch = Fetch> = {
 
 /**
  * Fetch class.
+ *
+ * A self-contained AJAX navigation primitive bound to a link, a form or any element with a
+ * `src` option. It resolves the request URL and `requestInit` from that element, fetches the
+ * content, then updates the DOM by matching elements from the response against the current
+ * page via the `selector` option and swapping them following the `mode` option (`replace`,
+ * `prepend`, `append` or `morph`). It optionally pushes browser history, wraps the update in a
+ * View Transition and emits a full set of lifecycle events.
+ *
  * @link https://ui.studiometa.dev/components/Fetch/
  */
 export class Fetch<T extends BaseProps = BaseProps>

--- a/packages/ui/Figure/AbstractFigure.ts
+++ b/packages/ui/Figure/AbstractFigure.ts
@@ -14,6 +14,12 @@ export interface AbstractFigureProps extends BaseProps {
 
 /**
  * Figure class.
+ *
+ * Shared base for the image figure components. It wraps a single `img` ref in a
+ * `Transition` and, through the `withMountWhenInView` decorator, defers loading
+ * of the `data-src` source until the element enters the viewport when the `lazy`
+ * option is set, running the enter transition and emitting `load` once the image
+ * is ready.
  */
 export class AbstractFigure<
   T extends BaseProps = BaseProps,

--- a/packages/ui/Figure/AbstractFigureDynamic.ts
+++ b/packages/ui/Figure/AbstractFigureDynamic.ts
@@ -11,6 +11,13 @@ export interface AbstractFigureDynamicProps extends BaseProps {
 
 /**
  * AbstractFigureDynamic class.
+ *
+ * Shared base for figures whose source is computed at runtime from the element's
+ * rendered size. It extends `AbstractFigure`, defaults the `lazy` option to
+ * `true`, and passes the original `data-src` through the overridable `formatSrc`
+ * method, unless the `disable` option is set. Its own `formatSrc` returns the
+ * source unchanged, so subclasses provide the actual transformation, and on
+ * resize it recomputes and reloads the source.
  */
 export class AbstractFigureDynamic<T extends BaseProps = BaseProps> extends AbstractFigure<
   T & AbstractFigureDynamicProps

--- a/packages/ui/Figure/Figure.ts
+++ b/packages/ui/Figure/Figure.ts
@@ -6,6 +6,11 @@ export interface FigureProps extends AbstractFigureProps {}
 
 /**
  * Figure class.
+ *
+ * Concrete lazy-loaded image figure built on `AbstractFigure`. It loads the
+ * `data-src` source when the element scrolls into view, then terminates itself
+ * once the image has loaded, as it has no further work to do after the reveal.
+ *
  * @link https://ui.studiometa.dev/components/Figure/
  */
 export class Figure<T extends BaseProps = BaseProps> extends AbstractFigure<T> {

--- a/packages/ui/Figure/FigureTwicpics.ts
+++ b/packages/ui/Figure/FigureTwicpics.ts
@@ -24,6 +24,13 @@ const isBot = /bot|crawl|slurp|spider/i.test(navigator.userAgent);
 
 /**
  * FigureTwicpics class.
+ *
+ * Dynamic image figure that rewrites its source into a TwicPics URL sized to the
+ * rendered element. Building on `AbstractFigureDynamic`, its `formatSrc` injects
+ * a `twic` query built from the `domain`, `path`, `transform` and `mode` options
+ * and the measured dimensions, multiplied by the device pixel ratio unless `dpr`
+ * is disabled or a bot is detected.
+ *
  * @link https://ui.studiometa.dev/components/FigureTwicpics/
  */
 export class FigureTwicpics<T extends BaseProps = BaseProps> extends AbstractFigureDynamic<

--- a/packages/ui/FigureVideo/FigureVideo.ts
+++ b/packages/ui/FigureVideo/FigureVideo.ts
@@ -14,6 +14,13 @@ export interface FigureVideoProps extends BaseProps {
 
 /**
  * FigureVideo class.
+ *
+ * Lazy-loaded video counterpart to `Figure`. Built on `Transition` and the
+ * `withMountWhenInView` decorator, it defers loading of the `video` ref's
+ * `data-poster` and `data-src` sources until the element enters the viewport when
+ * `lazy` is set, runs the enter transition, emits `load`, and then terminates
+ * itself.
+ *
  * @link https://ui.studiometa.dev/components/FigureVideo/
  */
 export class FigureVideo<T extends BaseProps = BaseProps> extends withMountWhenInView<Transition>(

--- a/packages/ui/Frame/AbstractFrameTrigger.ts
+++ b/packages/ui/Frame/AbstractFrameTrigger.ts
@@ -17,6 +17,11 @@ export interface AbstractFrameTriggerProps extends BaseProps {
 
 /**
  * AbstractFrameTrigger class.
+ *
+ * The shared base for the Frame navigation triggers (`FrameAnchor` and `FrameForm`). It
+ * resolves the request URL and `requestInit` from the root element, exposes a `trigger()`
+ * method that emits the `frame-trigger` event consumed by the parent `Frame`, and drives
+ * its `FrameTriggerLoader` children during the request lifecycle.
  */
 export class AbstractFrameTrigger<T extends BaseProps = BaseProps> extends Base<
   T & AbstractFrameTriggerProps

--- a/packages/ui/Frame/Frame.ts
+++ b/packages/ui/Frame/Frame.ts
@@ -24,6 +24,14 @@ export interface FrameProps extends BaseProps {
 
 /**
  * Frame class.
+ *
+ * The container of the Frame AJAX navigation system. It listens for `frame-trigger`
+ * events emitted by its `FrameAnchor` and `FrameForm` children, fetches the target URL,
+ * parses the returned HTML and dispatches the matching fragments to its `FrameTarget`
+ * children for swapping. It optionally pushes browser history (and reacts to `popstate`),
+ * drives `FrameLoader` children during the request and re-runs `$root.$update()` so newly
+ * injected components are mounted.
+ *
  * @link https://ui.studiometa.dev/components/Frame/
  */
 export class Frame<T extends BaseProps = BaseProps> extends Base<T & FrameProps> {

--- a/packages/ui/Frame/FrameAnchor.ts
+++ b/packages/ui/Frame/FrameAnchor.ts
@@ -7,6 +7,10 @@ export interface FrameAnchorProps extends BaseProps {
 
 /**
  * FrameAnchor class.
+ *
+ * The link trigger of the Frame navigation system. Bound to an `<a>` element, it prevents
+ * the default navigation on a plain left click (ignoring modifier keys and `target="_blank"`)
+ * and calls `trigger()` to have the parent `Frame` fetch the link's `href` instead.
  */
 export class FrameAnchor<T extends BaseProps = BaseProps> extends AbstractFrameTrigger<
   T & FrameAnchorProps

--- a/packages/ui/Frame/FrameForm.ts
+++ b/packages/ui/Frame/FrameForm.ts
@@ -10,6 +10,11 @@ export interface FrameFormProps extends BaseProps {
 
 /**
  * FrameForm class.
+ *
+ * The form trigger of the Frame navigation system. Bound to a `<form>` element, it prevents
+ * the default submission (unless `target="_blank"`) and calls `trigger()` so the parent
+ * `Frame` fetches the form's action, sending the form data as query params for GET or as a
+ * `FormData` body for POST, plus any headers declared through `headers` refs.
  */
 export class FrameForm<T extends BaseProps = BaseProps> extends AbstractFrameTrigger<
   T & FrameFormProps

--- a/packages/ui/Frame/FrameTarget.ts
+++ b/packages/ui/Frame/FrameTarget.ts
@@ -11,6 +11,11 @@ export interface FrameTargetProps extends BaseProps {
 
 /**
  * FrameTarget class.
+ *
+ * The swap region of the Frame navigation system. Identified by its `id`, it receives the
+ * matching fragment from the fetched HTML and updates its content according to the `mode`
+ * option (`replace`, `prepend`, `append` or `morph`). It extends `Transition` to play the
+ * leave/enter transitions around the swap and re-adopts any newly inserted `<script>` tags.
  */
 export class FrameTarget<T extends BaseProps = BaseProps> extends Transition<T & FrameTargetProps> {
   /**

--- a/packages/ui/Frame/FrameTriggerLoader.ts
+++ b/packages/ui/Frame/FrameTriggerLoader.ts
@@ -6,6 +6,11 @@ export type FrameTriggerLoaderProps = FrameLoaderProps;
 
 /**
  * FrameTriggerLoader class.
+ *
+ * The per-trigger loading indicator of the Frame navigation system. A `FrameLoader`
+ * scoped to a single `AbstractFrameTrigger`, whose `enter()`/`leave()` transitions are
+ * played only while that trigger's own request is in flight, rather than for every
+ * request handled by the parent `Frame`.
  */
 export class FrameTriggerLoader<T extends BaseProps = BaseProps> extends FrameLoader<
   T & FrameTriggerLoaderProps

--- a/packages/ui/Hoverable/Hoverable.ts
+++ b/packages/ui/Hoverable/Hoverable.ts
@@ -27,6 +27,13 @@ export interface HoverableProps extends BaseProps {
 
 /**
  * Hoverable class.
+ *
+ * Moves a `target` ref in response to the pointer's position over the root
+ * element, using the `withRelativePointer` decorator. The target is mapped across
+ * its available bounds and damped each frame by the `sensitivity` option; the
+ * `reversed` option inverts the movement and `contained` stops it once the
+ * pointer leaves the element.
+ *
  * @link https://ui.studiometa.dev/components/Hoverable/
  */
 export class Hoverable<T extends BaseProps = BaseProps> extends withRelativePointer(Base)<

--- a/packages/ui/Indexable/Indexable.ts
+++ b/packages/ui/Indexable/Indexable.ts
@@ -3,6 +3,11 @@ import { withIndex } from '../decorators/index.js';
 
 /**
  * Indexable class.
+ *
+ * A primitive built on the `withIndex` decorator that tracks a current index
+ * within a total, with configurable boundary behaviour (`clamp`, `loop` or
+ * `bounce`). It serves as a base for index-driven components such as sliders
+ * and carousels.
  */
 export class Indexable<T extends BaseProps = BaseProps> extends withIndex<Base>(Base)<T> {
   /**

--- a/packages/ui/LargeText/LargeText.ts
+++ b/packages/ui/LargeText/LargeText.ts
@@ -15,6 +15,13 @@ export interface LargeTextProps extends BaseProps {
 
 /**
  * LargeText class.
+ *
+ * A component that continuously translates its `target` ref horizontally,
+ * looping as the content scrolls out of view, to render horizontally scrolling
+ * text. The motion is driven by scroll delta and tuned via the `sensitivity`
+ * option, with an optional `skew` effect. Built on the `withMountWhenInView`
+ * decorator so it only runs while visible.
+ *
  * @link https://ui.studiometa.dev/components/LargeText/
  */
 export class LargeText<T extends BaseProps = BaseProps>

--- a/packages/ui/LazyInclude/LazyInclude.ts
+++ b/packages/ui/LazyInclude/LazyInclude.ts
@@ -14,6 +14,12 @@ export interface LazyIncludeProps extends BaseProps {
 
 /**
  * LazyInclude class.
+ *
+ * Lazily fetches remote HTML from the `src` option on mount and injects it into
+ * the element, toggling `loading` and `error` refs accordingly. It emits
+ * `content`, `error` and `always`, and can self-terminate once loaded via the
+ * `terminateOnLoad` option.
+ *
  * @link https://ui.studiometa.dev/components/LazyInclude/
  */
 export class LazyInclude<T extends BaseProps = BaseProps>

--- a/packages/ui/Menu/Menu.ts
+++ b/packages/ui/Menu/Menu.ts
@@ -18,6 +18,12 @@ export interface MenuProps extends BaseProps {
 
 /**
  * Menu class.
+ *
+ * A disclosure menu orchestrating a `MenuBtn` toggle button and a collapsible
+ * `MenuList`. The `mode` option chooses whether it opens on click or on hover,
+ * and it wires up ARIA attributes, keyboard handling (Enter/Escape),
+ * click-outside dismissal and mutual closing of sibling submenus.
+ *
  * @link https://ui.studiometa.dev/components/Menu/
  */
 export class Menu<T extends BaseProps = BaseProps> extends Base<T & MenuProps> {

--- a/packages/ui/Menu/MenuBtn.ts
+++ b/packages/ui/Menu/MenuBtn.ts
@@ -3,6 +3,10 @@ import type { BaseConfig, BaseProps } from '@studiometa/js-toolkit';
 
 /**
  * MenuBtn class.
+ *
+ * The toggle button child of a `Menu`. It tracks its own hover state and stops
+ * propagation of `mouseenter`/`mouseleave` events so the parent `Menu` can
+ * distinguish hovering the button from hovering the list.
  */
 export class MenuBtn<T extends BaseProps = BaseProps> extends Base<T> {
   /**

--- a/packages/ui/Menu/MenuList.ts
+++ b/packages/ui/Menu/MenuList.ts
@@ -25,6 +25,12 @@ export interface MenuListProps extends BaseProps {
 
 /**
  * MenuList class.
+ *
+ * The collapsible list child of a `Menu`, extending `Transition` to animate its
+ * reveal. It exposes `open()`, `close()` and `toggle()`, keeps `aria-hidden`
+ * and the `tabindex` of its focusable elements in sync with its visibility,
+ * recursively closes nested lists, and emits `items-open`, `items-close` and
+ * `items-mouseleave`.
  */
 export class MenuList<T extends BaseProps = BaseProps> extends Transition<T & MenuListProps> {
   /**

--- a/packages/ui/Modal/Modal.ts
+++ b/packages/ui/Modal/Modal.ts
@@ -45,6 +45,13 @@ export interface ModalProps extends BaseProps {
 
 /**
  * Modal class.
+ *
+ * An overlay dialog component that opens and closes via `open`/`close` refs and
+ * an `overlay`, transitioning per-ref styles between open and closed states. It
+ * traps focus, closes on Escape, can lock document scroll, optionally autofocus
+ * an element and relocate its markup in the DOM via the `move` option, and
+ * emits `open` and `close`. Deprecated in favour of the `Dialog` component.
+ *
  * @link https://ui.studiometa.dev/components/Modal/
  */
 export class Modal<T extends BaseProps = BaseProps> extends withDeprecation(

--- a/packages/ui/Modal/ModalWithTransition.ts
+++ b/packages/ui/Modal/ModalWithTransition.ts
@@ -3,6 +3,11 @@ import { Modal } from './Modal.js';
 
 /**
  * ModalWithTransition class.
+ *
+ * A `Modal` variant that ships default transition styles for its modal,
+ * overlay and container refs, adding fade and scale animations to the
+ * open/close lifecycle while managing the modal's `visibility` around them.
+ * Deprecated in favour of the `Dialog` component.
  */
 export class ModalWithTransition<T extends BaseProps = BaseProps> extends Modal<T> {
   /**

--- a/packages/ui/Panel/Panel.ts
+++ b/packages/ui/Panel/Panel.ts
@@ -12,6 +12,12 @@ const DEFAULT_POSITION = 'left';
 
 /**
  * Panel class.
+ *
+ * A `Modal` variant that slides its container in from a screen edge chosen by
+ * the `position` option (`top`, `right`, `bottom` or `left`), animating the
+ * container's transform and the overlay's opacity on open and close.
+ * Deprecated in favour of the `Dialog` component.
+ *
  * @link https://ui.studiometa.dev/components/Panel/
  */
 export class Panel<T extends BaseProps = BaseProps> extends Modal<T & PanelProps> {

--- a/packages/ui/Prefetch/AbstractPrefetch.ts
+++ b/packages/ui/Prefetch/AbstractPrefetch.ts
@@ -10,6 +10,13 @@ export interface AbstractPrefetchProps extends BaseProps {
 
 /**
  * AbstractPrefetch class.
+ *
+ * Shared base for the prefetch components, bound to an anchor element. It
+ * injects a `<link rel="prefetch">` for the anchor's `href` when the URL is
+ * prefetchable — same-origin, not the current page, and not disabled by the
+ * `prefetch` option — deduplicates across instances and emits a `prefetched`
+ * event. Subclasses decide when `prefetch()` is called.
+ *
  * @link https://ui.studiometa.dev/components/Prefetch/
  */
 export class AbstractPrefetch<T extends BaseProps = BaseProps> extends Base<

--- a/packages/ui/Prefetch/PrefetchWhenOver.ts
+++ b/packages/ui/Prefetch/PrefetchWhenOver.ts
@@ -3,6 +3,10 @@ import { AbstractPrefetch } from './AbstractPrefetch.js';
 
 /**
  * PrefetchWhenOver class.
+ *
+ * An `AbstractPrefetch` that prefetches the link's URL when the pointer enters
+ * the anchor, via its `onMouseenter` handler.
+ *
  * @link https://ui.studiometa.dev/components/Prefetch/
  */
 export class PrefetchWhenOver<T extends BaseProps = BaseProps> extends AbstractPrefetch<T> {

--- a/packages/ui/Prefetch/PrefetchWhenVisible.ts
+++ b/packages/ui/Prefetch/PrefetchWhenVisible.ts
@@ -4,6 +4,10 @@ import { AbstractPrefetch } from './AbstractPrefetch.js';
 
 /**
  * PrefetchWhenVisible class.
+ *
+ * An `AbstractPrefetch` using the `withMountWhenInView` decorator so it mounts
+ * only when the link enters the viewport, prefetching its URL on mount.
+ *
  * @link https://ui.studiometa.dev/components/Prefetch/
  */
 export class PrefetchWhenVisible extends withMountWhenInView<AbstractPrefetch>(AbstractPrefetch) {

--- a/packages/ui/ScrollAnimation/AbstractScrollAnimation.ts
+++ b/packages/ui/ScrollAnimation/AbstractScrollAnimation.ts
@@ -15,6 +15,14 @@ export interface AbstractScrollAnimationProps extends BaseProps {
 
 /**
  * AbstractScrollAnimation class.
+ *
+ * Shared base for the scroll-linked animation components. It drives a
+ * `@studiometa/js-toolkit` `animate` instance from the element's scroll
+ * progress, mapping the `scrolledInView` damped progress through the
+ * configurable `playRange` onto the animation defined by the `from`/`to` or
+ * `keyframes` and `easing` options. Options are frozen via `withFreezedOptions`,
+ * and the animation is restored on mount and snapped to its nearest boundary on
+ * destroy.
  */
 export class AbstractScrollAnimation<
   T extends BaseProps = BaseProps,

--- a/packages/ui/ScrollAnimation/ScrollAnimation.ts
+++ b/packages/ui/ScrollAnimation/ScrollAnimation.ts
@@ -12,6 +12,12 @@ export interface ScrollAnimationProps extends BaseProps {
 /**
  * ScrollAnimation class.
  *
+ * A single-element scroll-linked animation: it extends
+ * `AbstractScrollAnimation` with the `withScrolledInView` decorator and animates
+ * its `target` ref as the element scrolls through the viewport. Superseded by
+ * the timeline-based API — use `ScrollAnimationTimeline` with
+ * `ScrollAnimationTarget` children instead.
+ *
  * @deprecated Use `ScrollAnimationTimeline` with `ScrollAnimationTarget` children instead.
  * @link https://ui.studiometa.dev/components/ScrollAnimation/
  */

--- a/packages/ui/ScrollAnimation/ScrollAnimationChild.ts
+++ b/packages/ui/ScrollAnimation/ScrollAnimationChild.ts
@@ -33,6 +33,12 @@ function updateProps(
 /**
  * ScrollAnimationChild class.
  *
+ * An animation target driven by a `ScrollAnimationParent`: it extends
+ * `AbstractScrollAnimation` and smooths the parent's scroll progress with its
+ * own `dampFactor` and `dampPrecision` options before rendering, giving each
+ * child independent easing. Superseded by the timeline-based API — use
+ * `ScrollAnimationTarget` instead.
+ *
  * @deprecated Use `ScrollAnimationTarget` instead.
  */
 export class ScrollAnimationChild<T extends BaseProps = BaseProps> extends AbstractScrollAnimation<

--- a/packages/ui/ScrollAnimation/ScrollAnimationChildWithEase.ts
+++ b/packages/ui/ScrollAnimation/ScrollAnimationChildWithEase.ts
@@ -6,6 +6,11 @@ import { animationScrollWithEase } from './animationScrollWithEase.js';
 /**
  * ScrollAnimationChildWithEase class.
  *
+ * A `ScrollAnimationChild` wrapped with the `animationScrollWithEase` mixin,
+ * which applies an easing function — selected via its `ease` option (default
+ * `outExpo`) — to the child's damped scroll progress before rendering.
+ * Superseded by the timeline-based API — use `ScrollAnimationTarget` instead.
+ *
  * @deprecated Use `ScrollAnimationTarget` instead.
  */
 export class ScrollAnimationChildWithEase extends animationScrollWithEase(ScrollAnimationChild) {

--- a/packages/ui/ScrollAnimation/ScrollAnimationParent.ts
+++ b/packages/ui/ScrollAnimation/ScrollAnimationParent.ts
@@ -12,6 +12,12 @@ export interface ScrollAnimationParentProps extends BaseProps {
 /**
  * ScrollAnimationParent class.
  *
+ * The scroll driver for a group of animations: it uses the `withScrolledInView`
+ * decorator and forwards its `scrolledInView` progress to every
+ * `ScrollAnimationChild` component it contains, so several targets share one
+ * scroll range. Superseded by the timeline-based API — use
+ * `ScrollAnimationTimeline` instead.
+ *
  * @deprecated Use `ScrollAnimationTimeline` instead.
  */
 export class ScrollAnimationParent<T extends BaseProps = BaseProps> extends withScrolledInView(

--- a/packages/ui/ScrollAnimation/ScrollAnimationWithEase.ts
+++ b/packages/ui/ScrollAnimation/ScrollAnimationWithEase.ts
@@ -6,6 +6,12 @@ import { animationScrollWithEase } from './animationScrollWithEase.js';
 /**
  * ScrollAnimationWithEase class.
  *
+ * A `ScrollAnimation` wrapped with the `animationScrollWithEase` mixin, which
+ * applies an easing function — selected via its `ease` option (default
+ * `outExpo`) — to the scroll progress before rendering. Superseded by the
+ * timeline-based API — use `ScrollAnimationTimeline` with `ScrollAnimationTarget`
+ * children instead.
+ *
  * @deprecated Use `ScrollAnimationTimeline` with `ScrollAnimationTarget` children instead.
  */
 export class ScrollAnimationWithEase extends animationScrollWithEase(ScrollAnimation) {

--- a/packages/ui/ScrollReveal/ScrollReveal.ts
+++ b/packages/ui/ScrollReveal/ScrollReveal.ts
@@ -13,6 +13,13 @@ export interface ScrollRevealProps extends BaseProps {
 
 /**
  * ScrollReveal class.
+ *
+ * Plays a `Transition`'s `enter` transition when the element scrolls into view.
+ * Built on the `withMountWhenInView` decorator, it reveals its `target` ref (or
+ * the element itself) once and terminates, unless the `repeat` option is set, in
+ * which case it re-runs the transition on each entry while tracking scroll
+ * direction to skip reveals when scrolling up.
+ *
  * @link https://ui.studiometa.dev/components/ScrollReveal/
  */
 export class ScrollReveal<T extends BaseProps = BaseProps> extends withMountWhenInView<Transition>(

--- a/packages/ui/Sentinel/Sentinel.ts
+++ b/packages/ui/Sentinel/Sentinel.ts
@@ -3,6 +3,12 @@ import type { BaseConfig } from '@studiometa/js-toolkit';
 
 /**
  * Sentinel class.
+ *
+ * A minimal marker element that reports its own viewport intersection. Built on the
+ * `withIntersectionObserver` decorator with a `[0, 1]` threshold, it emits the decorator's
+ * `intersected` event so a parent component (such as `Sticky`) can react to the element
+ * entering or leaving the viewport.
+ *
  * @link https://ui.studiometa.dev/components/Sentinel/
  */
 export class Sentinel extends withIntersectionObserver(Base, { threshold: [0, 1] }) {

--- a/packages/ui/Slider/AbstractSliderChild.ts
+++ b/packages/ui/Slider/AbstractSliderChild.ts
@@ -7,6 +7,14 @@ export interface AbstractSliderChildProps extends BaseProps {}
 
 /**
  * AbstractSliderChild class.
+ *
+ * The shared base for Slider controls (buttons, counter, dots, progress). It
+ * connects to its parent `Slider` — either handed over by the Slider on mount
+ * or resolved through a guarded `$closest('Slider')` lookup, never via the
+ * deprecated `$parent` accessor — and subscribes to the Slider's index store,
+ * scheduling a call to the subclass `update(index)` method whenever the active
+ * slide changes. Subclasses must implement `update` to reflect the current
+ * index in the DOM.
  */
 export class AbstractSliderChild<T extends BaseProps = BaseProps> extends Base<
   T & AbstractSliderChildProps

--- a/packages/ui/Slider/Slider.ts
+++ b/packages/ui/Slider/Slider.ts
@@ -44,6 +44,17 @@ export interface SliderProps extends BaseProps {
 
 /**
  * Slider class.
+ *
+ * The root of the carousel/slider system. It measures its `SliderItem`
+ * children against the `wrapper` ref to compute per-slide positions for the
+ * `left`, `center` and `right` modes, then drives navigation through `goTo`,
+ * `goNext` and `goPrev` — emitting `goto` and `index` events and broadcasting
+ * the active index over a per-instance store its `AbstractSliderChild`
+ * controls subscribe to. Drag interactions handled by the `SliderDrag` child
+ * feed inertia-based slide selection, honouring the `fitBounds`, `contain`,
+ * `sensitivity` and `dropSensitivity` options, and arrow-key navigation is
+ * supported when the wrapper is focused.
+ *
  * @link https://ui.studiometa.dev/components/Slider/
  * @todo a11y
  */

--- a/packages/ui/Slider/SliderBtn.ts
+++ b/packages/ui/Slider/SliderBtn.ts
@@ -11,6 +11,12 @@ export interface SliderBtnProps extends BaseProps {
 
 /**
  * SliderBtn class.
+ *
+ * A previous/next navigation button for the Slider. Configured through the
+ * `prev` and `next` options, it calls the parent Slider's `goPrev`/`goNext` on
+ * click and toggles its own `disabled` attribute at the slider bounds. With the
+ * `contain` option it additionally disables the next button once the contained
+ * end state is reached, provided the parent Slider also runs in `contain` mode.
  */
 export class SliderBtn<T extends BaseProps = BaseProps> extends AbstractSliderChild<
   T & SliderBtnProps

--- a/packages/ui/Slider/SliderCount.ts
+++ b/packages/ui/Slider/SliderCount.ts
@@ -10,6 +10,10 @@ export interface SliderCountProps extends BaseProps {
 
 /**
  * SliderCount class.
+ *
+ * A slide index counter for the Slider. It writes the human-readable position
+ * of the active slide (the current index plus one) into its `current` ref
+ * whenever the Slider index changes.
  */
 export class SliderCount<T extends BaseProps = BaseProps> extends AbstractSliderChild<
   T & SliderCountProps

--- a/packages/ui/Slider/SliderDots.ts
+++ b/packages/ui/Slider/SliderDots.ts
@@ -10,6 +10,10 @@ export interface SliderDotsProps extends BaseProps {
 
 /**
  * SliderDots class.
+ *
+ * Pagination dots for the Slider. It reflects the active slide by running the
+ * `withTransition` enter/leave classes on the `dots` refs as the index changes,
+ * and navigates the parent Slider to the matching slide when a dot is clicked.
  */
 export class SliderDots<
   T extends BaseProps = BaseProps,

--- a/packages/ui/Slider/SliderDrag.ts
+++ b/packages/ui/Slider/SliderDrag.ts
@@ -9,6 +9,12 @@ export interface SliderDragProps extends BaseProps {
 
 /**
  * SliderDrag class.
+ *
+ * The draggable track of the Slider, built on the `withDrag` decorator. It
+ * re-emits the drag lifecycle as `start`, `drag`, `drop`, `inertia` and `stop`
+ * events for the parent Slider to translate into slide motion, and blocks
+ * vertical scrolling during a mostly-horizontal touch drag once movement passes
+ * the `scrollLockThreshold` option.
  */
 export class SliderDrag<T extends BaseProps = BaseProps> extends withDrag(Base)<
   T & SliderDragProps

--- a/packages/ui/Slider/SliderItem.ts
+++ b/packages/ui/Slider/SliderItem.ts
@@ -6,6 +6,12 @@ export interface SliderItemProps extends BaseProps {}
 
 /**
  * SliderItem class.
+ *
+ * A single slide within the Slider. It caches its bounding rectangle for the
+ * Slider's position computations and translates itself along the x axis on
+ * demand — either instantly via `moveInstantly` or with a damped, ticked
+ * animation via `move` — while exposing `activate`/`disactivate` to toggle its
+ * `is-active` state and setting `role`/`aria` attributes for accessibility.
  */
 export class SliderItem<T extends BaseProps = BaseProps> extends Base<T & SliderItemProps> {
   /**

--- a/packages/ui/Slider/SliderProgress.ts
+++ b/packages/ui/Slider/SliderProgress.ts
@@ -10,6 +10,10 @@ export interface SliderProgressProps extends BaseProps {
 
 /**
  * SliderProgress class.
+ *
+ * A progress indicator for the Slider. It translates its `progress` ref along
+ * the x axis in proportion to the active index over the slider's total range,
+ * revealing more of the bar as the slider advances.
  */
 export class SliderProgress<T extends BaseProps = BaseProps> extends AbstractSliderChild<
   T & SliderProgressProps

--- a/packages/ui/Sticky/Sticky.ts
+++ b/packages/ui/Sticky/Sticky.ts
@@ -18,6 +18,13 @@ export interface StickyProps extends BaseProps {
 
 /**
  * Sticky class.
+ *
+ * A sticky-positioning primitive that stacks multiple sticky elements without overlap. It
+ * uses a child `Sentinel` to detect when the element becomes stuck, then offsets and
+ * z-indexes each instance against the others sharing its positioning context. The
+ * `hideWhenUp` and `hideWhenDown` options let it hide on scroll direction, and the `zIndex`
+ * option sets the base stacking order.
+ *
  * @link https://ui.studiometa.dev/components/Sticky/
  */
 export class Sticky<T extends BaseProps = BaseProps> extends Base<T & StickyProps> {

--- a/packages/ui/Tabs/Tabs.ts
+++ b/packages/ui/Tabs/Tabs.ts
@@ -26,6 +26,12 @@ export interface TabsProps extends BaseProps {
 
 /**
  * Tabs class.
+ *
+ * A tabs component pairing `btn` and `content` refs by index: clicking a button
+ * enables its panel and disables the others, transitioning each panel between
+ * open and closed states defined by the `styles` option while keeping ARIA
+ * attributes in sync. Emits `enable` and `disable`.
+ *
  * @link https://ui.studiometa.dev/components/Tabs/
  */
 export class Tabs<T extends BaseProps = BaseProps> extends Base<T & TabsProps> {

--- a/packages/ui/Transition/Transition.ts
+++ b/packages/ui/Transition/Transition.ts
@@ -23,6 +23,12 @@ export type TransitionConstructor<T extends Transition = Transition> = {
 
 /**
  * Transition class.
+ *
+ * A primitive built on the `withTransition` decorator that runs enter/leave CSS
+ * transitions on its element. It exposes `enter()`, `leave()` and `toggle()`
+ * and emits the corresponding transition lifecycle events
+ * (`transition-enter`, `transition-leave` and their start/end variants).
+ *
  * @link https://ui.studiometa.dev/components/Transition/
  */
 export class Transition<T extends BaseProps = BaseProps> extends withTransition<Base>(Base)<T> {


### PR DESCRIPTION
## Summary

Every component whose class docblock previously said only "`<Name> class.`" now carries a concise, accurate description of what it does and how it's used, so editor/LSP hovers give real context instead of a tautology.

- **55 classes** across `packages/ui` enriched, following the existing style (e.g. `InView`): keep the `<Name> class.` line, add a 1–3 sentence description, then the existing tags.
- **Comment-only change** — no code, imports, types, or tags modified. All `@link` / `@deprecated` / `@todo` tags preserved verbatim.
- Descriptions were written from each class's actual `config` (options/emits/refs), decorators, and methods.

## Verification
- [x] No bare `<Name> class.` docblocks remain in `packages/ui`.
- [x] Diff adds only comment lines (no code added or removed).
- [x] `npm run lint` → 0 errors (types + prettier clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)