### PR TITLE
Prepare 1.9.0-beta.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [v1.9.0-beta.5](https://github.com/studiometa/ui/compare/1.9.0-beta.4..1.9.0-beta.5) (2026-07-29)
+
+### Added
+
+- **ClickOutside:** add the `ClickOutside` primitive that dispatches a `click-outside` event when a click lands outside its element, pairing with `Action` to react declaratively ([#557](https://github.com/studiometa/ui/pull/557))
+
 ## [v1.9.0-beta.4](https://github.com/studiometa/ui/compare/1.9.0-beta.3..1.9.0-beta.4) (2026-07-28)
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "studiometa/ui",
   "type": "composer-plugin",
-  "version": "1.9.0-beta.4",
+  "version": "1.9.0-beta.5",
   "description": "A set of opiniated, unstyled and accessible components.",
   "license": "MIT",
   "require": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@studiometa/ui-workspace",
-  "version": "1.9.0-beta.4",
+  "version": "1.9.0-beta.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@studiometa/ui-workspace",
-      "version": "1.9.0-beta.4",
+      "version": "1.9.0-beta.5",
       "hasInstallScript": true,
       "workspaces": [
         "packages/*"
@@ -20688,11 +20688,11 @@
     },
     "packages/api": {
       "name": "@studiometa/ui-api",
-      "version": "1.9.0-beta.4"
+      "version": "1.9.0-beta.5"
     },
     "packages/docs": {
       "name": "@studiometa/ui-docs",
-      "version": "1.9.0-beta.4",
+      "version": "1.9.0-beta.5",
       "dependencies": {
         "@studiometa/js-toolkit": "3.8.0"
       },
@@ -20712,7 +20712,7 @@
     },
     "packages/eslint-plugin-ui": {
       "name": "@studiometa/eslint-plugin-ui",
-      "version": "1.9.0-beta.4",
+      "version": "1.9.0-beta.5",
       "license": "MIT",
       "dependencies": {
         "@oxlint/plugins": "1.63.0"
@@ -20741,7 +20741,7 @@
     },
     "packages/playground": {
       "name": "@studiometa/ui-playground",
-      "version": "1.9.0-beta.4",
+      "version": "1.9.0-beta.5",
       "dependencies": {
         "@studiometa/playground": "0.3.10"
       },
@@ -20912,7 +20912,7 @@
     },
     "packages/tests": {
       "name": "@studiometa/ui-tests",
-      "version": "1.9.0-beta.4",
+      "version": "1.9.0-beta.5",
       "license": "MIT",
       "dependencies": {
         "@happy-dom/global-registrator": "^20.8.8",
@@ -21165,7 +21165,7 @@
     },
     "packages/ui": {
       "name": "@studiometa/ui",
-      "version": "1.9.0-beta.4",
+      "version": "1.9.0-beta.5",
       "license": "MIT",
       "dependencies": {
         "alien-signals": "^3.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-workspace",
-  "version": "1.9.0-beta.4",
+  "version": "1.9.0-beta.5",
   "type": "module",
   "private": true,
   "workspaces": [

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-api",
-  "version": "1.9.0-beta.4",
+  "version": "1.9.0-beta.5",
   "private": true,
   "type": "commonjs"
 }

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-docs",
-  "version": "1.9.0-beta.4",
+  "version": "1.9.0-beta.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/eslint-plugin-ui/package.json
+++ b/packages/eslint-plugin-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/eslint-plugin-ui",
-  "version": "1.9.0-beta.4",
+  "version": "1.9.0-beta.5",
   "description": "ESLint plugin to help developers discover and use @studiometa/ui components",
   "publishConfig": {
     "access": "public"

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-playground",
-  "version": "1.9.0-beta.4",
+  "version": "1.9.0-beta.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-tests",
-  "version": "1.9.0-beta.4",
+  "version": "1.9.0-beta.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui",
-  "version": "1.9.0-beta.4",
+  "version": "1.9.0-beta.5",
   "description": "A set of opiniated, unstyled and accessible components",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Prepares the `1.9.0-beta.5` prerelease.

## Changes

- Bump the version to `1.9.0-beta.5` across the root, all workspace packages, `composer.json` and `package-lock.json`.
- Update `CHANGELOG.md` with the `v1.9.0-beta.5` section.

## Changelog

### Added

- **ClickOutside:** add the `ClickOutside` primitive that dispatches a `click-outside` event when a click lands outside its element, pairing with `Action` to react declaratively (#557)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MEtF3VFxxNkqnkQ49feHXb