### PR TITLE
Add ClickOutside primitive

### DIFF
--- a/packages/docs/components/ClickOutside/index.md
+++ b/packages/docs/components/ClickOutside/index.md
@@ -1,0 +1,36 @@
+---
+badges: [JS]
+---
+
+# ClickOutside <Badges :texts="$frontmatter.badges" />
+
+The `ClickOutside` primitive dispatches a native `click-outside` event on its element whenever the user clicks anywhere outside of it.
+
+## Usage
+
+`ClickOutside` defines no behaviour of its own beyond emitting the event, so it is meant to be paired with the [`Action`](/components/Action/index.html) component on the same element. Add both components to an element and listen to the emitted event with the [`on:<event>` option](/components/Action/js-api.html#on-event-modifier): `data-on:click-outside="..."`.
+
+In the following example, a dropdown menu is toggled by a button and closes as soon as a click lands outside of it.
+
+<llm-exclude>
+<PreviewPlayground
+  :html="() => import('./stories/dropdown/app.twig')"
+  :script="() => import('./stories/dropdown/app.js?raw')"
+  />
+</llm-exclude>
+<llm-only>
+
+:::code-group
+
+<<< ./stories/dropdown/app.twig
+<<< ./stories/dropdown/app.js
+
+:::
+
+</llm-only>
+
+## Events
+
+### `click-outside`
+
+Dispatched on the component's root element when a `click` occurs outside of it. The original `MouseEvent` is available on the event's `detail.event` property.

--- a/packages/docs/components/ClickOutside/stories/dropdown/app.js
+++ b/packages/docs/components/ClickOutside/stories/dropdown/app.js
@@ -1,0 +1,6 @@
+import { registerComponent } from '@studiometa/js-toolkit';
+import { Action, ClickOutside, Target } from '@studiometa/ui';
+
+registerComponent(Action);
+registerComponent(ClickOutside);
+registerComponent(Target);

--- a/packages/docs/components/ClickOutside/stories/dropdown/app.twig
+++ b/packages/docs/components/ClickOutside/stories/dropdown/app.twig
@@ -1,0 +1,22 @@
+<div
+  data-component="ClickOutside Action"
+  data-on:click-outside="Target(#dropdown)->target.$el.hidden = true"
+  class="relative inline-block">
+  <button
+    type="button"
+    data-component="Action"
+    data-on:click="Target(#dropdown)->target.$el.hidden = !target.$el.hidden"
+    class="px-4 py-2 rounded bg-blue-500 text-white font-semibold">
+    Toggle menu
+  </button>
+
+  <ul
+    id="dropdown"
+    data-component="Target"
+    hidden
+    class="absolute left-0 mt-2 w-48 p-2 rounded bg-white dark:bg-zinc-800 shadow-xl">
+    <li><a href="#" class="block px-3 py-2 rounded hover:bg-zinc-100 dark:hover:bg-zinc-700">Profile</a></li>
+    <li><a href="#" class="block px-3 py-2 rounded hover:bg-zinc-100 dark:hover:bg-zinc-700">Settings</a></li>
+    <li><a href="#" class="block px-3 py-2 rounded hover:bg-zinc-100 dark:hover:bg-zinc-700">Sign out</a></li>
+  </ul>
+</div>

--- a/packages/tests/ClickOutside/ClickOutside.spec.ts
+++ b/packages/tests/ClickOutside/ClickOutside.spec.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { Base } from '@studiometa/js-toolkit';
+import { ClickOutside, Action } from '@studiometa/ui';
+import { h, mount, destroy } from '#test-utils';
+
+function click(target: EventTarget) {
+  target.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+}
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('The ClickOutside component', () => {
+  it('should dispatch a `click-outside` event when clicking outside the element', async () => {
+    const el = h('div');
+    const outside = h('div');
+    document.body.append(el, outside);
+    const clickOutside = new ClickOutside(el);
+    await mount(clickOutside);
+
+    const handler = vi.fn();
+    el.addEventListener('click-outside', handler);
+
+    click(outside);
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    await destroy(clickOutside);
+  });
+
+  it('should not dispatch when clicking the element or its children', async () => {
+    const child = h('span');
+    const el = h('div', [child]);
+    document.body.append(el);
+    const clickOutside = new ClickOutside(el);
+    await mount(clickOutside);
+
+    const handler = vi.fn();
+    el.addEventListener('click-outside', handler);
+
+    click(el);
+    click(child);
+    expect(handler).not.toHaveBeenCalled();
+
+    await destroy(clickOutside);
+  });
+
+  it('should forward the original event in the `detail`', async () => {
+    const el = h('div');
+    const outside = h('div');
+    document.body.append(el, outside);
+    const clickOutside = new ClickOutside(el);
+    await mount(clickOutside);
+
+    let detail: any;
+    el.addEventListener('click-outside', (event: CustomEvent) => {
+      detail = event.detail;
+    });
+
+    click(outside);
+    expect(detail.event).toBeInstanceOf(MouseEvent);
+
+    await destroy(clickOutside);
+  });
+
+  it('should trigger an `Action` effect via `data-on:click-outside`', async () => {
+    const fn = vi.fn();
+    class Foo extends Base {
+      static config = {
+        name: 'Foo',
+      };
+
+      fn() {
+        fn();
+      }
+    }
+
+    const el = h('div', {
+      dataComponent: 'ClickOutside Action',
+      'data-on:click-outside': 'Foo->target.fn()',
+    });
+    const fooEl = h('div', { class: 'foo', dataComponent: 'Foo' });
+    const outside = h('div');
+    document.body.append(el, fooEl, outside);
+
+    const clickOutside = new ClickOutside(el);
+    const action = new Action(el);
+    const foo = new Foo(fooEl);
+    await mount(clickOutside, action, foo);
+
+    click(outside);
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    click(el);
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    await destroy(clickOutside, action, foo);
+  });
+
+  it('should stop dispatching once destroyed', async () => {
+    const el = h('div');
+    const outside = h('div');
+    document.body.append(el, outside);
+    const clickOutside = new ClickOutside(el);
+    await mount(clickOutside);
+
+    const handler = vi.fn();
+    el.addEventListener('click-outside', handler);
+
+    await destroy(clickOutside);
+
+    click(outside);
+    expect(handler).not.toHaveBeenCalled();
+  });
+});

--- a/packages/tests/index.spec.ts
+++ b/packages/tests/index.spec.ts
@@ -23,6 +23,7 @@ test('components exports', () => {
       "CarouselItem",
       "CarouselWrapper",
       "CircularMarquee",
+      "ClickOutside",
       "Cursor",
       "DataBind",
       "DataComputed",

--- a/packages/ui/ClickOutside/ClickOutside.ts
+++ b/packages/ui/ClickOutside/ClickOutside.ts
@@ -1,0 +1,34 @@
+import { Base } from '@studiometa/js-toolkit';
+import type { BaseConfig, BaseProps, BaseEventHookParams } from '@studiometa/js-toolkit';
+
+export interface ClickOutsideProps extends BaseProps {}
+
+/**
+ * ClickOutside class.
+ *
+ * A minimal marker component that reports clicks landing outside its own element.
+ * Using the built-in `onDocumentClick` hook, it dispatches a native
+ * `click-outside` `CustomEvent` on its root element whenever a document click
+ * occurs outside of it. Paired with the `Action` component on the same element,
+ * this lets HTML react to outside clicks — closing a dropdown or popover for
+ * example — via `data-on:click-outside="..."` without writing any JavaScript.
+ *
+ * @link https://ui.studiometa.dev/components/ClickOutside/
+ */
+export class ClickOutside<T extends BaseProps = BaseProps> extends Base<ClickOutsideProps & T> {
+  /**
+   * Config.
+   */
+  static config: BaseConfig = {
+    name: 'ClickOutside',
+  };
+
+  /**
+   * Dispatch a `click-outside` event when a document click lands outside the element.
+   */
+  onDocumentClick({ event }: BaseEventHookParams<MouseEvent>) {
+    if (!event.composedPath().includes(this.$el)) {
+      this.$el.dispatchEvent(new CustomEvent('click-outside', { detail: { event } }));
+    }
+  }
+}

--- a/packages/ui/ClickOutside/index.ts
+++ b/packages/ui/ClickOutside/index.ts
@@ -1,0 +1,1 @@
+export * from './ClickOutside.js';

--- a/packages/ui/index.ts
+++ b/packages/ui/index.ts
@@ -4,6 +4,7 @@ export * from './AnchorNav/index.js';
 export * from './AnchorScrollTo/index.js';
 export * from './Carousel/index.js';
 export * from './CircularMarquee/index.js';
+export * from './ClickOutside/index.js';
 export * from './Cursor/index.js';
 export * from './Data/index.js';
 export * from './decorators/index.js';


### PR DESCRIPTION
## Summary

Adds a new `ClickOutside` primitive that reports clicks landing outside its own element, so an `Action` component can react to them declaratively from HTML.

- `ClickOutside` uses the built-in `onDocumentClick` hook and dispatches a native `click-outside` `CustomEvent` on its root element whenever a document click lands outside of it (`event.composedPath()` excludes `$el`). The original `MouseEvent` is forwarded on `detail.event`.
- Because `Action` binds native listeners on its `$el`, placing both components on the same element enables `data-on:click-outside="..."` — no change to `Action` was required.

## Usage

```html
<div
  data-component="ClickOutside Action"
  data-on:click-outside="Target(#dropdown)->target.$el.hidden = true">
  <!-- ... -->
</div>
```

## Changes

- `packages/ui/ClickOutside/` — the primitive and its barrel export.
- `packages/ui/index.ts` — export `ClickOutside`.
- `packages/tests/ClickOutside/ClickOutside.spec.ts` — outside/inside clicks, `detail.event` forwarding, `Action` integration, and teardown on destroy.
- `packages/docs/components/ClickOutside/` — docs page with a dropdown story (auto-added to the sidebar).

## Testing

- `npm run test -- -- ClickOutside` — 5 passing.
- `npm run lint` — no errors (pre-existing warnings only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MEtF3VFxxNkqnkQ49feHXb