### PR TITLE
Prepare 1.9.0-beta.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [v1.9.0-beta.3](https://github.com/studiometa/ui/compare/1.9.0-beta.2..1.9.0-beta.3) (2026-07-27)
+
 ### Added
 
 - **Fetch:** add `FetchShopifySection`, an adapter for Shopify's stable Section Rendering API ([#550](https://github.com/studiometa/ui/pull/550))

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "studiometa/ui",
   "type": "composer-plugin",
-  "version": "1.9.0-beta.2",
+  "version": "1.9.0-beta.3",
   "description": "A set of opiniated, unstyled and accessible components.",
   "license": "MIT",
   "require": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@studiometa/ui-workspace",
-  "version": "1.9.0-beta.2",
+  "version": "1.9.0-beta.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@studiometa/ui-workspace",
-      "version": "1.9.0-beta.2",
+      "version": "1.9.0-beta.3",
       "hasInstallScript": true,
       "workspaces": [
         "packages/*"
@@ -20682,11 +20682,11 @@
     },
     "packages/api": {
       "name": "@studiometa/ui-api",
-      "version": "1.9.0-beta.2"
+      "version": "1.9.0-beta.3"
     },
     "packages/docs": {
       "name": "@studiometa/ui-docs",
-      "version": "1.9.0-beta.2",
+      "version": "1.9.0-beta.3",
       "dependencies": {
         "@studiometa/js-toolkit": "3.8.0"
       },
@@ -20706,7 +20706,7 @@
     },
     "packages/eslint-plugin-ui": {
       "name": "@studiometa/eslint-plugin-ui",
-      "version": "1.9.0-beta.2",
+      "version": "1.9.0-beta.3",
       "license": "MIT",
       "dependencies": {
         "@oxlint/plugins": "1.63.0"
@@ -20735,7 +20735,7 @@
     },
     "packages/playground": {
       "name": "@studiometa/ui-playground",
-      "version": "1.9.0-beta.2",
+      "version": "1.9.0-beta.3",
       "dependencies": {
         "@studiometa/playground": "0.3.9"
       },
@@ -20906,7 +20906,7 @@
     },
     "packages/tests": {
       "name": "@studiometa/ui-tests",
-      "version": "1.9.0-beta.2",
+      "version": "1.9.0-beta.3",
       "license": "MIT",
       "dependencies": {
         "@happy-dom/global-registrator": "^20.8.8",
@@ -21159,7 +21159,7 @@
     },
     "packages/ui": {
       "name": "@studiometa/ui",
-      "version": "1.9.0-beta.2",
+      "version": "1.9.0-beta.3",
       "license": "MIT",
       "dependencies": {
         "alien-signals": "^3.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-workspace",
-  "version": "1.9.0-beta.2",
+  "version": "1.9.0-beta.3",
   "type": "module",
   "private": true,
   "workspaces": [

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-api",
-  "version": "1.9.0-beta.2",
+  "version": "1.9.0-beta.3",
   "private": true,
   "type": "commonjs"
 }

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-docs",
-  "version": "1.9.0-beta.2",
+  "version": "1.9.0-beta.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/eslint-plugin-ui/package.json
+++ b/packages/eslint-plugin-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/eslint-plugin-ui",
-  "version": "1.9.0-beta.2",
+  "version": "1.9.0-beta.3",
   "description": "ESLint plugin to help developers discover and use @studiometa/ui components",
   "publishConfig": {
     "access": "public"

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-playground",
-  "version": "1.9.0-beta.2",
+  "version": "1.9.0-beta.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-tests",
-  "version": "1.9.0-beta.2",
+  "version": "1.9.0-beta.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui",
-  "version": "1.9.0-beta.2",
+  "version": "1.9.0-beta.3",
   "description": "A set of opiniated, unstyled and accessible components",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Prepares the `1.9.0-beta.3` release: version bump across all packages (`package.json`, `composer.json`, lockfile) and changelog.

### Added

- **Fetch:** add `FetchShopifySection`, an adapter for Shopify's stable Section Rendering API (#550)

### Changed

- **Fetch:** `FetchShopifyPartial`'s `partials` option now takes a comma-separated string instead of a JSON array (#550)

> [!NOTE]
> The `partials` change is a breaking change to a component shipped in `beta.2`; both `FetchShopifyPartial` and `FetchShopifySection` are still in beta.

Merging this does **not** publish — the npm release is triggered by pushing the `1.9.0-beta.3` tag on the merge commit (per the `release` workflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MEtF3VFxxNkqnkQ49feHXb