### PR TITLE
[Release] Prepare 1.9.0-beta.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [v1.9.0-beta.4](https://github.com/studiometa/ui/compare/1.9.0-beta.3..1.9.0-beta.4) (2026-07-28)
+
 ### Added
 
-- **Carousel:** add the `Carousel` component (with `CarouselWrapper`, `CarouselItem`, `CarouselBtn` and `CarouselDrag`) built on the `Indexable` primitive, using native scroll-snap on touch devices and pointer drag on fine-pointer devices ([#320](https://github.com/studiometa/ui/pull/320))
+- **Carousel:** add the `Carousel` component (with `CarouselWrapper`, `CarouselItem`, `CarouselBtn` and `CarouselDrag`) built on the `Indexable` primitive, using native scroll-snap on touch devices and pointer drag on fine-pointer devices, with support for the `clamp`, `loop` and `bounce` boundary modes ([#553](https://github.com/studiometa/ui/pull/553))
+
+### Fixed
+
+- **Fetch:** let the `src` option take precedence over a `<form>`'s `action` or an `<a>`'s `href` when explicitly set, instead of being ignored on those elements ([#555](https://github.com/studiometa/ui/pull/555))
 
 ## [v1.9.0-beta.3](https://github.com/studiometa/ui/compare/1.9.0-beta.2..1.9.0-beta.3) (2026-07-27)
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "studiometa/ui",
   "type": "composer-plugin",
-  "version": "1.9.0-beta.3",
+  "version": "1.9.0-beta.4",
   "description": "A set of opiniated, unstyled and accessible components.",
   "license": "MIT",
   "require": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@studiometa/ui-workspace",
-  "version": "1.9.0-beta.3",
+  "version": "1.9.0-beta.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@studiometa/ui-workspace",
-      "version": "1.9.0-beta.3",
+      "version": "1.9.0-beta.4",
       "hasInstallScript": true,
       "workspaces": [
         "packages/*"
@@ -20688,11 +20688,11 @@
     },
     "packages/api": {
       "name": "@studiometa/ui-api",
-      "version": "1.9.0-beta.3"
+      "version": "1.9.0-beta.4"
     },
     "packages/docs": {
       "name": "@studiometa/ui-docs",
-      "version": "1.9.0-beta.3",
+      "version": "1.9.0-beta.4",
       "dependencies": {
         "@studiometa/js-toolkit": "3.8.0"
       },
@@ -20712,7 +20712,7 @@
     },
     "packages/eslint-plugin-ui": {
       "name": "@studiometa/eslint-plugin-ui",
-      "version": "1.9.0-beta.3",
+      "version": "1.9.0-beta.4",
       "license": "MIT",
       "dependencies": {
         "@oxlint/plugins": "1.63.0"
@@ -20741,7 +20741,7 @@
     },
     "packages/playground": {
       "name": "@studiometa/ui-playground",
-      "version": "1.9.0-beta.3",
+      "version": "1.9.0-beta.4",
       "dependencies": {
         "@studiometa/playground": "0.3.10"
       },
@@ -20912,7 +20912,7 @@
     },
     "packages/tests": {
       "name": "@studiometa/ui-tests",
-      "version": "1.9.0-beta.3",
+      "version": "1.9.0-beta.4",
       "license": "MIT",
       "dependencies": {
         "@happy-dom/global-registrator": "^20.8.8",
@@ -21165,7 +21165,7 @@
     },
     "packages/ui": {
       "name": "@studiometa/ui",
-      "version": "1.9.0-beta.3",
+      "version": "1.9.0-beta.4",
       "license": "MIT",
       "dependencies": {
         "alien-signals": "^3.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-workspace",
-  "version": "1.9.0-beta.3",
+  "version": "1.9.0-beta.4",
   "type": "module",
   "private": true,
   "workspaces": [

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-api",
-  "version": "1.9.0-beta.3",
+  "version": "1.9.0-beta.4",
   "private": true,
   "type": "commonjs"
 }

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-docs",
-  "version": "1.9.0-beta.3",
+  "version": "1.9.0-beta.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/eslint-plugin-ui/package.json
+++ b/packages/eslint-plugin-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/eslint-plugin-ui",
-  "version": "1.9.0-beta.3",
+  "version": "1.9.0-beta.4",
   "description": "ESLint plugin to help developers discover and use @studiometa/ui components",
   "publishConfig": {
     "access": "public"

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-playground",
-  "version": "1.9.0-beta.3",
+  "version": "1.9.0-beta.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-tests",
-  "version": "1.9.0-beta.3",
+  "version": "1.9.0-beta.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui",
-  "version": "1.9.0-beta.3",
+  "version": "1.9.0-beta.4",
   "description": "A set of opiniated, unstyled and accessible components",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Prepares the `1.9.0-beta.4` release.

- Bumps all packages (root, workspaces) and `composer.json` from `1.9.0-beta.3` to `1.9.0-beta.4`.
- Seals the `[Unreleased]` CHANGELOG entry under a `v1.9.0-beta.4` heading.

### Highlights

- **Carousel** — new component family (`CarouselWrapper`, `CarouselItem`, `CarouselBtn`, `CarouselDrag`) built on `Indexable`, with native scroll-snap on touch, pointer drag on fine-pointer devices, `clamp`/`loop`/`bounce` boundary support, and docs/examples/tests. Landed via #553.
- **Fetch** — the `src` option now takes precedence over a `<form>`'s `action` / `<a>`'s `href` when explicitly set, instead of being ignored on those elements. Landed via #555.

### ❓ Type of change

- [x] 🧹 Chore (release preparation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MEtF3VFxxNkqnkQ49feHXb
