### PR TITLE
[Feature] Add a Carousel component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+
+- **Carousel:** add the `Carousel` component (with `CarouselWrapper`, `CarouselItem`, `CarouselBtn` and `CarouselDrag`) built on the `Indexable` primitive, using native scroll-snap on touch devices and pointer drag on fine-pointer devices ([#320](https://github.com/studiometa/ui/pull/320))
+
 ## [v1.9.0-beta.3](https://github.com/studiometa/ui/compare/1.9.0-beta.2..1.9.0-beta.3) (2026-07-27)
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -7515,6 +7515,12 @@
         "node": ">= 10"
       }
     },
+    "node_modules/compute-scroll-into-view": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-3.1.1.tgz",
+      "integrity": "sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw==",
+      "license": "MIT"
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -21163,6 +21169,7 @@
       "license": "MIT",
       "dependencies": {
         "alien-signals": "^3.2.1",
+        "compute-scroll-into-view": "^3.1.0",
         "deepmerge": "^4.3.1",
         "morphdom": "^2.7.8"
       },

--- a/packages/docs/components/Carousel/examples.md
+++ b/packages/docs/components/Carousel/examples.md
@@ -1,0 +1,23 @@
+---
+title: Carousel examples
+---
+
+# Examples
+
+## Horizontal
+
+<PreviewPlayground
+  :html="() => import('./stories/horizontal/app.twig')"
+  :html-editor="false"
+  :script="() => import('./stories/horizontal/app.js?raw')"
+  :script-editor="false"
+  />
+
+## Vertical
+
+<PreviewPlayground
+  :html="() => import('./stories/vertical/app.twig')"
+  :html-editor="false"
+  :script="() => import('./stories/vertical/app.js?raw')"
+  :script-editor="false"
+  />

--- a/packages/docs/components/Carousel/examples.md
+++ b/packages/docs/components/Carousel/examples.md
@@ -21,3 +21,14 @@ title: Carousel examples
   :script="() => import('./stories/vertical/app.js?raw')"
   :script-editor="false"
   />
+
+## Boundaries
+
+The `boundary` option, inherited from the [`Indexable`](/components/Indexable/) primitive, controls what happens at the ends of the track. Use `clamp` (the default), `loop` or `bounce`. Watch the Prev/Next buttons: they disable at the ends in `clamp` mode but stay active in `loop` and `bounce`.
+
+<PreviewPlayground
+  :html="() => import('./stories/boundaries/app.twig')"
+  :html-editor="false"
+  :script="() => import('./stories/boundaries/app.js?raw')"
+  :script-editor="false"
+  />

