### PR TITLE
Fix drawer ViewTransition rendering glitches in the top layer

### DIFF
--- a/packages/docs/components/Dialog/index.md
+++ b/packages/docs/components/Dialog/index.md
@@ -121,6 +121,13 @@ Out of the box the panel appears and disappears instantly with the dialog. To sl
 
 The slide direction is yours: it is the translate class / keyframes you choose (`translate-x-full` from the right, `-translate-x-full` from the left, `translate-y-full` from the bottom, and so on) paired with the matching edge-anchoring classes.
 
+::: tip Two top-layer stacking guards
+Because the modal `<dialog>` promotes its children to the top layer, two browser quirks are worth guarding against in your CSS — both are one-liners the [drawer example](./examples.md#drawer) applies:
+
+- **Hide the panel with `opacity-0`, not just a transform.** A panel that is only `translate-x-full` is offscreen but still fully painted, so Safari/WebKit captures it into `::view-transition-old()` and the slide-out keyframes drag a ghost copy across the screen on open. Adding `opacity-0` to the hidden state makes that snapshot empty. (Chromium/Firefox clip the offscreen content, so they don't show the ghost — but the `opacity-0` is harmless there.)
+- **Pin the group stacking with `z-index`.** Some Chromium versions mis-order the snapshots of top-layer content, painting the semi-transparent backdrop over the panel and greying it out mid-transition. `::view-transition-group(panel) { z-index: 2 }` above the backdrop keeps the panel on top everywhere.
+:::
+
 See the [drawer example](./examples.md#drawer) for a complete right-side drawer sliding in via `ViewTransition`.
 
 ## The `<dialog>` gotcha

--- a/packages/docs/components/Dialog/stories/drawer/app.twig
+++ b/packages/docs/components/Dialog/stories/drawer/app.twig
@@ -34,12 +34,17 @@
     class="fixed inset-0 bg-black/50 opacity-0"></div>
 
   {# Right-anchored panel — author CSS handles the position, a ViewTransition
-     handles the slide. `translate-x-full` is the hidden (offscreen) state. #}
+     handles the slide. The hidden state is `translate-x-full opacity-0`: the
+     `opacity-0` is what matters for the transition — it makes the hidden
+     panel's view-transition snapshot empty. Without it, Safari/WebKit captures
+     the offscreen-but-opaque panel into `::view-transition-old(drawer-panel)`
+     and the slide-out keyframes drag a ghost copy across the screen on open
+     (Chromium/Firefox clip the offscreen content, so they never show it). #}
   <div
     data-component="ViewTransition"
     data-option-view-transition-name="drawer-panel"
-    data-option-leave-to="translate-x-full"
-    class="absolute inset-y-0 right-0 w-80 max-w-full p-8 bg-white text-black shadow-2xl translate-x-full">
+    data-option-leave-to="translate-x-full opacity-0"
+    class="absolute inset-y-0 right-0 w-80 max-w-full p-8 bg-white text-black shadow-2xl translate-x-full opacity-0">
     <h2 class="text-xl font-bold mb-3">Drawer</h2>
     <p class="mb-6 text-black/60">
       Backdrop fades, panel slides. Two <code>ViewTransition</code> children,
@@ -58,6 +63,14 @@
 <style>
   /* The native ::backdrop cannot be class-transitioned; animate our own. */
   dialog::backdrop { background: transparent; }
+
+  /* Keep the panel above the backdrop in the view-transition layer. The dialog
+     opens with showModal(), so its children live in the top layer, and some
+     Chromium versions mis-order the snapshots of top-layer content — the
+     semi-transparent backdrop then paints over the panel and greys out its
+     bg-white mid-transition. Pinning z-index makes the stacking robust. */
+  ::view-transition-group(drawer-panel)    { z-index: 2; }
+  ::view-transition-group(drawer-backdrop) { z-index: 1; }
 
   /* Panel: slide in from / out to the right edge. Change these keyframes to
      slide from another edge — the direction is entirely author-controlled. */


### PR DESCRIPTION
## What

Two rendering glitches in the [drawer example](https://ui.studiometa.dev/components/Dialog/examples.html#drawer) — where a `ViewTransition` panel + backdrop are animated inside a `showModal()` dialog (top layer) — are fixed with author-CSS guards. The `ViewTransition` / `Dialog` components are **unchanged**; both fixes live in the example markup, and the two guards are now documented in the **Building a drawer** section.

## The glitches

**1. Panel greys out mid-transition (Chromium).** Some Chromium versions mis-order the view-transition snapshots of top-layer content, so the semi-transparent `bg-black/50` backdrop paints *over* the panel and dims its `bg-white` to grey during the transition.

→ Fix: pin the group stacking so the panel always paints above the backdrop.
```css
::view-transition-group(drawer-panel)    { z-index: 2; }
::view-transition-group(drawer-backdrop) { z-index: 1; }
```

**2. Ghost duplicate panel on open (Safari / iOS).** The panel's hidden state was `translate-x-full` only — offscreen but still fully opaque and painted. Safari/WebKit captures that into `::view-transition-old(drawer-panel)`, and the `drawer-slide-out` keyframes drag a duplicate panel across the screen on open. (Chromium/Firefox clip the offscreen content, so they never showed it — which is why it was Safari-only.) The backdrop never ghosted because its hidden state is already `opacity-0`.

→ Fix: hide the panel with `opacity-0` too, so its snapshot is empty.
```
data-option-leave-to="translate-x-full opacity-0"
class="... translate-x-full opacity-0"
```

## Verification

- Reproduced **both** glitches and confirmed **both** fixes with Playwright — Chromium (greying, pixel-sampled) and **WebKit / Safari engine** (ghost panel, via recorded video since `page.screenshot()` doesn't capture an in-flight view transition on WebKit). No regression to the slide or the greying fix on either engine.
- The Safari ghost fix was also confirmed on real iOS Safari by the reporter.
- `npm run lint` — 0 errors. `npm run test` — 481 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)