--- a/packages/docs/components/Carousel/index.md
+++ b/packages/docs/components/Carousel/index.md
@@ -1,0 +1,59 @@
+---
+badges: [JS]
+---
+
+# Carousel <Badges :texts="$frontmatter.badges" />
+
+The `Carousel` component displays a set of items in a scrollable track. It is built on the [`Indexable` primitive](/components/Indexable/) and relies on native CSS scroll-snap on touch devices, keeping the JavaScript minimal. Pointer drag is added on top for fine-pointer devices (mouse, trackpad) through the optional [`CarouselDrag`](./js-api#carouseldrag) component.
+
+It works horizontally or vertically, exposes the full `Indexable` navigation API (`goTo()`, `goNext()`, `goPrev()`) and emits a `progress` event alongside a `--carousel-progress` CSS custom property you can hook animations onto.
+
+## Table of content
+
+- [Examples](./examples.md)
+- [JS API](./js-api.md)
+
+## Usage
+
+A carousel is authored from a few nested components:
+
+- a root `Carousel` element;
+- a `CarouselWrapper` holding the track, which is also the scroll container — add `CarouselDrag` on the same element to enable pointer dragging;
+- one `CarouselItem` per slide;
+- optional `CarouselBtn` controls to move to the previous, next or a specific item.
+
+::: code-group
+
+```js twoslash [app.js]
+import { registerComponent } from '@studiometa/js-toolkit';
+import { Carousel } from '@studiometa/ui';
+
+registerComponent(Carousel);
+```
+
+```twig [carousel.twig]
+<div data-component="Carousel">
+  <div data-component="CarouselWrapper CarouselDrag" class="whitespace-nowrap overflow-x-auto snap-x snap-mandatory">
+    {% for item in 1..4 %}
+      <div data-component="CarouselItem" class="inline-block snap-center">
+        #{{ item }}
+      </div>
+    {% endfor %}
+  </div>
+
+  <button type="button" data-component="CarouselBtn" data-option-action="prev">Previous</button>
+  <button type="button" data-component="CarouselBtn" data-option-action="next">Next</button>
+</div>
+```
+
+:::
+
+### Vertical carousel
+
+Set the [`axis`](./js-api#axis) option to `y` to scroll vertically instead of horizontally:
+
+```twig
+<div data-component="Carousel" data-option-axis="y">
+  ...
+</div>
+```

--- a/packages/docs/components/Carousel/js-api.md
+++ b/packages/docs/components/Carousel/js-api.md
@@ -34,7 +34,24 @@ Defines the scroll direction of the carousel: `'x'` for horizontal, `'y'` for ve
 ```
 <!-- prettier-ignore-end -->
 
-The [`boundary`](/components/Indexable/js-api#boundary) and [`reverse`](/components/Indexable/js-api#reverse) options are inherited from the `Indexable` primitive. The `total` option has no effect here: the carousel derives its length from the number of `CarouselItem` children.
+### `boundary`
+
+- Type: `'clamp' | 'loop' | 'bounce'`
+- Default: `'clamp'`
+
+Inherited from the [`Indexable`](/components/Indexable/js-api#boundary) primitive, it controls what happens at the ends of the track: `clamp` stops at the first/last item, `loop` wraps around, and `bounce` reverses direction. The `CarouselBtn` controls follow it — `prev`/`next` disable at the ends in `clamp` mode but stay active in `loop` and `bounce`. See the [boundaries example](./examples#boundaries).
+
+<!-- prettier-ignore-start -->
+```html {3}
+<div
+  data-component="Carousel"
+  data-option-boundary="loop">
+  ...
+</div>
+```
+<!-- prettier-ignore-end -->
+
+The [`reverse`](/components/Indexable/js-api#reverse) option is also inherited from `Indexable`. The `total` option has no effect here: the carousel derives its length from the number of `CarouselItem` children.
 
 ## Getters
 

--- a/packages/docs/components/Carousel/js-api.md
+++ b/packages/docs/components/Carousel/js-api.md
@@ -1,0 +1,133 @@
+---
+title: Carousel JS API
+outline: deep
+---
+
+# JS API
+
+The `Carousel` class extends the [`Indexable` primitive](/components/Indexable/). It inherits its index-navigation methods (`goTo()`, `goNext()`, `goPrev()`), its `boundary` and `reverse` options and its `index` event, so make sure to have a look at [its API reference](/components/Indexable/js-api) too.
+
+A carousel is composed of several components working together:
+
+- `Carousel` — the root component, extending `Indexable`
+- `CarouselWrapper` — the scrollable container holding the items
+- `CarouselItem` — a single slide
+- `CarouselBtn` — a previous, next or go-to control
+- `CarouselDrag` — optional pointer-drag behavior, mounted only on fine-pointer devices
+
+## Options
+
+### `axis`
+
+- Type: `'x' | 'y'`
+- Default: `'x'`
+
+Defines the scroll direction of the carousel: `'x'` for horizontal, `'y'` for vertical.
+
+<!-- prettier-ignore-start -->
+```html {2}
+<div
+  data-component="Carousel"
+  data-option-axis="y">
+  ...
+</div>
+```
+<!-- prettier-ignore-end -->
+
+The [`boundary`](/components/Indexable/js-api#boundary) and [`reverse`](/components/Indexable/js-api#reverse) options are inherited from the `Indexable` primitive. The `total` option has no effect here: the carousel derives its length from the number of `CarouselItem` children.
+
+## Getters
+
+### `isHorizontal`
+
+- Type: `boolean`
+
+Whether the carousel scrolls horizontally (the `axis` option is `'x'`).
+
+### `isVertical`
+
+- Type: `boolean`
+
+Whether the carousel scrolls vertically (the `axis` option is `'y'`).
+
+### `items`
+
+- Type: `CarouselItem[]`
+
+The carousel's item components.
+
+### `length`
+
+- Type: `number`
+
+The number of items, used as the `Indexable` length.
+
+### `wrapper`
+
+- Type: `CarouselWrapper`
+
+The scrollable wrapper component.
+
+### `progress`
+
+- Type: `number`
+
+The current scroll progress, between `0` and `1`.
+
+## Methods
+
+### `goTo(indexOrInstruction)`
+
+- Arguments: `number | 'next' | 'previous' | 'first' | 'last' | 'random'`
+- Returns: `Promise<void>`
+
+Scroll to the given item. Accepts an index or one of the [`Indexable` instructions](/components/Indexable/js-api). The `goNext()` and `goPrev()` shortcuts are inherited from the primitive.
+
+## Events
+
+### `progress`
+
+Emitted while the carousel scrolls, with the current progress between `0` and `1`. The same value is reflected on the root element through the [`--carousel-progress`](#carousel-progress) custom property.
+
+```js
+onCarouselProgress(progress) {
+  // progress is a number between 0 and 1
+}
+```
+
+The `index` event is inherited from the [`Indexable` primitive](/components/Indexable/js-api) and emitted whenever the current index changes.
+
+## CSS custom properties
+
+### `--carousel-progress`
+
+Set on the root `Carousel` element, reflects the scroll progress between `0` and `1`.
+
+### `--carousel-item-active`
+
+Set on each `CarouselItem`, equals `1` when the item is the current one and `0` otherwise. Use it to style the active slide.
+
+## CarouselBtn
+
+A control button, delegating to the parent carousel on click.
+
+### `action`
+
+- Type: `'next' | 'prev' | string`
+
+Use `next` or `prev` to step through the items, or a numeric string (e.g. `"2"`) to jump to a specific index. The button disables itself automatically when its action is unavailable, e.g. `prev` on the first item or `next` on the last one.
+
+<!-- prettier-ignore-start -->
+```html {3}
+<button
+  type="button"
+  data-component="CarouselBtn"
+  data-option-action="next">
+  Next
+</button>
+```
+<!-- prettier-ignore-end -->
+
+## CarouselDrag
+
+Adds pointer-drag navigation to the wrapper, built with the [`withDrag`](https://js-toolkit.studiometa.dev/api/decorators/withDrag.html) and [`withMountOnMediaQuery`](https://js-toolkit.studiometa.dev/api/decorators/withMountOnMediaQuery.html) decorators. It only mounts on fine-pointer devices (`(pointer: fine)`), leaving native CSS scroll-snap to handle touch devices. Apply it to the same element as `CarouselWrapper`.

--- a/packages/docs/components/Carousel/stories/boundaries/app.js
+++ b/packages/docs/components/Carousel/stories/boundaries/app.js
@@ -1,0 +1,4 @@
+import { registerComponent } from '@studiometa/js-toolkit';
+import { Carousel } from '@studiometa/ui';
+
+registerComponent(Carousel);

--- a/packages/docs/components/Carousel/stories/boundaries/app.twig
+++ b/packages/docs/components/Carousel/stories/boundaries/app.twig
@@ -1,0 +1,62 @@
+{% set colors = ['red', 'green', 'blue', 'purple'] %}
+{% set count = 5 %}
+{% set boundaries = {
+  clamp: 'Stops at the first and last item — the Prev/Next buttons disable at the ends.',
+  loop: 'Wraps around — Next from the last item goes back to the first, and the buttons never disable.',
+  bounce: 'Reverses direction at the ends instead of wrapping — the buttons never disable.',
+} %}
+
+<div class="grid gap-12 p-10">
+  {% for boundary, description in boundaries %}
+    <section class="grid gap-3">
+      <header>
+        <h2 class="font-bold">
+          <code>data-option-boundary="{{ boundary }}"</code>
+        </h2>
+        <p class="text-sm opacity-70">{{ description }}</p>
+      </header>
+
+      <div data-component="Carousel"
+        class="grid gap-4"
+        data-option-axis="x"
+        data-option-boundary="{{ boundary }}">
+        <div data-component="CarouselWrapper CarouselDrag"
+          class="flex items-center gap-8 w-full overflow-x-auto snap-x snap-mandatory"
+          style="scrollbar-width: none;">
+          {% for i in 1..count %}
+            {% set color = colors[loop.index0 % (colors|length)] %}
+            <div data-component="CarouselItem"
+              class="
+                snap-center shrink-0 flex items-center justify-center
+                w-1/3 h-32 bg-{{
+              color
+              }}-400 ring-inset ring-{{
+              color
+              }}-600 ring
+                text-white font-bold rounded-xl
+              "
+              style="--tw-ring-opacity: var(--carousel-item-active, 0)">
+              N°{{ i }}
+            </div>
+          {% endfor %}
+        </div>
+        <nav class="flex items-center justify-center gap-2">
+          {% include '@ui/Button/StyledButton.twig' with {
+            label: '← Prev',
+            attr: {
+              data_component: 'CarouselBtn',
+              data_option_action: 'prev'
+            }
+          } %}
+          {% include '@ui/Button/StyledButton.twig' with {
+            label: 'Next →',
+            attr: {
+              data_component: 'CarouselBtn',
+              data_option_action: 'next'
+            }
+          } %}
+        </nav>
+      </div>
+    </section>
+  {% endfor %}
+</div>

--- a/packages/docs/components/Carousel/stories/horizontal/app.js
+++ b/packages/docs/components/Carousel/stories/horizontal/app.js
@@ -1,0 +1,4 @@
+import { registerComponent } from '@studiometa/js-toolkit';
+import { Carousel } from '@studiometa/ui';
+
+registerComponent(Carousel);

--- a/packages/docs/components/Carousel/stories/horizontal/app.twig
+++ b/packages/docs/components/Carousel/stories/horizontal/app.twig
@@ -1,0 +1,56 @@
+{% set colors = ['red', 'green', 'blue', 'purple'] %}
+{% set count = 5 %}
+
+<div data-component="Carousel" class="grid gap-10 p-10" data-option-axis="x">
+  <div data-component="CarouselWrapper CarouselDrag"
+    class="flex items-center gap-8 w-full overflow-x-auto snap-x snap-mandatory"
+    style="scrollbar-width: none;">
+    {% for i in 1..count %}
+      {% set color = colors[loop.index0 % (colors|length)] %}
+      <div data-component="CarouselItem"
+        class="
+          snap-center shrink-0 flex items-center justify-center
+          w-1/3 h-48 bg-{{
+        color
+        }}-400 ring-inset ring-{{
+        color
+        }}-600
+          ring
+          text-white font-bold rounded-xl
+        "
+        style="--tw-ring-opacity: var(--carousel-item-active, 0)">
+        N°{{ i }}
+      </div>
+    {% endfor %}
+  </div>
+  <div class="relative w-full h-2 rounded-full bg-gray-200 overflow-hidden">
+    <div style="--tw-translate-x: calc((var(--carousel-progress, 0) - 1) * 100%)"
+      class="absolute inset-0 -translate-x-full bg-black rounded-full"></div>
+  </div>
+  <nav class="flex items-center justify-center gap-2">
+    {% include '@ui/Button/StyledButton.twig' with {
+      label: '← Prev',
+      attr: {
+        data_component: 'CarouselBtn',
+        data_option_action: 'prev'
+      }
+    } %}
+    {% for i in 1..count %}
+      {% include '@ui/Button/StyledButton.twig' with {
+        label: i,
+        theme: 'secondary',
+        attr: {
+          data_component: 'CarouselBtn',
+          data_option_action: loop.index0
+        }
+      } %}
+    {% endfor %}
+    {% include '@ui/Button/StyledButton.twig' with {
+      label: 'Next →',
+      attr: {
+        data_component: 'CarouselBtn',
+        data_option_action: 'next'
+      }
+    } %}
+  </nav>
+</div>

--- a/packages/docs/components/Carousel/stories/vertical/app.js
+++ b/packages/docs/components/Carousel/stories/vertical/app.js
@@ -1,0 +1,4 @@
+import { registerComponent } from '@studiometa/js-toolkit';
+import { Carousel } from '@studiometa/ui';
+
+registerComponent(Carousel);

--- a/packages/docs/components/Carousel/stories/vertical/app.twig
+++ b/packages/docs/components/Carousel/stories/vertical/app.twig
@@ -1,0 +1,58 @@
+{% set colors = ['red', 'green', 'blue', 'purple'] %}
+{% set count = 5 %}
+
+<div data-component="Carousel"
+  class="flex items-center justify-start gap-10 p-10"
+  data-option-axis="y">
+  <div data-component="CarouselWrapper CarouselDrag"
+    class="grid gap-4 w-[max-content] h-52 overflow-y-auto snap-y snap-mandatory"
+    style="scrollbar-width: none;">
+    {% for i in 1..count %}
+      {% set color = colors[loop.index0 % (colors|length)] %}
+      <div data-component="CarouselItem"
+        class="
+          snap-center shrink-0 flex items-center justify-center self-center justify-self-center
+          w-24 h-24 bg-{{
+        color
+        }}-400 ring-inset ring-{{
+        color
+        }}-600
+          ring
+          text-white font-bold rounded-xl
+        "
+        style="--tw-ring-opacity: var(--carousel-item-active, 0)">
+        N°{{ i }}
+      </div>
+    {% endfor %}
+  </div>
+  <div class="relative h-52 w-2 rounded-full bg-gray-200 overflow-hidden">
+    <div style="--tw-translate-y: calc((var(--carousel-progress, 0) - 1) * 100%)"
+      class="absolute inset-0 -translate-y-full bg-black rounded-full"></div>
+  </div>
+  <nav class="grid items-center justify-center gap-2">
+    {% include '@ui/Button/StyledButton.twig' with {
+      label: '↑',
+      attr: {
+        data_component: 'CarouselBtn',
+        data_option_action: 'prev'
+      }
+    } %}
+    {% for i in 1..count %}
+      {% include '@ui/Button/StyledButton.twig' with {
+        label: i,
+        theme: 'secondary',
+        attr: {
+          data_component: 'CarouselBtn',
+          data_option_action: loop.index0
+        }
+      } %}
+    {% endfor %}
+    {% include '@ui/Button/StyledButton.twig' with {
+      label: '↓',
+      attr: {
+        data_component: 'CarouselBtn',
+        data_option_action: 'next'
+      }
+    } %}
+  </nav>
+</div>

--- a/packages/playground/meta.config.js
+++ b/packages/playground/meta.config.js
@@ -23,6 +23,7 @@ export default defineWebpackConfig({
       },
       dependencies: [
         '@motionone/easing',
+        'compute-scroll-into-view',
         'deepmerge',
         'morphdom',
         { specifier: '@studiometa/js-toolkit', esmSh: { bundle: false } },

--- a/packages/tests/Carousel/AbstractCarouselChild.spec.ts
+++ b/packages/tests/Carousel/AbstractCarouselChild.spec.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi } from 'vitest';
+import { AbstractCarouselChild, Carousel } from '@studiometa/ui';
+import { h, mount, destroy } from '#test-utils';
+
+describe('The AbstractCarouselChild class', () => {
+  it('should not mount if it can not find a parent Carousel', async () => {
+    const div = h('div');
+    const child = new AbstractCarouselChild(div);
+    await mount(child);
+    expect(child.$isMounted).toBe(false);
+  });
+
+  it('should listen to its parent events and dispatch them', async () => {
+    const childElement = h('div');
+    const carouselElement = h('div', [childElement]);
+    const carousel = new Carousel(carouselElement);
+    const child = new AbstractCarouselChild(childElement);
+    await mount(carousel, child);
+    expect(child.carousel).toBe(carousel);
+    const spy = vi.spyOn(child, '$emit');
+
+    for (const eventName of ['index', 'progress']) {
+      carousel.$emit(eventName, 0);
+      expect(spy).toHaveBeenCalledExactlyOnceWith(`parent-carousel-${eventName}`, 0);
+      spy.mockClear();
+    }
+
+    await destroy(child);
+    spy.mockClear();
+
+    for (const eventName of ['index', 'progress']) {
+      carousel.$emit(eventName, 0);
+      expect(spy).not.toHaveBeenCalled();
+      spy.mockClear();
+    }
+  });
+
+  it('should expose the parent carousel isHorizontal and isVertical getters', async () => {
+    const childElement = h('div');
+    const carouselElement = h('div', [childElement]);
+    const carousel = new Carousel(carouselElement);
+    const child = new AbstractCarouselChild(childElement);
+    await mount(carousel, child);
+    expect(child.isHorizontal).toBe(carousel.isHorizontal);
+    expect(child.isVertical).toBe(carousel.isVertical);
+  });
+});

--- a/packages/tests/Carousel/AbstractCarouselChild.spec.ts
+++ b/packages/tests/Carousel/AbstractCarouselChild.spec.ts
@@ -1,47 +1,119 @@
 import { describe, it, expect, vi } from 'vitest';
 import { AbstractCarouselChild, Carousel } from '@studiometa/ui';
-import { h, mount, destroy } from '#test-utils';
+import type { BaseConfig, BaseProps } from '@studiometa/js-toolkit';
+import { h, mount, destroy, wait } from '#test-utils';
+
+/**
+ * A concrete subscribing child recording the indexes it is updated with.
+ */
+class TestChild<T extends BaseProps = BaseProps> extends AbstractCarouselChild<T> {
+  static config = { name: 'TestChild' };
+
+  updates: number[] = [];
+
+  update(index: number) {
+    this.updates.push(index);
+  }
+}
+
+/**
+ * A Carousel subclass registering `TestChild`, mirroring the documented usage
+ * where controls are added through `config.components`.
+ */
+class TestCarousel extends Carousel {
+  static config: BaseConfig = {
+    name: 'Carousel',
+    components: { TestChild },
+    emits: ['progress'],
+  };
+}
 
 describe('The AbstractCarouselChild class', () => {
-  it('should not mount if it can not find a parent Carousel', async () => {
-    const div = h('div');
-    const child = new AbstractCarouselChild(div);
-    await mount(child);
-    expect(child.$isMounted).toBe(false);
-  });
-
-  it('should listen to its parent events and dispatch them', async () => {
-    const childElement = h('div');
-    const carouselElement = h('div', [childElement]);
-    const carousel = new Carousel(carouselElement);
-    const child = new AbstractCarouselChild(childElement);
-    await mount(carousel, child);
-    expect(child.carousel).toBe(carousel);
-    const spy = vi.spyOn(child, '$emit');
-
-    for (const eventName of ['index', 'progress']) {
-      carousel.$emit(eventName, 0);
-      expect(spy).toHaveBeenCalledExactlyOnceWith(`parent-carousel-${eventName}`, 0);
-      spy.mockClear();
-    }
-
-    await destroy(child);
-    spy.mockClear();
-
-    for (const eventName of ['index', 'progress']) {
-      carousel.$emit(eventName, 0);
-      expect(spy).not.toHaveBeenCalled();
-      spy.mockClear();
-    }
-  });
-
   it('should expose the parent carousel isHorizontal and isVertical getters', async () => {
     const childElement = h('div');
     const carouselElement = h('div', [childElement]);
     const carousel = new Carousel(carouselElement);
-    const child = new AbstractCarouselChild(childElement);
+    const child = new TestChild(childElement);
     await mount(carousel, child);
     expect(child.isHorizontal).toBe(carousel.isHorizontal);
     expect(child.isVertical).toBe(carousel.isVertical);
+  });
+
+  it('should default the orientation getters when no carousel is resolvable', async () => {
+    const child = new TestChild(h('div'));
+    await mount(child);
+    expect(child.carousel).toBeUndefined();
+    expect(child.isHorizontal).toBe(true);
+    expect(child.isVertical).toBe(false);
+  });
+
+  it('should subscribe to the store and pull the seeded index on connect', async () => {
+    const childElement = h('div');
+    const carouselElement = h('div', [childElement]);
+    const carousel = new Carousel(carouselElement);
+    const child = new TestChild(childElement);
+    await mount(carousel, child);
+
+    // The Carousel seeds its store on mount, so the child pulls the initial
+    // index as soon as it connects.
+    await wait(20);
+    expect(child.updates.at(-1)).toBe(0);
+    expect(child.carousel).toBe(carousel);
+
+    // A same-value assignment is gated and must not re-notify subscribers.
+    child.updates.length = 0;
+    carousel.currentIndex = 0;
+    await wait(20);
+    expect(child.updates).toEqual([]);
+  });
+
+  it('should connect even when mounted before its Carousel (parent-side handshake)', async () => {
+    const childElement = h('div', { dataComponent: 'TestChild' });
+    const carouselElement = h('div', [childElement]);
+
+    // Fully mount the child before the Carousel is even constructed: it cannot
+    // resolve a parent and stays unsubscribed.
+    const child = new TestChild(childElement);
+    await mount(child);
+    await wait(20);
+    expect(child.updates).toEqual([]);
+
+    // Mounting the Carousel seeds the store and, via `connectChildren`, hands
+    // itself over to the pre-mounted child which then pulls the seeded index.
+    const carousel = new TestCarousel(carouselElement);
+    await mount(carousel);
+    await wait(20);
+    expect(child.carousel).toBe(carousel);
+    expect(child.updates.at(-1)).toBe(0);
+  });
+
+  it('should be idempotent: connecting twice subscribes only once', async () => {
+    const childElement = h('div');
+    const carouselElement = h('div', [childElement]);
+    const carousel = new Carousel(carouselElement);
+    const child = new TestChild(childElement);
+    await mount(carousel, child);
+
+    const subscribe = vi.spyOn(carousel.store, 'subscribe');
+    child.__connect(carousel as unknown as Carousel);
+    child.__connect(carousel as unknown as Carousel);
+    expect(subscribe).not.toHaveBeenCalled();
+  });
+
+  it('should unsubscribe from the store on destroy', async () => {
+    const childElement = h('div');
+    const carouselElement = h('div', [childElement]);
+    const carousel = new Carousel(carouselElement);
+    const child = new TestChild(childElement);
+    await mount(carousel, child);
+    await wait(20);
+
+    await destroy(child);
+    child.updates.length = 0;
+
+    // After destroy the child no longer reacts to store changes.
+    carousel.goTo(1);
+    await wait(20);
+    expect(child.updates).toEqual([]);
   });
 });

--- a/packages/tests/Carousel/Carousel.spec.ts
+++ b/packages/tests/Carousel/Carousel.spec.ts
@@ -89,6 +89,9 @@ describe('The Carousel class', () => {
     const carousel = new Carousel(div);
     const spy = vi.spyOn(carousel, 'goTo');
     carousel.resized();
+    // The re-snap is deferred one frame so the children's resize callbacks can
+    // invalidate their geometry caches first.
+    await wait();
     expect(spy).toHaveBeenCalledExactlyOnceWith(carousel.currentIndex);
   });
 });

--- a/packages/tests/Carousel/Carousel.spec.ts
+++ b/packages/tests/Carousel/Carousel.spec.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi } from 'vitest';
+import { Carousel } from '@studiometa/ui';
+import { h, mount, wait } from '#test-utils';
+
+describe('The Carousel class', () => {
+  it('should have an axis option', async () => {
+    const div = h('div');
+    const carousel = new Carousel(div);
+    await mount(carousel);
+    expect(carousel.isHorizontal).toBe(true);
+    expect(carousel.isVertical).toBe(false);
+    div.setAttribute('data-option-axis', 'y');
+    expect(carousel.isHorizontal).toBe(false);
+    expect(carousel.isVertical).toBe(true);
+  });
+
+  it('should emit index and progress events', async () => {
+    const items = [
+      h('div', { dataComponent: 'CarouselItem' }),
+      h('div', { dataComponent: 'CarouselItem' }),
+    ];
+    const wrapper = h('div', { dataComponent: 'CarouselWrapper' }, items);
+    const div = h('div', [wrapper]);
+    const carousel = new Carousel(div);
+    await mount(carousel);
+    const indexFn = vi.fn();
+    const progressFn = vi.fn();
+    carousel.$on('index', indexFn);
+    carousel.$on('progress', progressFn);
+    carousel.goTo(1);
+    expect(indexFn).toHaveBeenCalledOnce();
+    expect(indexFn.mock.lastCall[0].detail).toEqual([1]);
+    await wait();
+    expect(progressFn).toHaveBeenCalledOnce();
+    progressFn.mockClear();
+    carousel.goTo(0);
+    expect(indexFn.mock.lastCall[0].detail).toEqual([0]);
+  });
+
+  it('should implement an indexable API', async () => {
+    const items = [
+      h('div', { dataComponent: 'CarouselItem' }),
+      h('div', { dataComponent: 'CarouselItem' }),
+      h('div', { dataComponent: 'CarouselItem' }),
+      h('div', { dataComponent: 'CarouselItem' }),
+    ];
+    const wrapper = h('div', { dataComponent: 'CarouselWrapper' }, items);
+    const div = h('div', [wrapper]);
+    const carousel = new Carousel(div);
+    await mount(carousel);
+
+    expect(carousel.currentIndex).toBe(0);
+    expect(carousel.prevIndex).toBe(0);
+    expect(carousel.nextIndex).toBe(1);
+    expect(carousel.lastIndex).toBe(3);
+
+    carousel.goTo(1);
+
+    expect(carousel.currentIndex).toBe(1);
+    expect(carousel.prevIndex).toBe(0);
+    expect(carousel.nextIndex).toBe(2);
+    expect(carousel.lastIndex).toBe(3);
+
+    carousel.goNext();
+
+    expect(carousel.currentIndex).toBe(2);
+    expect(carousel.prevIndex).toBe(1);
+    expect(carousel.nextIndex).toBe(3);
+    expect(carousel.lastIndex).toBe(3);
+
+    carousel.goPrev();
+
+    expect(carousel.currentIndex).toBe(1);
+    expect(carousel.prevIndex).toBe(0);
+    expect(carousel.nextIndex).toBe(2);
+    expect(carousel.lastIndex).toBe(3);
+  });
+
+  it('should go to the current index on mount', async () => {
+    const div = h('div');
+    const carousel = new Carousel(div);
+    const spy = vi.spyOn(carousel, 'goTo');
+    await mount(carousel);
+    expect(spy).toHaveBeenCalledExactlyOnceWith(carousel.currentIndex);
+  });
+
+  it('should go to the current index on resize', async () => {
+    const div = h('div');
+    const carousel = new Carousel(div);
+    const spy = vi.spyOn(carousel, 'goTo');
+    carousel.resized();
+    expect(spy).toHaveBeenCalledExactlyOnceWith(carousel.currentIndex);
+  });
+});

--- a/packages/tests/Carousel/CarouselBtn.spec.ts
+++ b/packages/tests/Carousel/CarouselBtn.spec.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi } from 'vitest';
+import { CarouselBtn, Carousel } from '@studiometa/ui';
+import { h } from '#test-utils';
+
+describe('The CarouselBtn class', () => {
+  for (const [action, method] of [
+    ['prev', 'goPrev'],
+    ['next', 'goNext'],
+    [2, 'goTo'],
+  ] as const) {
+    it('should dispatch its action to the carousel', async () => {
+      const btn = h('button', { dataOptionAction: action });
+      const div = h('div', [btn]);
+      const carousel = new Carousel(div);
+      const carouselBtn = new CarouselBtn(btn);
+
+      const spy = vi.spyOn(carousel, method);
+      spy.mockImplementation(() => Promise.resolve());
+      carouselBtn.onClick();
+      expect(spy).toHaveBeenCalledOnce();
+    });
+  }
+
+  for (const [action, index, lastIndex, isDisabled] of [
+    ['prev', 0, 10, true],
+    ['prev', 1, 10, false],
+    ['next', 1, 10, false],
+    ['next', 10, 10, true],
+    [1, 1, 10, true],
+    [1, 2, 10, false],
+  ] as const) {
+    it(`should set the disabled attribute to ${String(isDisabled)} when action is ${action}, index is ${index} and lastIndex is ${lastIndex}.`, async () => {
+      const btn = h('button', { dataOptionAction: action });
+      const carouselBtn = new CarouselBtn(btn);
+      const spy = vi.spyOn(carouselBtn, 'carousel', 'get');
+      // @ts-expect-error mock is partial
+      spy.mockImplementation(() => ({ currentIndex: index, lastIndex }));
+      carouselBtn.onParentCarouselProgress();
+      expect(btn.disabled).toBe(isDisabled);
+    });
+  }
+});

--- a/packages/tests/Carousel/CarouselBtn.spec.ts
+++ b/packages/tests/Carousel/CarouselBtn.spec.ts
@@ -21,20 +21,27 @@ describe('The CarouselBtn class', () => {
     });
   }
 
-  for (const [action, index, lastIndex, isDisabled] of [
-    ['prev', 0, 10, true],
-    ['prev', 1, 10, false],
-    ['next', 1, 10, false],
-    ['next', 10, 10, true],
-    [1, 1, 10, true],
-    [1, 2, 10, false],
+  // The disabled state is derived from `prevIndex`/`nextIndex` (whether the
+  // action would actually move), so it honours boundary/reverse options.
+  for (const [action, index, carouselMock, isDisabled] of [
+    // clamp (default): the reachable end index equals the current index.
+    ['prev', 0, { prevIndex: 0 }, true],
+    ['prev', 1, { prevIndex: 0 }, false],
+    ['next', 1, { nextIndex: 2 }, false],
+    ['next', 10, { nextIndex: 10 }, true],
+    // numeric action: disabled only on the slide it points to.
+    [1, 1, {}, true],
+    [1, 2, {}, false],
+    // loop/reverse: prev/next still move at the raw ends, so never disabled.
+    ['prev', 0, { prevIndex: 10 }, false],
+    ['next', 10, { nextIndex: 0 }, false],
   ] as const) {
-    it(`should set the disabled attribute to ${String(isDisabled)} when action is ${action}, index is ${index} and lastIndex is ${lastIndex}.`, async () => {
+    it(`should set disabled=${String(isDisabled)} for action=${action} at index=${index} (${JSON.stringify(carouselMock)})`, async () => {
       const btn = h('button', { dataOptionAction: action });
       const carouselBtn = new CarouselBtn(btn);
       const spy = vi.spyOn(carouselBtn, 'carousel', 'get');
       // @ts-expect-error mock is partial
-      spy.mockImplementation(() => ({ lastIndex }));
+      spy.mockImplementation(() => carouselMock);
       carouselBtn.update(index);
       expect(btn.disabled).toBe(isDisabled);
     });

--- a/packages/tests/Carousel/CarouselBtn.spec.ts
+++ b/packages/tests/Carousel/CarouselBtn.spec.ts
@@ -34,8 +34,8 @@ describe('The CarouselBtn class', () => {
       const carouselBtn = new CarouselBtn(btn);
       const spy = vi.spyOn(carouselBtn, 'carousel', 'get');
       // @ts-expect-error mock is partial
-      spy.mockImplementation(() => ({ currentIndex: index, lastIndex }));
-      carouselBtn.onParentCarouselProgress();
+      spy.mockImplementation(() => ({ lastIndex }));
+      carouselBtn.update(index);
       expect(btn.disabled).toBe(isDisabled);
     });
   }

--- a/packages/tests/Carousel/CarouselDrag.spec.ts
+++ b/packages/tests/Carousel/CarouselDrag.spec.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi } from 'vitest';
+import { CarouselDrag } from '@studiometa/ui';
+import { h, mount, useMatchMedia, wait } from '#test-utils';
+
+describe('The CarouselDrag class', () => {
+  it('should mount only when pointer is fine', async () => {
+    const matchMedia = useMatchMedia();
+    const div = h('div');
+    const carouselDrag = new CarouselDrag(div);
+    const fn = vi.fn();
+    carouselDrag.$on('mounted', fn);
+    await mount(carouselDrag);
+    expect(fn).not.toHaveBeenCalled();
+
+    matchMedia.useMediaQuery('(pointer: fine)');
+
+    await wait(10);
+    expect(fn).toHaveBeenCalledOnce();
+  });
+
+  it('should do nothing when not mounted', async () => {
+    const div = h('div');
+    const carouselDrag = new CarouselDrag(div);
+    const spy = vi.spyOn(div, 'scrollTo');
+    // @ts-expect-error partial mock
+    carouselDrag.dragged({});
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('should do nothing for stop or inertia mode', async () => {
+    const div = h('div');
+    const carouselDrag = new CarouselDrag(div);
+    vi.spyOn(carouselDrag, '$isMounted', 'get').mockImplementation(() => true);
+    const spy = vi.spyOn(div, 'scrollTo');
+    // @ts-expect-error partial mock
+    carouselDrag.dragged({ mode: 'inertia' });
+    expect(spy).not.toHaveBeenCalled();
+    // @ts-expect-error partial mock
+    carouselDrag.dragged({ mode: 'stop' });
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('should do nothing if no distance', async () => {
+    const div = h('div');
+    const carouselDrag = new CarouselDrag(div);
+
+    vi.spyOn(carouselDrag, '$isMounted', 'get').mockImplementation(() => true);
+    vi.spyOn(carouselDrag, 'isHorizontal', 'get').mockImplementation(() => true);
+    vi.spyOn(carouselDrag, 'isVertical', 'get').mockImplementation(() => false);
+
+    const spy = vi.spyOn(div, 'scrollTo');
+
+    // @ts-expect-error partial mock
+    carouselDrag.dragged({ mode: 'drag', distance: { x: 0 } });
+    expect(spy).not.toHaveBeenCalled();
+
+    vi.spyOn(carouselDrag, 'isHorizontal', 'get').mockImplementation(() => false);
+    vi.spyOn(carouselDrag, 'isVertical', 'get').mockImplementation(() => true);
+
+    // @ts-expect-error partial mock
+    carouselDrag.dragged({ mode: 'drag', distance: { y: 0 } });
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('should scroll instantly when dragging', async () => {
+    const div = h('div');
+    const carouselDrag = new CarouselDrag(div);
+    const spy = vi.spyOn(div, 'scrollTo');
+
+    vi.spyOn(carouselDrag, '$isMounted', 'get').mockImplementation(() => true);
+    vi.spyOn(carouselDrag, 'isHorizontal', 'get').mockImplementation(() => true);
+    vi.spyOn(carouselDrag, 'isVertical', 'get').mockImplementation(() => false);
+
+    // @ts-expect-error partial mock
+    carouselDrag.dragged({ mode: 'drag', distance: { x: 1, y: 0 }, delta: { x: 1, y: 0 } });
+
+    expect(div.style.scrollSnapType).toBe('none');
+    expect(spy).toHaveBeenCalledExactlyOnceWith({
+      left: -1,
+      top: 0,
+      behavior: 'instant',
+    });
+  });
+
+  it('should scroll to a snapped item on drop', async () => {
+    const div = h('div');
+    const carouselDrag = new CarouselDrag(div);
+    const spy = vi.spyOn(div, 'scrollTo');
+
+    vi.spyOn(carouselDrag, '$isMounted', 'get').mockImplementation(() => true);
+    vi.spyOn(carouselDrag, 'isHorizontal', 'get').mockImplementation(() => true);
+    vi.spyOn(carouselDrag, 'isVertical', 'get').mockImplementation(() => false);
+    vi.spyOn(carouselDrag, 'carousel', 'get').mockImplementation(() => ({
+      items: [
+        {
+          // @ts-expect-error partial mock
+          state: {
+            left: 0,
+            top: 0,
+          },
+        },
+        {
+          // @ts-expect-error partial mock
+          state: {
+            left: -100,
+            top: -100,
+          },
+        },
+      ],
+    }));
+
+    // @ts-expect-error partial mock
+    carouselDrag.dragged({ mode: 'drop', distance: { x: 10, y: 0 }, delta: { x: 10, y: 0 } });
+
+    expect(spy).toHaveBeenCalledExactlyOnceWith({
+      left: -100,
+      behavior: 'smooth',
+    });
+    spy.mockClear();
+
+    vi.spyOn(carouselDrag, 'isHorizontal', 'get').mockImplementation(() => false);
+    vi.spyOn(carouselDrag, 'isVertical', 'get').mockImplementation(() => true);
+
+    // @ts-expect-error partial mock
+    carouselDrag.dragged({ mode: 'drop', distance: { x: 0, y: 10 }, delta: { x: 0, y: 10 } });
+
+    expect(spy).toHaveBeenCalledExactlyOnceWith({
+      top: -100,
+      behavior: 'smooth',
+    });
+    div.dispatchEvent(new Event('scrollend'));
+    expect(div.style.scrollSnapType).toBe('');
+  });
+});

--- a/packages/tests/Carousel/CarouselDrag.spec.ts
+++ b/packages/tests/Carousel/CarouselDrag.spec.ts
@@ -131,4 +131,27 @@ describe('The CarouselDrag class', () => {
     div.dispatchEvent(new Event('scrollend'));
     expect(div.style.scrollSnapType).toBe('');
   });
+
+  it('should not throw or scroll on drop when the carousel has no items', async () => {
+    const div = h('div');
+    const carouselDrag = new CarouselDrag(div);
+    const spy = vi.spyOn(div, 'scrollTo');
+
+    vi.spyOn(carouselDrag, '$isMounted', 'get').mockImplementation(() => true);
+    vi.spyOn(carouselDrag, 'isHorizontal', 'get').mockImplementation(() => true);
+    vi.spyOn(carouselDrag, 'isVertical', 'get').mockImplementation(() => false);
+    // @ts-expect-error partial mock
+    vi.spyOn(carouselDrag, 'carousel', 'get').mockImplementation(() => ({ items: [] }));
+
+    // A preceding `drag` disables scroll-snap; a drop with no target slide must
+    // restore it and bail instead of scrolling to an `undefined` offset.
+    div.style.scrollSnapType = 'none';
+
+    expect(() =>
+      // @ts-expect-error partial mock
+      carouselDrag.dragged({ mode: 'drop', distance: { x: 10, y: 0 }, delta: { x: 10, y: 0 } }),
+    ).not.toThrow();
+    expect(spy).not.toHaveBeenCalled();
+    expect(div.style.scrollSnapType).toBe('');
+  });
 });

--- a/packages/tests/Carousel/CarouselItem.spec.ts
+++ b/packages/tests/Carousel/CarouselItem.spec.ts
@@ -53,4 +53,20 @@ describe('The CarouselItem class', () => {
     expect(carouselItem.state).not.toBe(state);
     expect(carouselItem.state).toEqual(state);
   });
+
+  it('should reset its state on update', async () => {
+    const item = h('div', { dataComponent: 'CarouselItem' });
+    const wrapper = h('div', { dataComponent: 'CarouselWrapper' }, [item]);
+    const div = h('div', [wrapper]);
+    const carousel = new Carousel(div);
+    await mount(carousel);
+    const carouselItem = getInstanceFromElement(item, CarouselItem);
+    const { state } = carouselItem;
+    expect(carouselItem.state).toBe(state);
+    // Inserting/removing slides re-measures offsets: a plain `$update` must
+    // invalidate the cached scroll target too, not just a window resize.
+    carouselItem.updated();
+    expect(carouselItem.state).not.toBe(state);
+    expect(carouselItem.state).toEqual(state);
+  });
 });

--- a/packages/tests/Carousel/CarouselItem.spec.ts
+++ b/packages/tests/Carousel/CarouselItem.spec.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from 'vitest';
+import { CarouselItem, Carousel } from '@studiometa/ui';
+import { getInstanceFromElement } from '@studiometa/js-toolkit';
+import { h, mount, wait } from '#test-utils';
+
+vi.mock('compute-scroll-into-view', () => ({
+  compute: (target: Element) => [{ el: target, top: 0, left: 0 }],
+}));
+
+describe('The CarouselItem class', () => {
+  it('should know its own index', async () => {
+    const items = [
+      h('div', { dataComponent: 'CarouselItem' }),
+      h('div', { dataComponent: 'CarouselItem' }),
+      h('div', { dataComponent: 'CarouselItem' }),
+      h('div', { dataComponent: 'CarouselItem' }),
+    ];
+    const wrapper = h('div', { dataComponent: 'CarouselWrapper' }, items);
+    const div = h('div', [wrapper]);
+    const carousel = new Carousel(div);
+    await mount(carousel);
+
+    const firstItem = getInstanceFromElement(items.at(0), CarouselItem);
+    const secondItem = getInstanceFromElement(items.at(1), CarouselItem);
+
+    expect(firstItem.index).toBe(0);
+    expect(secondItem.index).toBe(1);
+  });
+
+  it('should set an active state when active', async () => {
+    const div = h('div');
+    const carouselItem = new CarouselItem(div);
+    vi.spyOn(carouselItem, 'index', 'get').mockImplementation(() => 0);
+    // @ts-expect-error partial mock
+    vi.spyOn(carouselItem, 'carousel', 'get').mockImplementation(() => ({ currentIndex: 0 }));
+
+    carouselItem.onParentCarouselProgress();
+    await wait(20);
+    expect(div.style.getPropertyValue('--carousel-item-active')).toBe('1');
+
+    // @ts-expect-error partial mock
+    vi.spyOn(carouselItem, 'carousel', 'get').mockImplementation(() => ({ currentIndex: 1 }));
+    carouselItem.onParentCarouselProgress();
+    expect(div.style.getPropertyValue('--carousel-item-active')).toBe('1');
+    await wait(20);
+    expect(div.style.getPropertyValue('--carousel-item-active')).toBe('0');
+  });
+
+  it('should reset its state on window resize', async () => {
+    const item = h('div', { dataComponent: 'CarouselItem' });
+    const wrapper = h('div', { dataComponent: 'CarouselWrapper' }, [item]);
+    const div = h('div', [wrapper]);
+    const carousel = new Carousel(div);
+    await mount(carousel);
+    const carouselItem = getInstanceFromElement(item, CarouselItem);
+    const { state } = carouselItem;
+    expect(carouselItem.state).toBe(state);
+    carouselItem.resized();
+    expect(carouselItem.state).not.toBe(state);
+    expect(carouselItem.state).toEqual(state);
+  });
+});

--- a/packages/tests/Carousel/CarouselItem.spec.ts
+++ b/packages/tests/Carousel/CarouselItem.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { CarouselItem, Carousel } from '@studiometa/ui';
 import { getInstanceFromElement } from '@studiometa/js-toolkit';
-import { h, mount, wait } from '#test-utils';
+import { h, mount } from '#test-utils';
 
 vi.mock('compute-scroll-into-view', () => ({
   compute: (target: Element) => [{ el: target, top: 0, left: 0 }],
@@ -27,22 +27,16 @@ describe('The CarouselItem class', () => {
     expect(secondItem.index).toBe(1);
   });
 
-  it('should set an active state when active', async () => {
+  it('should set an active state when its index matches', async () => {
     const div = h('div');
     const carouselItem = new CarouselItem(div);
     vi.spyOn(carouselItem, 'index', 'get').mockImplementation(() => 0);
-    // @ts-expect-error partial mock
-    vi.spyOn(carouselItem, 'carousel', 'get').mockImplementation(() => ({ currentIndex: 0 }));
 
-    carouselItem.onParentCarouselProgress();
-    await wait(20);
+    // `update` returns the DOM write to run in the scheduler's write phase.
+    carouselItem.update(0)?.();
     expect(div.style.getPropertyValue('--carousel-item-active')).toBe('1');
 
-    // @ts-expect-error partial mock
-    vi.spyOn(carouselItem, 'carousel', 'get').mockImplementation(() => ({ currentIndex: 1 }));
-    carouselItem.onParentCarouselProgress();
-    expect(div.style.getPropertyValue('--carousel-item-active')).toBe('1');
-    await wait(20);
+    carouselItem.update(1)?.();
     expect(div.style.getPropertyValue('--carousel-item-active')).toBe('0');
   });
 

--- a/packages/tests/Carousel/CarouselNavigation.spec.ts
+++ b/packages/tests/Carousel/CarouselNavigation.spec.ts
@@ -169,4 +169,18 @@ describe('Carousel navigation', () => {
     expect(items[0].style.getPropertyValue('--carousel-item-active')).toBe('0');
     expect(items[1].style.getPropertyValue('--carousel-item-active')).toBe('1');
   });
+
+  it('should refresh progress after an update', async () => {
+    const { carousel, wrapper } = await getCarousel();
+    await wait();
+
+    // After an update the progress denominator can change; `updated` must
+    // re-emit the refreshed progress rather than leave `--carousel-progress`
+    // stale until the next scroll.
+    vi.spyOn(wrapper, 'progress', 'get').mockReturnValue(0.5);
+    carousel.updated();
+    await wait();
+
+    expect(carousel.$el.style.getPropertyValue('--carousel-progress')).toBe('0.5');
+  });
 });

--- a/packages/tests/Carousel/CarouselNavigation.spec.ts
+++ b/packages/tests/Carousel/CarouselNavigation.spec.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// Give each item a deterministic scroll target based on its position among the
+// CarouselItem siblings, so `getClosestIndex` can map a scroll position back to
+// an index without a real layout engine.
+vi.mock('compute-scroll-into-view', () => ({
+  compute: (el: Element) => {
+    const items = [...el.parentElement!.querySelectorAll('[data-component~="CarouselItem"]')];
+    const index = items.indexOf(el);
+    return [{ el, top: index * 100, left: index * 100 }];
+  },
+}));
+
+import { Carousel } from '@studiometa/ui';
+import { h, mount } from '#test-utils';
+
+describe('Carousel navigation', () => {
+  async function getCarousel() {
+    const items = [
+      h('div', { dataComponent: 'CarouselItem' }),
+      h('div', { dataComponent: 'CarouselItem' }),
+      h('div', { dataComponent: 'CarouselItem' }),
+    ];
+    const wrapperEl = h('div', { dataComponent: 'CarouselWrapper' }, items);
+    const el = h('div', [wrapperEl]);
+    const carousel = new Carousel(el);
+    await mount(carousel);
+    return { carousel, wrapper: carousel.wrapper };
+  }
+
+  it('should scroll to the target item when navigating programmatically', async () => {
+    const { carousel, wrapper } = await getCarousel();
+    const scrollTo = vi.spyOn(wrapper.$el, 'scrollTo');
+
+    carousel.goTo(2);
+
+    expect(carousel.currentIndex).toBe(2);
+    expect(scrollTo).toHaveBeenCalledExactlyOnceWith({ left: 200, top: 200, behavior: 'smooth' });
+  });
+
+  it('should sync the index from a scroll without scrolling back to it', async () => {
+    const { carousel, wrapper } = await getCarousel();
+    const scrollTo = vi.spyOn(wrapper.$el, 'scrollTo');
+
+    // Emulate the wrapper being scrolled to the second item, then a scroll event.
+    vi.spyOn(wrapper.$el, 'scrollLeft', 'get').mockReturnValue(100);
+    wrapper.onScroll();
+
+    // The index reflects the scroll position…
+    expect(carousel.currentIndex).toBe(1);
+    // …but the wrapper must NOT scroll back to it, otherwise it would hijack a
+    // programmatic smooth scroll and never reach the requested item.
+    expect(scrollTo).not.toHaveBeenCalled();
+
+    // A subsequent programmatic navigation still scrolls.
+    carousel.goTo(0);
+    expect(scrollTo).toHaveBeenCalledExactlyOnceWith({ left: 0, top: 0, behavior: 'smooth' });
+  });
+});

--- a/packages/tests/Carousel/CarouselNavigation.spec.ts
+++ b/packages/tests/Carousel/CarouselNavigation.spec.ts
@@ -183,4 +183,42 @@ describe('Carousel navigation', () => {
 
     expect(carousel.$el.style.getPropertyValue('--carousel-progress')).toBe('0.5');
   });
+
+  describe('boundary option', () => {
+    async function mountWith(boundary: string) {
+      const items = [
+        h('div', { dataComponent: 'CarouselItem' }),
+        h('div', { dataComponent: 'CarouselItem' }),
+        h('div', { dataComponent: 'CarouselItem' }),
+      ];
+      const wrapperEl = h('div', { dataComponent: 'CarouselWrapper' }, items);
+      const el = h('div', { dataOptionBoundary: boundary }, [wrapperEl]);
+      const carousel = new Carousel(el);
+      await mount(carousel);
+      return carousel;
+    }
+
+    it('clamp: goNext stops at the last index', async () => {
+      const carousel = await mountWith('clamp');
+      carousel.goTo(2);
+      carousel.goNext();
+      expect(carousel.currentIndex).toBe(2);
+    });
+
+    it('loop: navigation wraps around the ends', async () => {
+      const carousel = await mountWith('loop');
+      carousel.goTo(2);
+      carousel.goNext();
+      expect(carousel.currentIndex).toBe(0);
+      carousel.goPrev();
+      expect(carousel.currentIndex).toBe(2);
+    });
+
+    it('bounce: navigation reverses at the last index', async () => {
+      const carousel = await mountWith('bounce');
+      carousel.goTo(2);
+      carousel.goNext();
+      expect(carousel.currentIndex).toBe(1);
+    });
+  });
 });

--- a/packages/tests/Carousel/CarouselNavigation.spec.ts
+++ b/packages/tests/Carousel/CarouselNavigation.spec.ts
@@ -1,20 +1,26 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // Give each item a deterministic scroll target based on its position among the
 // CarouselItem siblings, so `getClosestIndex` can map a scroll position back to
-// an index without a real layout engine.
+// an index without a real layout engine. `geo.scale` is mutable so a resize can
+// change the geometry and tests can tell a fresh measurement from a stale one.
+const geo = vi.hoisted(() => ({ scale: 100 }));
 vi.mock('compute-scroll-into-view', () => ({
   compute: (el: Element) => {
     const items = [...el.parentElement!.querySelectorAll('[data-component~="CarouselItem"]')];
     const index = items.indexOf(el);
-    return [{ el, top: index * 100, left: index * 100 }];
+    return [{ el, top: index * geo.scale, left: index * geo.scale }];
   },
 }));
 
 import { Carousel } from '@studiometa/ui';
-import { h, mount } from '#test-utils';
+import { h, mount, wait, resizeWindow } from '#test-utils';
 
 describe('Carousel navigation', () => {
+  beforeEach(() => {
+    geo.scale = 100;
+  });
+
   async function getCarousel() {
     const items = [
       h('div', { dataComponent: 'CarouselItem' }),
@@ -25,7 +31,7 @@ describe('Carousel navigation', () => {
     const el = h('div', [wrapperEl]);
     const carousel = new Carousel(el);
     await mount(carousel);
-    return { carousel, wrapper: carousel.wrapper };
+    return { carousel, wrapper: carousel.wrapper, items };
   }
 
   it('should scroll to the target item when navigating programmatically', async () => {
@@ -55,5 +61,84 @@ describe('Carousel navigation', () => {
     // A subsequent programmatic navigation still scrolls.
     carousel.goTo(0);
     expect(scrollTo).toHaveBeenCalledExactlyOnceWith({ left: 0, top: 0, behavior: 'smooth' });
+  });
+
+  it('should mark item 0 active and disable the prev button after mount alone', async () => {
+    // No navigation happens: this asserts the store is seeded on mount, which is
+    // what fixes the initial-state race (item 0 not active, prev not disabled).
+    const items = [
+      h('div', { dataComponent: 'CarouselItem' }),
+      h('div', { dataComponent: 'CarouselItem' }),
+    ];
+    const prevBtn = h('button', { dataComponent: 'CarouselBtn', dataOptionAction: 'prev' });
+    const wrapperEl = h('div', { dataComponent: 'CarouselWrapper' }, items);
+    const el = h('div', [wrapperEl, prevBtn]);
+    const carousel = new Carousel(el);
+    await mount(carousel);
+    await wait(50);
+
+    expect(items[0].style.getPropertyValue('--carousel-item-active')).toBe('1');
+    expect(items[1].style.getPropertyValue('--carousel-item-active')).toBe('0');
+    expect((prevBtn as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('should update progress on a scroll that is not preceded by a goTo', async () => {
+    const { carousel, wrapper } = await getCarousel();
+    await wait();
+
+    // A native/touch scroll only reports through onScroll; it must still keep
+    // the progress bar animating (the `ticked` service is re-enabled there).
+    vi.spyOn(wrapper, 'progress', 'get').mockReturnValue(0.5);
+    wrapper.onScroll();
+    await wait();
+
+    expect(carousel.$el.style.getPropertyValue('--carousel-progress')).toBe('0.5');
+  });
+
+  it('should re-snap to the freshly-measured position on resize', async () => {
+    const { carousel, wrapper } = await getCarousel();
+    carousel.goTo(1);
+    await wait();
+
+    const scrollTo = vi.spyOn(wrapper.$el, 'scrollTo');
+
+    // The geometry changes on resize: item positions halve. Driving the real
+    // resize service (not calling `resized()` directly) exercises js-toolkit's
+    // parent-first callback order, so a synchronous re-snap would read the stale
+    // cached position (100). The deferred re-snap must use the fresh one (50).
+    geo.scale = 50;
+    await resizeWindow({ width: 800 });
+
+    expect(scrollTo).toHaveBeenCalledWith({ left: 50, top: 50, behavior: 'smooth' });
+    expect(scrollTo).not.toHaveBeenCalledWith({ left: 100, top: 100, behavior: 'smooth' });
+  });
+
+  it('should refresh controls when items are added after mount', async () => {
+    // After appending items, `lastIndex` grows but the stored index is unchanged,
+    // so the change-gated store never re-notifies. Controls must still refresh on
+    // update, otherwise the `next` button stays stuck disabled.
+    const items = [
+      h('div', { dataComponent: 'CarouselItem' }),
+      h('div', { dataComponent: 'CarouselItem' }),
+    ];
+    const nextBtn = h('button', { dataComponent: 'CarouselBtn', dataOptionAction: 'next' });
+    const wrapperEl = h('div', { dataComponent: 'CarouselWrapper' }, items);
+    const el = h('div', [wrapperEl, nextBtn]);
+    const carousel = new Carousel(el);
+    await mount(carousel);
+
+    carousel.goTo(1); // last index of two items -> next disabled
+    await wait();
+    expect((nextBtn as HTMLButtonElement).disabled).toBe(true);
+
+    wrapperEl.append(
+      h('div', { dataComponent: 'CarouselItem' }),
+      h('div', { dataComponent: 'CarouselItem' }),
+    );
+    await carousel.$update();
+    await wait();
+
+    // lastIndex is now 3, so index 1 is no longer the last -> next re-enables.
+    expect((nextBtn as HTMLButtonElement).disabled).toBe(false);
   });
 });

--- a/packages/tests/Carousel/CarouselNavigation.spec.ts
+++ b/packages/tests/Carousel/CarouselNavigation.spec.ts
@@ -141,4 +141,32 @@ describe('Carousel navigation', () => {
     // lastIndex is now 3, so index 1 is no longer the last -> next re-enables.
     expect((nextBtn as HTMLButtonElement).disabled).toBe(false);
   });
+
+  it('should re-normalize the current index when items are removed', async () => {
+    const items = [
+      h('div', { dataComponent: 'CarouselItem' }),
+      h('div', { dataComponent: 'CarouselItem' }),
+      h('div', { dataComponent: 'CarouselItem' }),
+      h('div', { dataComponent: 'CarouselItem' }),
+    ];
+    const wrapperEl = h('div', { dataComponent: 'CarouselWrapper' }, items);
+    const el = h('div', [wrapperEl]);
+    const carousel = new Carousel(el);
+    await mount(carousel);
+
+    carousel.goTo(3);
+    await wait();
+    expect(carousel.currentIndex).toBe(3);
+
+    // Remove the last two items so index 3 is now out of range.
+    items[3].remove();
+    items[2].remove();
+    await carousel.$update();
+    await wait();
+
+    // The index is clamped to the new last index and the active item follows.
+    expect(carousel.currentIndex).toBe(1);
+    expect(items[0].style.getPropertyValue('--carousel-item-active')).toBe('0');
+    expect(items[1].style.getPropertyValue('--carousel-item-active')).toBe('1');
+  });
 });

--- a/packages/tests/Carousel/CarouselWrapper.spec.ts
+++ b/packages/tests/Carousel/CarouselWrapper.spec.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi } from 'vitest';
+import { CarouselWrapper } from '@studiometa/ui';
+import { h } from '#test-utils';
+
+describe('The CarouselWrapper class', () => {
+  it('should return its progress', async () => {
+    const div = h('div');
+    const carouselWrapper = new CarouselWrapper(div);
+
+    vi.spyOn(carouselWrapper, 'isHorizontal', 'get').mockImplementation(() => false);
+    vi.spyOn(carouselWrapper, 'isVertical', 'get').mockImplementation(() => false);
+
+    expect(carouselWrapper.progress).toBe(0);
+
+    // Horizontal but no scroll
+    vi.spyOn(carouselWrapper, 'isHorizontal', 'get').mockImplementation(() => true);
+    vi.spyOn(carouselWrapper, 'isVertical', 'get').mockImplementation(() => false);
+    expect(carouselWrapper.progress).toBe(0);
+
+    // Vertical but no scroll
+    vi.spyOn(carouselWrapper, 'isHorizontal', 'get').mockImplementation(() => false);
+    vi.spyOn(carouselWrapper, 'isVertical', 'get').mockImplementation(() => true);
+    expect(carouselWrapper.progress).toBe(0);
+
+    // Horizontal, size and scrollable, no scroll
+    vi.spyOn(div, 'scrollWidth', 'get').mockImplementation(() => 100);
+    vi.spyOn(div, 'offsetWidth', 'get').mockImplementation(() => 50);
+    vi.spyOn(carouselWrapper, 'isHorizontal', 'get').mockImplementation(() => true);
+    vi.spyOn(carouselWrapper, 'isVertical', 'get').mockImplementation(() => false);
+    expect(carouselWrapper.progress).toBe(0);
+
+    // Horizontal, size and scrollable and scroll
+    vi.spyOn(div, 'scrollLeft', 'get').mockImplementation(() => 25);
+    expect(carouselWrapper.progress).toBe(0.5);
+
+    // Vertical, size and scrollable, no scroll
+    vi.spyOn(div, 'scrollHeight', 'get').mockImplementation(() => 100);
+    vi.spyOn(div, 'offsetHeight', 'get').mockImplementation(() => 50);
+    vi.spyOn(carouselWrapper, 'isHorizontal', 'get').mockImplementation(() => false);
+    vi.spyOn(carouselWrapper, 'isVertical', 'get').mockImplementation(() => true);
+    expect(carouselWrapper.progress).toBe(0);
+
+    // Horizontal, size and scrollable and scroll
+    vi.spyOn(div, 'scrollTop', 'get').mockImplementation(() => 25);
+    expect(carouselWrapper.progress).toBe(0.5);
+  });
+
+  it('should update index when scrolling', () => {
+    const div = h('div');
+    const carouselWrapper = new CarouselWrapper(div);
+    const mock = {
+      currentIndex: 0,
+      $services: {
+        enable: vi.fn(),
+      },
+      items: [
+        {
+          state: {
+            left: 0,
+            top: 0,
+          },
+        },
+        {
+          state: {
+            left: -100,
+            top: -100,
+          },
+        },
+      ],
+    };
+    const carousel = vi.spyOn(carouselWrapper, 'carousel', 'get');
+    // @ts-expect-error partial mock
+    carousel.mockImplementation(() => mock);
+
+    vi.spyOn(carouselWrapper, 'isHorizontal', 'get').mockImplementation(() => true);
+    vi.spyOn(carouselWrapper, 'isVertical', 'get').mockImplementation(() => false);
+    vi.spyOn(div, 'scrollLeft', 'get').mockImplementation(() => 10);
+    vi.spyOn(div, 'scrollTop', 'get').mockImplementation(() => 10);
+
+    carouselWrapper.onScroll();
+
+    expect(mock.currentIndex).toBe(0);
+    expect(mock.$services.enable).toHaveBeenCalledExactlyOnceWith('ticked');
+
+    vi.spyOn(div, 'scrollLeft', 'get').mockImplementation(() => -100);
+    vi.spyOn(div, 'scrollTop', 'get').mockImplementation(() => -100);
+    carouselWrapper.onScroll();
+
+    expect(mock.currentIndex).toBe(1);
+
+    vi.spyOn(carouselWrapper, 'isHorizontal', 'get').mockImplementation(() => false);
+    vi.spyOn(carouselWrapper, 'isVertical', 'get').mockImplementation(() => true);
+    vi.spyOn(div, 'scrollLeft', 'get').mockImplementation(() => -90);
+    vi.spyOn(div, 'scrollTop', 'get').mockImplementation(() => -90);
+    carouselWrapper.onScroll();
+
+    expect(mock.currentIndex).toBe(1);
+  });
+
+  it('should scroll to the matching item when the carousel goes to', async () => {
+    const div = h('div');
+    const carouselWrapper = new CarouselWrapper(div);
+    const mock = {
+      currentIndex: 0,
+      items: [
+        {
+          state: {
+            left: 0,
+            top: 0,
+          },
+        },
+        {
+          state: {
+            left: -100,
+            top: -100,
+          },
+        },
+      ],
+    };
+    const carousel = vi.spyOn(carouselWrapper, 'carousel', 'get');
+    // @ts-expect-error partial mock
+    carousel.mockImplementation(() => mock);
+
+    const spy = vi.spyOn(div, 'scrollTo');
+    carouselWrapper.onParentCarouselIndex();
+    expect(spy).toHaveBeenCalledExactlyOnceWith({
+      left: 0,
+      top: 0,
+      behavior: 'smooth',
+    });
+    spy.mockClear();
+
+    mock.currentIndex = 1;
+
+    carouselWrapper.onParentCarouselIndex();
+    expect(spy).toHaveBeenCalledExactlyOnceWith({
+      left: -100,
+      top: -100,
+      behavior: 'smooth',
+    });
+  });
+});

--- a/packages/tests/Carousel/CarouselWrapper.spec.ts
+++ b/packages/tests/Carousel/CarouselWrapper.spec.ts
@@ -83,6 +83,24 @@ describe('The CarouselWrapper class', () => {
     expect(scrollWidth.mock.calls.length).toBeGreaterThan(callsAfterFirstRead);
   });
 
+  it('should invalidate the cached scroll distance on update', () => {
+    const div = h('div');
+    const carouselWrapper = new CarouselWrapper(div);
+    vi.spyOn(carouselWrapper, 'isHorizontal', 'get').mockImplementation(() => true);
+    vi.spyOn(carouselWrapper, 'isVertical', 'get').mockImplementation(() => false);
+    vi.spyOn(div, 'scrollLeft', 'get').mockImplementation(() => 25);
+    const scrollWidth = vi.spyOn(div, 'scrollWidth', 'get').mockImplementation(() => 100);
+    vi.spyOn(div, 'clientWidth', 'get').mockImplementation(() => 50);
+
+    expect(carouselWrapper.progress).toBe(0.5);
+
+    // Adding/removing items changes scrollWidth: `updated` must invalidate the
+    // cache so progress reflects the new scrollable distance without a resize.
+    scrollWidth.mockImplementation(() => 150);
+    carouselWrapper.updated();
+    expect(carouselWrapper.progress).toBe(0.25);
+  });
+
   it('should update index when scrolling', () => {
     const div = h('div');
     const carouselWrapper = new CarouselWrapper(div);

--- a/packages/tests/Carousel/CarouselWrapper.spec.ts
+++ b/packages/tests/Carousel/CarouselWrapper.spec.ts
@@ -22,27 +22,65 @@ describe('The CarouselWrapper class', () => {
     vi.spyOn(carouselWrapper, 'isVertical', 'get').mockImplementation(() => true);
     expect(carouselWrapper.progress).toBe(0);
 
-    // Horizontal, size and scrollable, no scroll
+    // Horizontal, size and scrollable, no scroll. `offsetWidth` is larger than
+    // `clientWidth` to emulate a scrollbar/border: progress must divide by the
+    // real scrollable distance (`scrollWidth - clientWidth`), not `offsetWidth`.
     vi.spyOn(div, 'scrollWidth', 'get').mockImplementation(() => 100);
-    vi.spyOn(div, 'offsetWidth', 'get').mockImplementation(() => 50);
+    vi.spyOn(div, 'clientWidth', 'get').mockImplementation(() => 50);
+    vi.spyOn(div, 'offsetWidth', 'get').mockImplementation(() => 65);
     vi.spyOn(carouselWrapper, 'isHorizontal', 'get').mockImplementation(() => true);
     vi.spyOn(carouselWrapper, 'isVertical', 'get').mockImplementation(() => false);
+    carouselWrapper.resized();
     expect(carouselWrapper.progress).toBe(0);
 
     // Horizontal, size and scrollable and scroll
     vi.spyOn(div, 'scrollLeft', 'get').mockImplementation(() => 25);
     expect(carouselWrapper.progress).toBe(0.5);
 
+    // Reaches exactly 1 at the maximum scroll position.
+    vi.spyOn(div, 'scrollLeft', 'get').mockImplementation(() => 50);
+    expect(carouselWrapper.progress).toBe(1);
+
+    // A sub-pixel-short scroll offset still resolves to a clean 1.
+    vi.spyOn(div, 'scrollLeft', 'get').mockImplementation(() => 49.77);
+    expect(carouselWrapper.progress).toBe(1);
+
     // Vertical, size and scrollable, no scroll
     vi.spyOn(div, 'scrollHeight', 'get').mockImplementation(() => 100);
-    vi.spyOn(div, 'offsetHeight', 'get').mockImplementation(() => 50);
+    vi.spyOn(div, 'clientHeight', 'get').mockImplementation(() => 50);
+    vi.spyOn(div, 'offsetHeight', 'get').mockImplementation(() => 65);
     vi.spyOn(carouselWrapper, 'isHorizontal', 'get').mockImplementation(() => false);
     vi.spyOn(carouselWrapper, 'isVertical', 'get').mockImplementation(() => true);
+    carouselWrapper.resized();
     expect(carouselWrapper.progress).toBe(0);
 
-    // Horizontal, size and scrollable and scroll
+    // Vertical, size and scrollable and scroll
     vi.spyOn(div, 'scrollTop', 'get').mockImplementation(() => 25);
     expect(carouselWrapper.progress).toBe(0.5);
+  });
+
+  it('should cache the scroll distance until resized', () => {
+    const div = h('div');
+    const carouselWrapper = new CarouselWrapper(div);
+    vi.spyOn(carouselWrapper, 'isHorizontal', 'get').mockImplementation(() => true);
+    vi.spyOn(carouselWrapper, 'isVertical', 'get').mockImplementation(() => false);
+    vi.spyOn(div, 'scrollLeft', 'get').mockImplementation(() => 25);
+    const scrollWidth = vi.spyOn(div, 'scrollWidth', 'get').mockImplementation(() => 100);
+    vi.spyOn(div, 'clientWidth', 'get').mockImplementation(() => 50);
+
+    // First read measures and caches the layout values.
+    expect(carouselWrapper.progress).toBe(0.5);
+    const callsAfterFirstRead = scrollWidth.mock.calls.length;
+
+    // Subsequent reads reuse the cache and do not touch the layout again.
+    expect(carouselWrapper.progress).toBe(0.5);
+    expect(carouselWrapper.progress).toBe(0.5);
+    expect(scrollWidth.mock.calls.length).toBe(callsAfterFirstRead);
+
+    // A resize invalidates the cache, so the next read measures again.
+    carouselWrapper.resized();
+    expect(carouselWrapper.progress).toBe(0.5);
+    expect(scrollWidth.mock.calls.length).toBeGreaterThan(callsAfterFirstRead);
   });
 
   it('should update index when scrolling', () => {

--- a/packages/tests/Carousel/CarouselWrapper.spec.ts
+++ b/packages/tests/Carousel/CarouselWrapper.spec.ts
@@ -135,11 +135,10 @@ describe('The CarouselWrapper class', () => {
     expect(mock.currentIndex).toBe(1);
   });
 
-  it('should scroll to the matching item when the carousel goes to', async () => {
+  it('should scroll to the matching item on scrollToIndex', async () => {
     const div = h('div');
     const carouselWrapper = new CarouselWrapper(div);
     const mock = {
-      currentIndex: 0,
       items: [
         {
           state: {
@@ -160,7 +159,7 @@ describe('The CarouselWrapper class', () => {
     carousel.mockImplementation(() => mock);
 
     const spy = vi.spyOn(div, 'scrollTo');
-    carouselWrapper.onParentCarouselIndex();
+    carouselWrapper.scrollToIndex(0);
     expect(spy).toHaveBeenCalledExactlyOnceWith({
       left: 0,
       top: 0,
@@ -168,13 +167,23 @@ describe('The CarouselWrapper class', () => {
     });
     spy.mockClear();
 
-    mock.currentIndex = 1;
-
-    carouselWrapper.onParentCarouselIndex();
+    carouselWrapper.scrollToIndex(1);
     expect(spy).toHaveBeenCalledExactlyOnceWith({
       left: -100,
       top: -100,
       behavior: 'smooth',
     });
+  });
+
+  it('should not scroll on scrollToIndex when the carousel has no matching item', () => {
+    const div = h('div');
+    const carouselWrapper = new CarouselWrapper(div);
+    const spy = vi.spyOn(div, 'scrollTo');
+    // @ts-expect-error partial mock
+    vi.spyOn(carouselWrapper, 'carousel', 'get').mockImplementation(() => ({ items: [] }));
+
+    // An empty carousel (or an out-of-range index) must not throw or scroll.
+    expect(() => carouselWrapper.scrollToIndex(0)).not.toThrow();
+    expect(spy).not.toHaveBeenCalled();
   });
 });

--- a/packages/tests/Carousel/utils.spec.ts
+++ b/packages/tests/Carousel/utils.spec.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { getClosestIndex } from '#private/Carousel/utils.js';
+
+describe('The getClosestIndex function', () => {
+  it('should return the closest index', () => {
+    const fixtures = [
+      [[0, 1, 2, 3] as number[], 1, 1],
+      [[0.1, 0.2, 0.3, 0.4] as number[], 0.222, 1],
+    ] as const;
+
+    for (const [numbers, target, result] of fixtures) {
+      expect(getClosestIndex(numbers, target)).toBe(result);
+    }
+  });
+});

--- a/packages/tests/__utils__/index.ts
+++ b/packages/tests/__utils__/index.ts
@@ -2,6 +2,7 @@ export * from './components.js';
 export * from './faketimers.js';
 export * from './h.js';
 export * from './lifecycle.js';
+export * from './matchMedia.js';
 export * from './mockImageLoad.js';
 export * from './mockVideoLoad.js';
 export * from './mockIntersectionObserver.js';

--- a/packages/tests/__utils__/matchMedia.ts
+++ b/packages/tests/__utils__/matchMedia.ts
@@ -1,0 +1,127 @@
+import { afterEach, vi } from 'vitest';
+
+class MatchMedia {
+  mediaQueries = {};
+  mediaQueryList = {};
+  currentMediaQuery = '';
+  constructor() {
+    this.mediaQueries = {};
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      configurable: true,
+      value: (query) => {
+        this.mediaQueryList = {
+          matches: query === this.currentMediaQuery,
+          media: query,
+          onchange: null,
+          addListener: (listener) => {
+            this.addListener(query, listener);
+          },
+          removeListener: (listener) => {
+            this.removeListener(query, listener);
+          },
+          addEventListener: (type, listener) => {
+            if (type !== 'change') return;
+            this.addListener(query, listener);
+          },
+          removeEventListener: (type, listener) => {
+            if (type !== 'change') return;
+            this.removeListener(query, listener);
+          },
+          dispatchEvent: vi.fn(),
+        };
+        return this.mediaQueryList;
+      },
+    });
+  }
+  /**
+   * Adds a new listener function for the specified media query
+   * @private
+   */
+  addListener(mediaQuery, listener) {
+    if (!this.mediaQueries[mediaQuery]) {
+      this.mediaQueries[mediaQuery] = [];
+    }
+    const query = this.mediaQueries[mediaQuery];
+    const listenerIndex = query.indexOf(listener);
+    if (listenerIndex !== -1) return;
+    query.push(listener);
+  }
+  /**
+   * Removes a previously added listener function for the specified media query
+   * @private
+   */
+  removeListener(mediaQuery, listener) {
+    if (!this.mediaQueries[mediaQuery]) return;
+    const query = this.mediaQueries[mediaQuery];
+    const listenerIndex = query.indexOf(listener);
+    if (listenerIndex === -1) return;
+    query.splice(listenerIndex, 1);
+  }
+  /**
+   * Updates the currently used media query,
+   * and calls previously added listener functions registered for this media query
+   * @public
+   */
+  useMediaQuery(mediaQuery) {
+    if (typeof mediaQuery !== 'string') throw new Error('Media Query must be a string');
+    this.currentMediaQuery = mediaQuery;
+    if (!this.mediaQueries[mediaQuery]) return;
+    const mqListEvent = {
+      matches: true,
+      media: mediaQuery,
+    };
+    this.mediaQueries[mediaQuery].forEach((listener) => {
+      listener.call(this.mediaQueryList, mqListEvent);
+    });
+  }
+  /**
+   * Returns an array listing the media queries for which the matchMedia has registered listeners
+   * @public
+   */
+  getMediaQueries() {
+    return Object.keys(this.mediaQueries);
+  }
+  /**
+   * Returns a copy of the array of listeners for the specified media query
+   * @public
+   */
+  getListeners(mediaQuery) {
+    if (!this.mediaQueries[mediaQuery]) return [];
+    return this.mediaQueries[mediaQuery].slice();
+  }
+  /**
+   * Clears all registered media queries and their listeners
+   * @public
+   */
+  clear() {
+    this.mediaQueries = {};
+  }
+  /**
+   * Clears all registered media queries and their listeners,
+   * and destroys the implementation of `window.matchMedia`
+   * @public
+   */
+  destroy() {
+    this.clear();
+    delete window.matchMedia;
+  }
+}
+
+const defaultMediaQuery = '(min-width: 80rem)';
+// @ts-ignore
+const matchMedia = new MatchMedia();
+
+export function useMatchMedia(mediaQuery = defaultMediaQuery) {
+  matchMedia.useMediaQuery(mediaQuery);
+
+  return matchMedia;
+}
+
+export function resetMatchMedia() {
+  matchMedia.useMediaQuery(defaultMediaQuery);
+}
+
+afterEach(() => {
+  resetMatchMedia();
+});

--- a/packages/tests/index.spec.ts
+++ b/packages/tests/index.spec.ts
@@ -4,6 +4,7 @@ import * as components from '@studiometa/ui';
 test('components exports', () => {
   expect(Object.keys(components).toSorted()).toMatchInlineSnapshot(`
     [
+      "AbstractCarouselChild",
       "AbstractFrameTrigger",
       "AbstractPrefetch",
       "AbstractScrollAnimation",
@@ -15,6 +16,11 @@ test('components exports', () => {
       "AnchorNavLink",
       "AnchorNavTarget",
       "AnchorScrollTo",
+      "Carousel",
+      "CarouselBtn",
+      "CarouselDrag",
+      "CarouselItem",
+      "CarouselWrapper",
       "CircularMarquee",
       "Cursor",
       "DataBind",

--- a/packages/tests/index.spec.ts
+++ b/packages/tests/index.spec.ts
@@ -5,6 +5,7 @@ test('components exports', () => {
   expect(Object.keys(components).toSorted()).toMatchInlineSnapshot(`
     [
       "AbstractCarouselChild",
+      "AbstractCarouselComponent",
       "AbstractFrameTrigger",
       "AbstractPrefetch",
       "AbstractScrollAnimation",

--- a/packages/ui/Carousel/AbstractCarouselChild.ts
+++ b/packages/ui/Carousel/AbstractCarouselChild.ts
@@ -1,0 +1,74 @@
+import type { BaseConfig, BaseProps } from '@studiometa/js-toolkit';
+import { Base, getClosestParent } from '@studiometa/js-toolkit';
+import { Carousel } from './Carousel.js';
+
+/**
+ * AbstractCarouselChild class.
+ */
+export class AbstractCarouselChild<T extends BaseProps = BaseProps> extends Base<T> {
+  /**
+   * Config.
+   */
+  static config: BaseConfig = {
+    name: 'AbstractCarouselChild',
+    emits: ['parent-carousel-index', 'parent-carousel-progress'],
+  };
+
+  /**
+   * Get the parent carousel instance.
+   * @todo data-option-carousel for better grouping?
+   */
+  get carousel() {
+    return getClosestParent(this, Carousel);
+  }
+
+  /**
+   * Is the carousel horizontal?
+   */
+  get isHorizontal() {
+    return this.carousel.isHorizontal;
+  }
+
+  /**
+   * Is the carousel vertical?
+   */
+  get isVertical() {
+    return this.carousel.isVertical;
+  }
+
+  /**
+   * Disptach events from the parent carousel on the child components.
+   */
+  handleEvent(event: CustomEvent) {
+    switch (event.type) {
+      case 'index':
+      case 'progress':
+        this.$emit(`parent-carousel-${event.type}`, ...event.detail);
+        break;
+    }
+  }
+
+  /**
+   * Mounted hook.
+   */
+  mounted() {
+    const { carousel } = this;
+
+    if (!carousel) {
+      this.$warn('Could not find a parent slider, not mounting.');
+      this.$destroy();
+      return;
+    }
+
+    carousel.$on('index', this);
+    carousel.$on('progress', this);
+  }
+
+  /**
+   * Destroyed hook.
+   */
+  destroyed() {
+    this.carousel?.$off?.('index', this);
+    this.carousel?.$off?.('progress', this);
+  }
+}

--- a/packages/ui/Carousel/AbstractCarouselChild.ts
+++ b/packages/ui/Carousel/AbstractCarouselChild.ts
@@ -1,74 +1,137 @@
 import type { BaseConfig, BaseProps } from '@studiometa/js-toolkit';
-import { Base, getClosestParent } from '@studiometa/js-toolkit';
-import { Carousel } from './Carousel.js';
+import { nextFrame, domScheduler, isFunction } from '@studiometa/js-toolkit/utils';
+import { AbstractCarouselComponent } from './AbstractCarouselComponent.js';
+import type { Carousel } from './Carousel.js';
+
+export interface AbstractCarouselChildProps extends BaseProps {}
 
 /**
  * AbstractCarouselChild class.
+ *
+ * The shared base for Carousel controls that must reflect the active index
+ * (items, buttons). It connects to its parent `Carousel` — either handed over
+ * by the Carousel on mount or resolved through the inherited guarded
+ * `$closest('Carousel')` lookup, never via the deprecated `$parent` accessor —
+ * and subscribes to the Carousel's index store, scheduling a call to the
+ * subclass `update(index)` method whenever the active item changes. Subclasses
+ * must implement `update` to reflect the current index in the DOM.
  */
-export class AbstractCarouselChild<T extends BaseProps = BaseProps> extends Base<T> {
+export class AbstractCarouselChild<T extends BaseProps = BaseProps> extends AbstractCarouselComponent<
+  T & AbstractCarouselChildProps
+> {
   /**
    * Config.
    */
   static config: BaseConfig = {
     name: 'AbstractCarouselChild',
-    emits: ['parent-carousel-index', 'parent-carousel-progress'],
   };
 
   /**
-   * Get the parent carousel instance.
-   * @todo data-option-carousel for better grouping?
+   * Unsubscribe callback for the parent Carousel store subscription.
+   * @private
    */
-  get carousel() {
-    return getClosestParent(this, Carousel);
+  __unsubscribe: (() => void) | null = null;
+
+  /**
+   * Connect to the parent Carousel on mount.
+   */
+  mounted() {
+    this.__connect();
   }
 
   /**
-   * Is the carousel horizontal?
+   * Reconnect and refresh with the current index on resize.
    */
-  get isHorizontal() {
-    return this.carousel.isHorizontal;
-  }
-
-  /**
-   * Is the carousel vertical?
-   */
-  get isVertical() {
-    return this.carousel.isVertical;
-  }
-
-  /**
-   * Disptach events from the parent carousel on the child components.
-   */
-  handleEvent(event: CustomEvent) {
-    switch (event.type) {
-      case 'index':
-      case 'progress':
-        this.$emit(`parent-carousel-${event.type}`, ...event.detail);
-        break;
+  resized() {
+    this.__connect();
+    const { carousel } = this;
+    if (carousel?.store.has('index')) {
+      nextFrame(() => {
+        this.__updateWith(carousel.store.get('index', 0));
+      });
     }
   }
 
   /**
-   * Mounted hook.
+   * Reconnect and refresh on update.
+   *
+   * Reconnects (idempotent) then re-runs the subclass `update` against the
+   * current index. This matters when items are added or removed after mount:
+   * the index *value* may be unchanged — so the store's change-gated `set` does
+   * not re-notify — yet `carousel.lastIndex` and an item's own position among
+   * its siblings have shifted. Without this refresh a `CarouselBtn` could stay
+   * stuck disabled (e.g. `next` after appending items) or a `CarouselItem` keep
+   * a stale active state.
    */
-  mounted() {
+  updated() {
+    this.__connect();
     const { carousel } = this;
+    if (carousel?.store.has('index')) {
+      this.__updateWith(carousel.store.get('index', 0));
+    }
+  }
 
-    if (!carousel) {
-      this.$warn('Could not find a parent slider, not mounting.');
-      this.$destroy();
+  /**
+   * Remove the store subscription.
+   */
+  destroyed() {
+    this.__unsubscribe?.();
+    this.__unsubscribe = null;
+    this.__carousel = undefined;
+  }
+
+  /**
+   * Subscribe to a Carousel index store.
+   *
+   * The subscription never relies on the deprecated `$parent` accessor. The
+   * Carousel is either handed over by the parent itself — see
+   * `Carousel.connectChildren`, which connects the children that mounted before
+   * it — or resolved through a guarded `$closest('Carousel')` lookup. The call
+   * is idempotent and a no-op once the child is connected or unmounted.
+   *
+   * The current index is pulled immediately only when the Carousel has already
+   * seeded its store, which happens after `Carousel.mounted` runs its initial
+   * `goTo`. This ensures the `update` callback never runs against a
+   * not-yet-initialised Carousel and fixes the initial-state race where the
+   * first item was not marked active and the `prev` button was not disabled on
+   * load.
+   * @private
+   */
+  __connect(carousel: Carousel | undefined = this.carousel) {
+    if (this.__unsubscribe || !this.$isMounted || !carousel) {
       return;
     }
 
-    carousel.$on('index', this);
-    carousel.$on('progress', this);
+    this.__carousel = carousel;
+    this.__unsubscribe = carousel.store.subscribe('index', (index) => {
+      this.__updateWith(index ?? 0);
+    });
+
+    if (carousel.store.has('index')) {
+      this.__updateWith(carousel.store.get('index', 0));
+    }
   }
 
   /**
-   * Destroyed hook.
+   * Schedule the `update` callback for the given index.
+   * @private
    */
-  destroyed() {
-    this.carousel?.$off?.('index', this);
-    this.carousel?.$off?.('progress', this);
+  __updateWith(index: number) {
+    domScheduler.read(() => {
+      const callback = this.update(index);
+      if (isFunction(callback)) {
+        domScheduler.write(() => {
+          // @ts-ignore
+          callback();
+        });
+      }
+    });
+  }
+
+  /**
+   * Update the child component with the given index.
+   */
+  update(index: number): void | (() => void) {
+    throw new Error(`The \`AbstractCarouselChild.update(${index})\` method must be implemented.`);
   }
 }

--- a/packages/ui/Carousel/AbstractCarouselComponent.ts
+++ b/packages/ui/Carousel/AbstractCarouselComponent.ts
@@ -1,0 +1,64 @@
+import { Base } from '@studiometa/js-toolkit';
+import type { BaseConfig, BaseProps } from '@studiometa/js-toolkit';
+import type { Carousel } from './Carousel.js';
+
+export interface AbstractCarouselComponentProps extends BaseProps {}
+
+/**
+ * AbstractCarouselComponent class.
+ *
+ * The shared, non-subscribing base for every Carousel child component. It
+ * resolves the parent `Carousel` — either handed over by the Carousel on mount
+ * or through a guarded `$closest('Carousel')` lookup, never via the deprecated
+ * `$parent` accessor — and exposes the orientation getters the children rely on.
+ *
+ * It does not subscribe to the Carousel index store: components that only need
+ * to read the carousel (the `CarouselWrapper` scroller and the `CarouselDrag`
+ * track) extend this base directly, mirroring how `SliderItem`/`SliderDrag`
+ * extend `Base` rather than `AbstractSliderChild`. Controls that must react to
+ * index changes extend the subscribing `AbstractCarouselChild` instead.
+ */
+export class AbstractCarouselComponent<T extends BaseProps = BaseProps> extends Base<
+  T & AbstractCarouselComponentProps
+> {
+  /**
+   * Config.
+   */
+  static config: BaseConfig = {
+    name: 'AbstractCarouselComponent',
+  };
+
+  /**
+   * The parent Carousel this component is connected to.
+   * @private
+   */
+  __carousel: Carousel | undefined;
+
+  /**
+   * The parent Carousel instance, if any.
+   *
+   * Returns the Carousel that connected this component, falling back to a
+   * guarded `$closest('Carousel')` lookup. Never dereferences the deprecated
+   * `$parent` accessor; may be `undefined` before the component is connected to
+   * a Carousel.
+   */
+  get carousel(): Carousel | undefined {
+    return this.__carousel ?? this.$closest<Carousel>('Carousel');
+  }
+
+  /**
+   * Is the carousel horizontal? Defaults to `true` (the `x` axis) when the
+   * parent Carousel cannot be resolved yet.
+   */
+  get isHorizontal(): boolean {
+    return this.carousel?.isHorizontal ?? true;
+  }
+
+  /**
+   * Is the carousel vertical? Defaults to `false` when the parent Carousel
+   * cannot be resolved yet.
+   */
+  get isVertical(): boolean {
+    return this.carousel?.isVertical ?? false;
+  }
+}

--- a/packages/ui/Carousel/Carousel.ts
+++ b/packages/ui/Carousel/Carousel.ts
@@ -1,0 +1,125 @@
+import type { BaseConfig } from '@studiometa/js-toolkit';
+import type { IndexableInstructions, IndexableProps } from '../decorators/index.js';
+import { Indexable } from '../Indexable/index.js';
+import { CarouselBtn } from './CarouselBtn.js';
+import { CarouselDrag } from './CarouselDrag.js';
+import { CarouselItem } from './CarouselItem.js';
+import { CarouselWrapper } from './CarouselWrapper.js';
+
+/**
+ * Props for the Carousel class.
+ */
+export interface CarouselProps {
+  $children: {
+    CarouselBtn: CarouselBtn[];
+    CarouselDrag: CarouselDrag[];
+    CarouselItem: CarouselItem[];
+    CarouselWrapper: CarouselWrapper[];
+  };
+  $options: {
+    axis: 'x' | 'y';
+  };
+}
+
+/**
+ * Carousel class.
+ */
+export class Carousel<T extends IndexableProps = IndexableProps> extends Indexable<T & CarouselProps> {
+  /**
+   * Config.
+   */
+  static config: BaseConfig = {
+    name: 'Carousel',
+    components: {
+      CarouselBtn,
+      CarouselDrag,
+      CarouselItem,
+      CarouselWrapper,
+    },
+    options: {
+      ...Indexable.config.options,
+      axis: { type: String, default: 'x' },
+    },
+    emits: ['progress'],
+  };
+
+  /**
+   * Is the carousel horizontal?
+   */
+  get isHorizontal() {
+    return !this.isVertical;
+  }
+
+  /**
+   * Is the carousel vertical?
+   */
+  get isVertical() {
+    return this.$options.axis === 'y';
+  }
+
+  /**
+   * Get the carousel's items.
+   */
+  get items() {
+    return this.$children.CarouselItem;
+  }
+
+  /**
+   * Get the carousel's length.
+   */
+  get length() {
+    return this.items?.length || 0;
+  }
+
+  /**
+   * Get the carousel's wrapper.
+   */
+  get wrapper() {
+    return this.$children.CarouselWrapper?.[0];
+  }
+
+  /**
+   * Previous progress value.
+   */
+  previousProgress = -1;
+
+  /**
+   * Progress from 0 to 1.
+   */
+  get progress() {
+    return this.wrapper?.progress ?? 0;
+  }
+
+  /**
+   * Mounted hook.
+   */
+  mounted() {
+    this.goTo(this.currentIndex);
+  }
+
+  /**
+   * Resized hook.
+   */
+  resized() {
+    this.goTo(this.currentIndex);
+  }
+
+  /**
+   * Go to the given item.
+   */
+  goTo(indexOrInstruction: number | IndexableInstructions) {
+    this.$log('goTo', indexOrInstruction);
+    this.$services.enable('ticked');
+    return super.goTo(indexOrInstruction);
+  }
+
+  ticked() {
+    if (this.progress !== this.previousProgress) {
+      this.previousProgress = this.progress;
+      this.$emit('progress', this.progress);
+      this.$el.style.setProperty('--carousel-progress', String(this.progress));
+    } else {
+      this.$services.disable('ticked');
+    }
+  }
+}

--- a/packages/ui/Carousel/Carousel.ts
+++ b/packages/ui/Carousel/Carousel.ts
@@ -196,6 +196,12 @@ export class Carousel<T extends IndexableProps = IndexableProps> extends Indexab
     const { currentIndex } = this;
     this.currentIndex = currentIndex;
     this.connectChildren();
+    // Item changes alter the progress denominator (the children invalidate their
+    // geometry caches in their own `updated` hooks). Force `ticked` to re-emit
+    // the refreshed progress on the next frame, otherwise the emitted `progress`
+    // value and `--carousel-progress` stay stale until the next scroll.
+    this.previousProgress = -1;
+    this.$services.enable('ticked');
   }
 
   /**

--- a/packages/ui/Carousel/Carousel.ts
+++ b/packages/ui/Carousel/Carousel.ts
@@ -182,13 +182,19 @@ export class Carousel<T extends IndexableProps = IndexableProps> extends Indexab
   }
 
   /**
-   * Reconnect dynamically-added children on update.
+   * Re-normalise the index and reconnect children on update.
    *
-   * `connectChildren` is idempotent (the `__unsubscribe` guard makes re-connect
-   * a no-op for already-connected children), so calling it here closes the gap
-   * for children added to the DOM after mount for free.
+   * Removing items after mount shrinks `length` but leaves `currentIndex`
+   * untouched, so it can fall outside the new `0…lastIndex` range and leave no
+   * item active. Reassigning it runs the `withIndex` setter, which re-normalises
+   * against the current item count and re-seeds the store (a no-op when the
+   * index is still in range). `connectChildren` then connects any newly-added
+   * children — it is idempotent for already-connected ones thanks to the
+   * `__unsubscribe` guard.
    */
   updated() {
+    const { currentIndex } = this;
+    this.currentIndex = currentIndex;
     this.connectChildren();
   }
 

--- a/packages/ui/Carousel/Carousel.ts
+++ b/packages/ui/Carousel/Carousel.ts
@@ -1,10 +1,22 @@
-import type { BaseConfig } from '@studiometa/js-toolkit';
+import type { Base, BaseConfig } from '@studiometa/js-toolkit';
+import {
+  createMemoryStorageProvider,
+  createStorage,
+  isNumber,
+  nextFrame,
+} from '@studiometa/js-toolkit/utils';
 import type { IndexableInstructions, IndexableProps } from '../decorators/index.js';
 import { Indexable } from '../Indexable/index.js';
+import { AbstractCarouselChild } from './AbstractCarouselChild.js';
 import { CarouselBtn } from './CarouselBtn.js';
 import { CarouselDrag } from './CarouselDrag.js';
 import { CarouselItem } from './CarouselItem.js';
 import { CarouselWrapper } from './CarouselWrapper.js';
+
+/**
+ * Shape of the per-instance store shared with the child components.
+ */
+export type CarouselStore = { index: number };
 
 /**
  * Props for the Carousel class.
@@ -42,6 +54,22 @@ export class Carousel<T extends IndexableProps = IndexableProps> extends Indexab
     },
     emits: ['progress'],
   };
+
+  /**
+   * Per-instance store used to broadcast the current index to the child
+   * components. Controls subscribe to it through a guarded `$closest('Carousel')`
+   * lookup instead of listening to `index`/`progress` events, which removes the
+   * mount-order race where a child that mounted before the Carousel missed the
+   * initial index.
+   *
+   * The store uses the in-memory provider and lives for the whole lifetime of
+   * the instance (it is a constructor-time field). It survives `$destroy`/
+   * `$mount` cycles of the same instance — a re-mounted Carousel exposes a
+   * stale-but-consistent seeded index and its children re-subscribe on remount
+   * and unsubscribe on destroy, so there is no leak and no need to `destroy()`
+   * the memory store.
+   */
+  store = createStorage<CarouselStore>({ provider: createMemoryStorageProvider() });
 
   /**
    * Is the carousel horizontal?
@@ -91,26 +119,113 @@ export class Carousel<T extends IndexableProps = IndexableProps> extends Indexab
   }
 
   /**
+   * Get the current index.
+   *
+   * The accessor pair is overridden as a whole: defining only the setter would
+   * shadow the getter inherited from `withIndex` and make reads `undefined`.
+   */
+  get currentIndex(): number {
+    return super.currentIndex;
+  }
+
+  /**
+   * Set the current index and broadcast it to the child components.
+   *
+   * `super` runs first so `withIndex` normalises the value (clamp/loop/bounce)
+   * and assigns `__index` before any subscriber reads `currentIndex`; the store
+   * is then seeded with the normalised value, never the raw one. Assigning the
+   * index only reports and stores state — it never scrolls the wrapper. Use
+   * `goTo()` to navigate (which scrolls); this separation is what lets
+   * `CarouselWrapper.onScroll` report the scroll-synced index without forming a
+   * scroll/index feedback loop.
+   *
+   * The store write is gated on an actual change (or the store not being seeded
+   * yet) so the initial `0 -> 0` assignment during `mounted` still seeds the
+   * store, while same-value scroll updates do not re-run every subscriber. The
+   * memory store fires subscribers synchronously with no deduplication, so this
+   * gate is load-bearing.
+   */
+  set currentIndex(value: number) {
+    super.currentIndex = value;
+    const index = this.currentIndex;
+    if (!this.store.has('index') || this.store.get('index') !== index) {
+      this.store.set('index', index);
+    }
+  }
+
+  /**
    * Mounted hook.
+   *
+   * Seeds the store with the current index (via `goTo`) then connects the
+   * children — including any that mounted before this Carousel — so they
+   * synchronise against an already-seeded store.
    */
   mounted() {
     this.goTo(this.currentIndex);
+    this.connectChildren();
+  }
+
+  /**
+   * Connect the child components that track the current index, including those
+   * that mounted before this Carousel. Runs after `goTo` has seeded the store so
+   * connected children synchronise against an initialised Carousel. Idempotent
+   * thanks to the child-side `__unsubscribe` guard.
+   */
+  connectChildren() {
+    for (const children of Object.values(this.$children as Record<string, Base[]>)) {
+      for (const child of children) {
+        if (child instanceof AbstractCarouselChild) {
+          child.__connect(this as unknown as Carousel);
+        }
+      }
+    }
+  }
+
+  /**
+   * Reconnect dynamically-added children on update.
+   *
+   * `connectChildren` is idempotent (the `__unsubscribe` guard makes re-connect
+   * a no-op for already-connected children), so calling it here closes the gap
+   * for children added to the DOM after mount for free.
+   */
+  updated() {
+    this.connectChildren();
   }
 
   /**
    * Resized hook.
+   *
+   * Re-snaps to the current index. `goTo` scrolls imperatively, reading each
+   * item's freshly-measured `state`, so the re-snap must run only after the
+   * children have invalidated their geometry caches (`CarouselItem.state` and
+   * `CarouselWrapper`'s scroll distance). js-toolkit dispatches resize callbacks
+   * in mount (registration) order — the parent Carousel registers *before* its
+   * children — so a synchronous re-snap here would read stale pre-resize
+   * geometry. Deferring by one frame lets the children's `resized` callbacks
+   * (which run synchronously later in the same resize tick) invalidate their
+   * caches first, mirroring how `Slider.resized` defers with `nextFrame`.
    */
   resized() {
-    this.goTo(this.currentIndex);
+    nextFrame(() => this.goTo(this.currentIndex));
   }
 
   /**
    * Go to the given item.
+   *
+   * Navigation is imperative: after updating the index it scrolls the wrapper to
+   * the matching item. The scroll is triggered only for numeric arguments —
+   * instruction arguments (`next`, `prev`, …) recurse through `goNext`/`goPrev`
+   * into a numeric `goTo`, which owns the scroll, so guarding on `isNumber`
+   * avoids scrolling twice per instruction navigation.
    */
   goTo(indexOrInstruction: number | IndexableInstructions) {
     this.$log('goTo', indexOrInstruction);
     this.$services.enable('ticked');
-    return super.goTo(indexOrInstruction);
+    const result = super.goTo(indexOrInstruction);
+    if (isNumber(indexOrInstruction)) {
+      this.wrapper?.scrollToIndex(this.currentIndex);
+    }
+    return result;
   }
 
   ticked() {

--- a/packages/ui/Carousel/CarouselBtn.ts
+++ b/packages/ui/Carousel/CarouselBtn.ts
@@ -1,0 +1,59 @@
+import type { BaseConfig, BaseProps } from '@studiometa/js-toolkit';
+import { AbstractCarouselChild } from './AbstractCarouselChild.js';
+
+/**
+ * Props for the CarouselBtn class.
+ */
+export interface CarouselBtnProps extends BaseProps {
+  $el: HTMLButtonElement;
+  $options: {
+    action: 'next' | 'prev' | string;
+  };
+}
+
+/**
+ * CarouselBtn class.
+ */
+export class CarouselBtn<T extends BaseProps = BaseProps> extends AbstractCarouselChild<
+  T & CarouselBtnProps
+> {
+  /**
+   * Config.
+   */
+  static config: BaseConfig = {
+    name: 'CarouselBtn',
+    options: { action: String },
+  };
+
+  /**
+   * Go to the next or previous item on click.
+   */
+  onClick() {
+    const { action } = this.$options;
+    switch (action) {
+      case 'next':
+        this.carousel.goNext();
+        break;
+      case 'prev':
+        this.carousel.goPrev();
+        break;
+      default:
+        this.carousel.goTo(Number(action));
+        break;
+    }
+  }
+
+  /**
+   * Update button state on parent carousel progress.
+   */
+  onParentCarouselProgress() {
+    const { action } = this.$options;
+    const { currentIndex, lastIndex } = this.carousel;
+    const shouldDisable =
+      (action === 'next' && currentIndex === lastIndex) ||
+      (action === 'prev' && currentIndex === 0) ||
+      Number(action) === currentIndex;
+
+    this.$el.disabled = shouldDisable;
+  }
+}

--- a/packages/ui/Carousel/CarouselBtn.ts
+++ b/packages/ui/Carousel/CarouselBtn.ts
@@ -58,11 +58,19 @@ export class CarouselBtn<T extends BaseProps = BaseProps> extends AbstractCarous
     }
 
     const { action } = this.$options;
-    const { lastIndex } = carousel;
-    const shouldDisable =
-      (action === 'next' && index === lastIndex) ||
-      (action === 'prev' && index === 0) ||
-      Number(action) === index;
+    // Base the disabled state on whether the action would actually move the
+    // index, so it honours the inherited `Indexable` options: with `boundary`
+    // `loop`/`bounce` the ends never disable (navigation wraps), and `reverse`
+    // flips which end is terminal. `prevIndex`/`nextIndex` already encode all of
+    // that; a numeric action disables only on the slide it points to.
+    let shouldDisable: boolean;
+    if (action === 'next') {
+      shouldDisable = carousel.nextIndex === index;
+    } else if (action === 'prev') {
+      shouldDisable = carousel.prevIndex === index;
+    } else {
+      shouldDisable = Number(action) === index;
+    }
 
     this.$el.disabled = shouldDisable;
   }

--- a/packages/ui/Carousel/CarouselBtn.ts
+++ b/packages/ui/Carousel/CarouselBtn.ts
@@ -29,30 +29,40 @@ export class CarouselBtn<T extends BaseProps = BaseProps> extends AbstractCarous
    * Go to the next or previous item on click.
    */
   onClick() {
+    const { carousel } = this;
+    if (!carousel) {
+      return;
+    }
+
     const { action } = this.$options;
     switch (action) {
       case 'next':
-        this.carousel.goNext();
+        carousel.goNext();
         break;
       case 'prev':
-        this.carousel.goPrev();
+        carousel.goPrev();
         break;
       default:
-        this.carousel.goTo(Number(action));
+        carousel.goTo(Number(action));
         break;
     }
   }
 
   /**
-   * Update button state on parent carousel progress.
+   * Update the disabled state for the given index.
    */
-  onParentCarouselProgress() {
+  update(index: number) {
+    const { carousel } = this;
+    if (!carousel) {
+      return;
+    }
+
     const { action } = this.$options;
-    const { currentIndex, lastIndex } = this.carousel;
+    const { lastIndex } = carousel;
     const shouldDisable =
-      (action === 'next' && currentIndex === lastIndex) ||
-      (action === 'prev' && currentIndex === 0) ||
-      Number(action) === currentIndex;
+      (action === 'next' && index === lastIndex) ||
+      (action === 'prev' && index === 0) ||
+      Number(action) === index;
 
     this.$el.disabled = shouldDisable;
   }

--- a/packages/ui/Carousel/CarouselDrag.ts
+++ b/packages/ui/Carousel/CarouselDrag.ts
@@ -1,0 +1,93 @@
+import type { BaseConfig, BaseProps, DragServiceProps } from '@studiometa/js-toolkit';
+import { withDrag, withMountOnMediaQuery } from '@studiometa/js-toolkit';
+import { inertiaFinalValue } from '@studiometa/js-toolkit/utils';
+import { AbstractCarouselChild } from './AbstractCarouselChild.js';
+import { getClosestIndex } from './utils.js';
+
+/**
+ * Props for the CarouselDrag class.
+ */
+export interface CarouselDragProps extends BaseProps {}
+
+/**
+ * CarouselDrag class.
+ */
+export class CarouselDrag<
+  T extends BaseProps = BaseProps,
+> extends withMountOnMediaQuery<AbstractCarouselChild>(
+  withDrag(AbstractCarouselChild),
+  '(pointer: fine)',
+)<T & CarouselDragProps> {
+  /**
+   * Config.
+   */
+  static config: BaseConfig = {
+    name: 'CarouselDrag',
+  };
+
+  /**
+   * Dragged hook.
+   */
+  dragged(props: DragServiceProps) {
+    if (!this.$isMounted) return;
+
+    // do noting on inertia and stop
+    if (props.mode === 'inertia' || props.mode === 'stop') {
+      return;
+    }
+
+    // do nothin while the distance is 0
+    if (
+      (this.isHorizontal && props.distance.x === 0) ||
+      (this.isVertical && props.distance.y === 0)
+    ) {
+      return;
+    }
+
+    const wrapper = this.$el;
+
+    // @todo wait for the props.delta values to be fixed
+    // @see https://github.com/studiometa/js-toolkit/pull/533
+    if (props.mode === 'drag') {
+      const left = wrapper.scrollLeft - props.delta.x;
+      const top = wrapper.scrollTop - props.delta.y;
+      // We must disable the scroll-snap otherwise we
+      // cannot programmatically scroll to a position
+      // that is not a snap-point. This might be easily
+      // fixed by not using scroll-snap at all.
+      wrapper.style.scrollSnapType = 'none';
+      wrapper.scrollTo({ left, top, behavior: 'instant' });
+      return;
+    }
+
+    // @todo implement inertia with the raf service for a smoother transition than the native smooth scroll
+    if (props.mode === 'drop') {
+      const options: ScrollToOptions = { behavior: 'smooth' };
+
+      if (this.isHorizontal) {
+        const finalValue = inertiaFinalValue(wrapper.scrollLeft, props.delta.x * -2.5);
+        const index = getClosestIndex(
+          this.carousel.items.map((item) => item.state.left),
+          finalValue,
+        );
+        options.left = this.carousel.items[index].state.left;
+      } else if (this.isVertical) {
+        const finalValue = inertiaFinalValue(wrapper.scrollTop, props.delta.y * -2.5);
+        const index = getClosestIndex(
+          this.carousel.items.map((item) => item.state.top),
+          finalValue,
+        );
+        options.top = this.carousel.items[index].state.top;
+      }
+
+      wrapper.addEventListener(
+        'scrollend',
+        () => {
+          wrapper.style.scrollSnapType = '';
+        },
+        { once: true },
+      );
+      wrapper.scrollTo(options);
+    }
+  }
+}

--- a/packages/ui/Carousel/CarouselDrag.ts
+++ b/packages/ui/Carousel/CarouselDrag.ts
@@ -81,14 +81,22 @@ export class CarouselDrag<
           carousel.items.map((item) => item.state.left),
           finalValue,
         );
-        options.left = carousel.items[index].state.left;
+        options.left = carousel.items[index]?.state?.left;
       } else if (this.isVertical) {
         const finalValue = inertiaFinalValue(wrapper.scrollTop, props.delta.y * -2.5);
         const index = getClosestIndex(
           carousel.items.map((item) => item.state.top),
           finalValue,
         );
-        options.top = carousel.items[index].state.top;
+        options.top = carousel.items[index]?.state?.top;
+      }
+
+      // No target slide to snap to (e.g. an empty carousel): restore scroll-snap
+      // — which the `drag` branch disabled — and bail instead of scrolling to an
+      // `undefined` offset.
+      if (options.left === undefined && options.top === undefined) {
+        wrapper.style.scrollSnapType = '';
+        return;
       }
 
       wrapper.addEventListener(

--- a/packages/ui/Carousel/CarouselDrag.ts
+++ b/packages/ui/Carousel/CarouselDrag.ts
@@ -1,7 +1,7 @@
 import type { BaseConfig, BaseProps, DragServiceProps } from '@studiometa/js-toolkit';
 import { withDrag, withMountOnMediaQuery } from '@studiometa/js-toolkit';
 import { inertiaFinalValue } from '@studiometa/js-toolkit/utils';
-import { AbstractCarouselChild } from './AbstractCarouselChild.js';
+import { AbstractCarouselComponent } from './AbstractCarouselComponent.js';
 import { getClosestIndex } from './utils.js';
 
 /**
@@ -11,11 +11,17 @@ export interface CarouselDragProps extends BaseProps {}
 
 /**
  * CarouselDrag class.
+ *
+ * The draggable track of the Carousel. It only reads the carousel (items and
+ * orientation) and never reacts to index changes, so it extends the
+ * non-subscribing `AbstractCarouselComponent` rather than
+ * `AbstractCarouselChild` — mirroring how `SliderDrag` extends `Base`, not
+ * `AbstractSliderChild`.
  */
 export class CarouselDrag<
   T extends BaseProps = BaseProps,
-> extends withMountOnMediaQuery<AbstractCarouselChild>(
-  withDrag(AbstractCarouselChild),
+> extends withMountOnMediaQuery<AbstractCarouselComponent>(
+  withDrag(AbstractCarouselComponent),
   '(pointer: fine)',
 )<T & CarouselDragProps> {
   /**
@@ -62,22 +68,27 @@ export class CarouselDrag<
 
     // @todo implement inertia with the raf service for a smoother transition than the native smooth scroll
     if (props.mode === 'drop') {
+      const { carousel } = this;
+      if (!carousel) {
+        return;
+      }
+
       const options: ScrollToOptions = { behavior: 'smooth' };
 
       if (this.isHorizontal) {
         const finalValue = inertiaFinalValue(wrapper.scrollLeft, props.delta.x * -2.5);
         const index = getClosestIndex(
-          this.carousel.items.map((item) => item.state.left),
+          carousel.items.map((item) => item.state.left),
           finalValue,
         );
-        options.left = this.carousel.items[index].state.left;
+        options.left = carousel.items[index].state.left;
       } else if (this.isVertical) {
         const finalValue = inertiaFinalValue(wrapper.scrollTop, props.delta.y * -2.5);
         const index = getClosestIndex(
-          this.carousel.items.map((item) => item.state.top),
+          carousel.items.map((item) => item.state.top),
           finalValue,
         );
-        options.top = this.carousel.items[index].state.top;
+        options.top = carousel.items[index].state.top;
       }
 
       wrapper.addEventListener(

--- a/packages/ui/Carousel/CarouselItem.ts
+++ b/packages/ui/Carousel/CarouselItem.ts
@@ -1,0 +1,73 @@
+import type { BaseConfig, BaseProps } from '@studiometa/js-toolkit';
+import type { ScrollAction } from 'compute-scroll-into-view';
+import { domScheduler } from '@studiometa/js-toolkit/utils';
+import { compute } from 'compute-scroll-into-view';
+import { AbstractCarouselChild } from './AbstractCarouselChild.js';
+
+/**
+ * Props for the CarouselItem class.
+ */
+export interface CarouselItemProps extends BaseProps {}
+
+/**
+ * CarouselItem class.
+ */
+export class CarouselItem<T extends BaseProps = BaseProps> extends AbstractCarouselChild<
+  T & CarouselItemProps
+> {
+  /**
+   * Config.
+   */
+  static config: BaseConfig = {
+    name: 'CarouselItem',
+  };
+
+  /**
+   * The item's index in the carousel.
+   */
+  get index() {
+    return this.carousel.$children.CarouselItem.indexOf(this);
+  }
+
+  __state: ScrollAction;
+  __shouldEvaluateState = true;
+
+  /**
+   * The item's active state descriptor.
+   */
+  get state(): ScrollAction {
+    if (this.__shouldEvaluateState) {
+      const [state] = compute(this.$el, {
+        block: 'center',
+        inline: 'center',
+        boundary: this.carousel.wrapper.$el,
+      });
+      this.__state = state;
+      this.__shouldEvaluateState = false;
+    }
+
+    return this.__state;
+  }
+
+  resized() {
+    this.__shouldEvaluateState = true;
+  }
+
+  /**
+   * Update the item's state on parent carousel progress.
+   * @todo a11y
+   */
+  onParentCarouselProgress() {
+    domScheduler.read(() => {
+      const { index } = this;
+      const { currentIndex: carouselIndex } = this.carousel;
+
+      domScheduler.write(() => {
+        this.$el.style.setProperty(
+          '--carousel-item-active',
+          String(Number(index === carouselIndex)),
+        );
+      });
+    });
+  }
+}

--- a/packages/ui/Carousel/CarouselItem.ts
+++ b/packages/ui/Carousel/CarouselItem.ts
@@ -1,6 +1,5 @@
 import type { BaseConfig, BaseProps } from '@studiometa/js-toolkit';
 import type { ScrollAction } from 'compute-scroll-into-view';
-import { domScheduler } from '@studiometa/js-toolkit/utils';
 import { compute } from 'compute-scroll-into-view';
 import { AbstractCarouselChild } from './AbstractCarouselChild.js';
 
@@ -26,7 +25,7 @@ export class CarouselItem<T extends BaseProps = BaseProps> extends AbstractCarou
    * The item's index in the carousel.
    */
   get index() {
-    return this.carousel.$children.CarouselItem.indexOf(this);
+    return this.carousel?.$children.CarouselItem.indexOf(this) ?? -1;
   }
 
   __state: ScrollAction;
@@ -40,7 +39,7 @@ export class CarouselItem<T extends BaseProps = BaseProps> extends AbstractCarou
       const [state] = compute(this.$el, {
         block: 'center',
         inline: 'center',
-        boundary: this.carousel.wrapper.$el,
+        boundary: this.carousel?.wrapper?.$el,
       });
       this.__state = state;
       this.__shouldEvaluateState = false;
@@ -49,25 +48,27 @@ export class CarouselItem<T extends BaseProps = BaseProps> extends AbstractCarou
     return this.__state;
   }
 
+  /**
+   * Invalidate the cached state on resize.
+   *
+   * Extends the base reconnect/refresh (`super.resized`) rather than shadowing
+   * it: the cache is invalidated first so a subsequent `state` read re-measures.
+   * The active-state `update` does not depend on geometry, so the ordering only
+   * matters for keeping the base refresh alive for a future edit.
+   */
   resized() {
     this.__shouldEvaluateState = true;
+    super.resized();
   }
 
   /**
-   * Update the item's state on parent carousel progress.
+   * Reflect the active state for the given index.
    * @todo a11y
    */
-  onParentCarouselProgress() {
-    domScheduler.read(() => {
-      const { index } = this;
-      const { currentIndex: carouselIndex } = this.carousel;
-
-      domScheduler.write(() => {
-        this.$el.style.setProperty(
-          '--carousel-item-active',
-          String(Number(index === carouselIndex)),
-        );
-      });
-    });
+  update(index: number) {
+    const isActive = this.index === index;
+    return () => {
+      this.$el.style.setProperty('--carousel-item-active', String(Number(isActive)));
+    };
   }
 }

--- a/packages/ui/Carousel/CarouselItem.ts
+++ b/packages/ui/Carousel/CarouselItem.ts
@@ -62,6 +62,19 @@ export class CarouselItem<T extends BaseProps = BaseProps> extends AbstractCarou
   }
 
   /**
+   * Invalidate the cached scroll target when the item list or content changes.
+   *
+   * Inserting/removing slides (or changing an item's content) via `$update`
+   * shifts the offsets returned by `compute-scroll-into-view`, so the cache is
+   * cleared before the base reconnect/refresh runs — otherwise `scrollToIndex`
+   * and `onScroll` keep using stale positions until the next resize.
+   */
+  updated() {
+    this.__shouldEvaluateState = true;
+    super.updated();
+  }
+
+  /**
    * Reflect the active state for the given index.
    * @todo a11y
    */

--- a/packages/ui/Carousel/CarouselWrapper.ts
+++ b/packages/ui/Carousel/CarouselWrapper.ts
@@ -1,0 +1,62 @@
+import type { BaseConfig, BaseProps } from '@studiometa/js-toolkit';
+import { AbstractCarouselChild } from './AbstractCarouselChild.js';
+import { getClosestIndex } from './utils.js';
+
+/**
+ * Props for the CarouselWrapper class.
+ */
+export interface CarouselWrapperProps extends BaseProps {}
+
+/**
+ * CarouselWrapper class.
+ */
+export class CarouselWrapper<T extends BaseProps = BaseProps> extends AbstractCarouselChild<
+  T & CarouselWrapperProps
+> {
+  /**
+   * Config.
+   */
+  static config: BaseConfig = {
+    name: 'CarouselWrapper',
+  };
+
+  /**
+   * Current progress between 0 and 1.
+   */
+  get progress() {
+    if (this.isHorizontal) {
+      const { scrollLeft, scrollWidth, offsetWidth } = this.$el;
+      return scrollWidth - offsetWidth === 0 ? 0 : scrollLeft / (scrollWidth - offsetWidth);
+    } else if (this.isVertical) {
+      const { scrollTop, scrollHeight, offsetHeight } = this.$el;
+      return scrollHeight - offsetHeight === 0 ? 0 : scrollTop / (scrollHeight - offsetHeight);
+    }
+
+    return 0;
+  }
+
+  /**
+   * Update index and emit progress on wrapper scroll.
+   */
+  onScroll() {
+    const { isHorizontal, $el, carousel } = this;
+
+    const minDiffIndex = getClosestIndex(
+      carousel.items.map((item) => (isHorizontal ? item.state.left : item.state.top)),
+      isHorizontal ? $el.scrollLeft : $el.scrollTop,
+    );
+
+    carousel.currentIndex = minDiffIndex;
+    this.carousel.$services.enable('ticked');
+  }
+
+  /**
+   * Scroll to the new item on parent carousel go-to event.
+   */
+  onParentCarouselIndex() {
+    const { state } = this.carousel.items[this.carousel.currentIndex];
+    if (state) {
+      this.$el.scrollTo({ left: state.left, top: state.top, behavior: 'smooth' });
+    }
+  }
+}

--- a/packages/ui/Carousel/CarouselWrapper.ts
+++ b/packages/ui/Carousel/CarouselWrapper.ts
@@ -77,6 +77,17 @@ export class CarouselWrapper<T extends BaseProps = BaseProps> extends AbstractCa
   }
 
   /**
+   * Invalidate the cached scroll distances when the item list changes.
+   *
+   * Adding or removing items changes `scrollWidth`, so `progress` (and the
+   * `--carousel-progress` variable derived from it) would keep dividing by the
+   * pre-update distance until the next resize otherwise.
+   */
+  updated() {
+    this.__shouldMeasure = true;
+  }
+
+  /**
    * Scroll to the item at the given index.
    *
    * Called imperatively by `Carousel.goTo`. Guards against an empty carousel or

--- a/packages/ui/Carousel/CarouselWrapper.ts
+++ b/packages/ui/Carousel/CarouselWrapper.ts
@@ -1,6 +1,6 @@
 import type { BaseConfig, BaseProps } from '@studiometa/js-toolkit';
 import { clamp } from '@studiometa/js-toolkit/utils';
-import { AbstractCarouselChild } from './AbstractCarouselChild.js';
+import { AbstractCarouselComponent } from './AbstractCarouselComponent.js';
 import { getClosestIndex } from './utils.js';
 
 /**
@@ -10,8 +10,15 @@ export interface CarouselWrapperProps extends BaseProps {}
 
 /**
  * CarouselWrapper class.
+ *
+ * The scrollable track of the Carousel. It scrolls to a given item on demand
+ * through the imperative `scrollToIndex` (called by `Carousel.goTo`) and, on
+ * native/touch scroll, merely reports the closest item back to the Carousel via
+ * `currentIndex`. Because scrolling is only ever initiated by `goTo` and
+ * `onScroll` only reports, the scroll/index feedback loop that used to hijack a
+ * smooth scroll cannot form, so no synchronising guard is needed.
  */
-export class CarouselWrapper<T extends BaseProps = BaseProps> extends AbstractCarouselChild<
+export class CarouselWrapper<T extends BaseProps = BaseProps> extends AbstractCarouselComponent<
   T & CarouselWrapperProps
 > {
   /**
@@ -20,15 +27,6 @@ export class CarouselWrapper<T extends BaseProps = BaseProps> extends AbstractCa
   static config: BaseConfig = {
     name: 'CarouselWrapper',
   };
-
-  /**
-   * Whether the current index is being synced from a scroll event. While this
-   * is `true`, the wrapper must not scroll back to the index, otherwise the
-   * scroll position and the index fight each other and hijack any smooth
-   * scroll triggered by `goTo()`.
-   * @private
-   */
-  __syncingIndexFromScroll = false;
 
   /**
    * Cached maximum scroll distances (`scrollWidth - clientWidth` and
@@ -79,37 +77,40 @@ export class CarouselWrapper<T extends BaseProps = BaseProps> extends AbstractCa
   }
 
   /**
-   * Update index and emit progress on wrapper scroll.
+   * Scroll to the item at the given index.
+   *
+   * Called imperatively by `Carousel.goTo`. Guards against an empty carousel or
+   * a missing item so the unconditional mount-time seed cannot throw.
+   */
+  scrollToIndex(index: number) {
+    const state = this.carousel?.items[index]?.state;
+    if (state) {
+      this.$el.scrollTo({ left: state.left, top: state.top, behavior: 'smooth' });
+    }
+  }
+
+  /**
+   * Report the scroll-synced index and keep the progress bar animating.
+   *
+   * Assigning `carousel.currentIndex` only stores/reports the index — it never
+   * scrolls back — so this cannot hijack a `goTo` smooth scroll. The `ticked`
+   * service must be (re-)enabled here because it self-disables once progress
+   * stabilises: without it `--carousel-progress` and the `progress` event would
+   * freeze during any scroll not initiated by `goTo`, including all touch
+   * scrolling (the `CarouselDrag` track only mounts on `(pointer: fine)`).
    */
   onScroll() {
     const { isHorizontal, $el, carousel } = this;
+    if (!carousel) {
+      return;
+    }
 
     const minDiffIndex = getClosestIndex(
       carousel.items.map((item) => (isHorizontal ? item.state.left : item.state.top)),
       isHorizontal ? $el.scrollLeft : $el.scrollTop,
     );
 
-    // Reflect the scroll position on the index without scrolling back to it:
-    // the `index` event is dispatched synchronously, so `onParentCarouselIndex`
-    // runs while this flag is set and bails out.
-    this.__syncingIndexFromScroll = true;
     carousel.currentIndex = minDiffIndex;
-    this.__syncingIndexFromScroll = false;
-
-    this.carousel.$services.enable('ticked');
-  }
-
-  /**
-   * Scroll to the new item on parent carousel go-to event.
-   */
-  onParentCarouselIndex() {
-    if (this.__syncingIndexFromScroll) {
-      return;
-    }
-
-    const { state } = this.carousel.items[this.carousel.currentIndex];
-    if (state) {
-      this.$el.scrollTo({ left: state.left, top: state.top, behavior: 'smooth' });
-    }
+    carousel.$services.enable('ticked');
   }
 }

--- a/packages/ui/Carousel/CarouselWrapper.ts
+++ b/packages/ui/Carousel/CarouselWrapper.ts
@@ -21,6 +21,15 @@ export class CarouselWrapper<T extends BaseProps = BaseProps> extends AbstractCa
   };
 
   /**
+   * Whether the current index is being synced from a scroll event. While this
+   * is `true`, the wrapper must not scroll back to the index, otherwise the
+   * scroll position and the index fight each other and hijack any smooth
+   * scroll triggered by `goTo()`.
+   * @private
+   */
+  __syncingIndexFromScroll = false;
+
+  /**
    * Current progress between 0 and 1.
    */
   get progress() {
@@ -46,7 +55,13 @@ export class CarouselWrapper<T extends BaseProps = BaseProps> extends AbstractCa
       isHorizontal ? $el.scrollLeft : $el.scrollTop,
     );
 
+    // Reflect the scroll position on the index without scrolling back to it:
+    // the `index` event is dispatched synchronously, so `onParentCarouselIndex`
+    // runs while this flag is set and bails out.
+    this.__syncingIndexFromScroll = true;
     carousel.currentIndex = minDiffIndex;
+    this.__syncingIndexFromScroll = false;
+
     this.carousel.$services.enable('ticked');
   }
 
@@ -54,6 +69,10 @@ export class CarouselWrapper<T extends BaseProps = BaseProps> extends AbstractCa
    * Scroll to the new item on parent carousel go-to event.
    */
   onParentCarouselIndex() {
+    if (this.__syncingIndexFromScroll) {
+      return;
+    }
+
     const { state } = this.carousel.items[this.carousel.currentIndex];
     if (state) {
       this.$el.scrollTo({ left: state.left, top: state.top, behavior: 'smooth' });

--- a/packages/ui/Carousel/CarouselWrapper.ts
+++ b/packages/ui/Carousel/CarouselWrapper.ts
@@ -1,4 +1,5 @@
 import type { BaseConfig, BaseProps } from '@studiometa/js-toolkit';
+import { clamp } from '@studiometa/js-toolkit/utils';
 import { AbstractCarouselChild } from './AbstractCarouselChild.js';
 import { getClosestIndex } from './utils.js';
 
@@ -30,18 +31,51 @@ export class CarouselWrapper<T extends BaseProps = BaseProps> extends AbstractCa
   __syncingIndexFromScroll = false;
 
   /**
+   * Cached maximum scroll distances (`scrollWidth - clientWidth` and
+   * `scrollHeight - clientHeight`). The `progress` getter runs on every frame,
+   * so these layout-triggering reads are cached and only refreshed on resize.
+   * @private
+   */
+  __scrollDistance = { x: 0, y: 0 };
+
+  /**
+   * Whether the cached scroll distances need to be re-measured.
+   * @private
+   */
+  __shouldMeasure = true;
+
+  /**
    * Current progress between 0 and 1.
    */
   get progress() {
+    if (this.__shouldMeasure) {
+      const { scrollWidth, clientWidth, scrollHeight, clientHeight } = this.$el;
+      // Round to integer pixels: browsers report fractional scroll sizes and
+      // offsets, so the last item can settle a sub-pixel short of the maximum
+      // and keep progress from ever reaching a clean `1`.
+      this.__scrollDistance = {
+        x: Math.round(scrollWidth - clientWidth),
+        y: Math.round(scrollHeight - clientHeight),
+      };
+      this.__shouldMeasure = false;
+    }
+
     if (this.isHorizontal) {
-      const { scrollLeft, scrollWidth, offsetWidth } = this.$el;
-      return scrollWidth - offsetWidth === 0 ? 0 : scrollLeft / (scrollWidth - offsetWidth);
+      const { x } = this.__scrollDistance;
+      return x === 0 ? 0 : clamp(Math.round(this.$el.scrollLeft) / x, 0, 1);
     } else if (this.isVertical) {
-      const { scrollTop, scrollHeight, offsetHeight } = this.$el;
-      return scrollHeight - offsetHeight === 0 ? 0 : scrollTop / (scrollHeight - offsetHeight);
+      const { y } = this.__scrollDistance;
+      return y === 0 ? 0 : clamp(Math.round(this.$el.scrollTop) / y, 0, 1);
     }
 
     return 0;
+  }
+
+  /**
+   * Invalidate the cached scroll distances on resize.
+   */
+  resized() {
+    this.__shouldMeasure = true;
   }
 
   /**

--- a/packages/ui/Carousel/index.ts
+++ b/packages/ui/Carousel/index.ts
@@ -1,0 +1,6 @@
+export * from './Carousel.js';
+export * from './CarouselBtn.js';
+export * from './CarouselDrag.js';
+export * from './CarouselItem.js';
+export * from './CarouselWrapper.js';
+export * from './AbstractCarouselChild.js';

--- a/packages/ui/Carousel/index.ts
+++ b/packages/ui/Carousel/index.ts
@@ -3,4 +3,5 @@ export * from './CarouselBtn.js';
 export * from './CarouselDrag.js';
 export * from './CarouselItem.js';
 export * from './CarouselWrapper.js';
+export * from './AbstractCarouselComponent.js';
 export * from './AbstractCarouselChild.js';

--- a/packages/ui/Carousel/utils.ts
+++ b/packages/ui/Carousel/utils.ts
@@ -1,0 +1,21 @@
+/**
+ * Get the index of the closest number to the target.
+ */
+export function getClosestIndex(numbers: number[], target: number): number {
+  let index = 0;
+  let min = Number.POSITIVE_INFINITY;
+  let closestIndex = 0;
+
+  for (const number of numbers) {
+    const absoluteDiff = Math.abs(number - target);
+
+    if (absoluteDiff < min) {
+      closestIndex = index;
+      min = absoluteDiff;
+    }
+
+    index += 1;
+  }
+
+  return closestIndex;
+}

--- a/packages/ui/index.ts
+++ b/packages/ui/index.ts
@@ -2,6 +2,7 @@ export * from './Accordion/index.js';
 export * from './Action/index.js';
 export * from './AnchorNav/index.js';
 export * from './AnchorScrollTo/index.js';
+export * from './Carousel/index.js';
 export * from './CircularMarquee/index.js';
 export * from './Cursor/index.js';
 export * from './Data/index.js';

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -30,6 +30,7 @@
   "homepage": "https://github.com/studiometa/ui#readme",
   "dependencies": {
     "alien-signals": "^3.2.1",
+    "compute-scroll-into-view": "^3.1.0",
     "deepmerge": "^4.3.1",
     "morphdom": "^2.7.8"
   },


### PR DESCRIPTION
Supersedes #320.

This re-opens the Carousel work from #320 on top of the current `main`. The original branch was ~1 year / 450+ commits behind and its `Indexable` primitive + `withIndex` decorator had since been extracted and merged separately (#491) with an evolved API, so it was ported fresh onto `main` as a clean history rather than rebased commit-by-commit.

### 📚 Description

Adds a `Carousel` component (with `CarouselWrapper`, `CarouselItem`, `CarouselBtn` and `CarouselDrag`), built on the `Indexable` primitive. It uses native CSS scroll-snap on touch devices and adds pointer drag on fine-pointer devices via `withDrag` + `withMountOnMediaQuery`. Parent↔child communication uses a per-instance store (mirroring the `Slider` pattern) rather than mount-order-sensitive event wiring.

Includes full docs (`index.md`, `examples.md`, `js-api.md`) using the `registerComponent` convention, with horizontal, vertical and clamp/loop/bounce **boundary** examples.

### 🐞 Fixes made during review (verified on Chromium and Firefox)

- **Navigation hijack** — clicking a `CarouselBtn` / calling `goTo()` never reached the requested item. Resolved structurally by the store refactor: scrolling is imperative in `goTo`, `onScroll` only reports the index, so the scroll/index feedback loop cannot form.
- **Progress never reaching a clean `1`** — the getter divided by `scrollWidth - offsetWidth` (should be `clientWidth`) and browsers report fractional offsets. Fixed with client-size, integer-rounded, clamped `[0,1]` progress, cached per frame and refreshed on resize/update.
- **Initial-state race (now fixed)** — item 0 not marked active / `prev` not disabled on load in Chromium. The store handshake (children pull the seeded index on connect) fixes it; verified on load cross-browser.
- **Store-refactor hardening** — empty-carousel drag drop, index re-normalization and geometry-cache invalidation after item add/remove, and boundary/`reverse`-aware button disabled state.

### ❓ Type of change

- [x] ✨ New feature (a non-breaking change that adds functionality)

### 📝 Checklist

- [x] I have added tests.
- [x] I have updated the documentation accordingly.
- [x] I have updated the changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MEtF3VFxxNkqnkQ49feHXb
