### PR TITLE
Add StoreLocator and StoreLocatorItem components

### DIFF
--- a/packages/docs/components/StoreLocator/examples.md
+++ b/packages/docs/components/StoreLocator/examples.md
@@ -1,0 +1,53 @@
+---
+title: StoreLocator examples
+---
+
+# Examples
+
+Both examples register a single root component that declares the `StoreLocator` — its `MapboxMap` and `StoreLocatorItem` children are resolved automatically, and the `MapboxCluster` inside the map is fed by the coordinator once the map has loaded. Each example loads the [Mapbox GL stylesheet](/components/MapboxMap/#installation) from a CDN and picks a Mapbox style through the `map-options` option. Replace the access token with your own [access token](https://docs.mapbox.com/help/getting-started/access-tokens/); the token used here is a public, restricted demo token.
+
+## Basic store locator
+
+A `StoreLocator` wrapping a sidebar list of Paris stores and a clustered map. Note that the `MapboxCluster` has **no** authored data: the coordinator derives a GeoJSON `FeatureCollection` from the list items and pushes it to the cluster after the map loads.
+
+Try it out:
+
+- **Pan or zoom the map** — the sidebar filters to the in-view stores and reorders them nearest-first.
+- **Click a store in the list** — the map flies there, the item is marked active and the detail drawer opens.
+- **Click a cluster** — the map zooms in and splits it; click an individual pin to select its store.
+
+The detail panel is the integrator's choice. Here it is a [`Dialog`](/components/Dialog/) drawer, opened from the [`select`](./js-api#select) event through a small root component's `onStoreLocatorSelect` handler, which copies the selected item's `<template>` detail into the drawer. A [`MapboxPopup`](/components/MapboxMap/js-api#mapboxpopup) or a static `aside` bound to the same event would work too.
+
+<PreviewPlayground
+  :html="() => import('./stories/basic/app.twig')"
+  :script="() => import('./stories/basic/app.js?raw')"
+  :css="() => import('./stories/basic/app.css?raw')"
+  />
+
+## Faceted list {#faceted-list}
+
+Because the map data is [derived from the registered items](./#the-three-state-model), replacing the list updates both the list **and** the map. This example swaps the `data-ref="list"` markup when a facet is picked: js-toolkit mounts and terminates the `StoreLocatorItem`s accordingly, the coordinator re-derives the map data from the new item set, and the clusters/markers follow. With `fit-on-update` set, the map also re-frames to the new subset.
+
+<PreviewPlayground
+  :html="() => import('./stories/faceted/app.twig')"
+  :script="() => import('./stories/faceted/app.js?raw')"
+  :css="() => import('./stories/faceted/app.css?raw')"
+  />
+
+### Doing it with `Fetch`
+
+The example above swaps the list client-side so it runs on a static page. In a real integration you would instead [`Fetch`](/components/Fetch/) the new list fragment from a server endpoint and let it replace the `data-ref="list"` container — the coordinator reacts to the mounted/terminated items exactly the same way, so nothing else changes. The debounced item-set sync coalesces a whole `Fetch` swap into a single map-data update.
+
+```html
+<form data-component="Fetch" action="/stores" method="GET" data-option-selector="[data-ref='list']">
+  <button type="submit" name="bank" value="left">Left bank</button>
+  <button type="submit" name="bank" value="right">Right bank</button>
+</form>
+
+<div data-component="StoreLocator">
+  <ul id="store-list" data-ref="list">
+    <!-- The server responds with a fresh <ul id="store-list"> of items. -->
+  </ul>
+  <div data-component="MapboxMap"><!-- … --></div>
+</div>
+```

--- a/packages/docs/components/StoreLocator/index.md
+++ b/packages/docs/components/StoreLocator/index.md
@@ -1,0 +1,99 @@
+---
+badges: [JS]
+---
+
+# StoreLocator <Badges :texts="$frontmatter.badges" />
+
+The `StoreLocator` component coordinates a "find a store near you" experience around a [`MapboxMap`](/components/MapboxMap/). It is a thin, composable coordinator: it owns no map rendering of its own and instead wires together a `MapboxMap`, an optional [`MapboxCluster`](/components/MapboxMap/js-api#cluster) (the map data source), an optional [`MapboxGeocoder`](/components/MapboxMap/js-api#mapboxgeocoder) (address search) and a sidebar list of `StoreLocatorItem`s — all authored declaratively from your HTML with [js-toolkit](https://js-toolkit.studiometa.dev/), no framework runtime.
+
+It is part of the [`@studiometa/ui-mapbox`](https://www.npmjs.com/package/@studiometa/ui-mapbox) package, alongside the rest of the [`MapboxMap` family](/components/MapboxMap/).
+
+## The three-state model
+
+Each store has three independent states, each with its own source of truth. Keeping them separate is what makes the coordinator predictable — panning the map never rebuilds the map data, and updating the item set never fights with the current viewport.
+
+| State          | Source of truth                            | Drives                                          | Recomputed on        |
+| -------------- | ------------------------------------------ | ----------------------------------------------- | -------------------- |
+| **Registered** | the item exists in the DOM                 | the **map data** (markers/clusters)             | item-set change only |
+| **In bounds**  | the item's `lngLat` is inside the viewport | **list visibility + distance sort** only        | every map `moveend`  |
+| **Selected**   | the chosen item                            | fly-to, `active` styling and the `select` event | selection            |
+
+Because the map data is derived only from the registered items, swapping the list (for instance through a [`Fetch`](/components/Fetch/)) updates both the list **and** the map at once. See the [faceted example](./examples#faceted-list).
+
+## Composability
+
+The `StoreLocator` emits events and reflects state as data-attributes; it makes no decision about how a selected store is presented. The [examples](./examples.md) use a [`Dialog`](/components/Dialog/) drawer as the detail panel, but a [`MapboxPopup`](/components/MapboxMap/js-api#mapboxpopup) or a plain static `aside` would work just as well — wire whichever you like to the [`select`](./js-api#select) event.
+
+## Table of content
+
+- [Examples](./examples.md)
+- [JS API](./js-api.md)
+
+## Installation
+
+The component ships with the `@studiometa/ui-mapbox` package. Install it alongside its `mapbox-gl` peer dependency, exactly like the rest of the [`MapboxMap` family](/components/MapboxMap/#installation).
+
+```bash
+npm install @studiometa/ui-mapbox mapbox-gl
+```
+
+The [Mapbox GL stylesheet](/components/MapboxMap/#installation) and a [Mapbox access token](https://docs.mapbox.com/help/getting-started/access-tokens/) are required, just like for a plain map.
+
+## Usage
+
+Register only the `StoreLocator` with [`registerComponent`](https://js-toolkit.studiometa.dev/api/helpers/registerComponent.html): it declares `MapboxMap` and `StoreLocatorItem` internally, and the `MapboxCluster` living inside the map is resolved automatically once the map has loaded.
+
+Author a root `StoreLocator` element wrapping a sidebar `list` ref of `StoreLocatorItem`s and a `MapboxMap`. The `MapboxCluster` carries **no** authored data — the coordinator derives a GeoJSON `FeatureCollection` from the items and pushes it to the cluster once the map is ready.
+
+::: code-group
+
+```js [app.js]
+import { registerComponent } from '@studiometa/js-toolkit';
+import { StoreLocator } from '@studiometa/ui-mapbox';
+
+registerComponent(StoreLocator);
+```
+
+```html [index.html]
+<div data-component="StoreLocator" class="grid md:grid-cols-[20rem_1fr] h-[500px]">
+  <ul data-ref="list" class="overflow-y-auto">
+    <li
+      data-component="StoreLocatorItem"
+      data-option-id="louvre"
+      data-option-lng-lat="[2.3364, 48.8592]">
+      <button type="button" data-ref="select">Paris 1er — Louvre</button>
+    </li>
+    <!-- more items… -->
+  </ul>
+
+  <div
+    data-component="MapboxMap"
+    data-option-access-token="<YOUR_MAPBOX_ACCESS_TOKEN>"
+    data-option-zoom="11"
+    data-option-center="[2.35, 48.86]"
+    data-option-map-options='{"style":"mapbox://styles/mapbox/streets-v12"}'>
+    <div data-ref="container" class="h-full w-full"></div>
+
+    <!-- No authored data: the StoreLocator drives this source. -->
+    <div hidden data-component="MapboxCluster"></div>
+  </div>
+</div>
+```
+
+```css [app.css]
+@import 'mapbox-gl/dist/mapbox-gl.css';
+
+/* List-visibility contract: hide items outside the current viewport. */
+[data-component='StoreLocatorItem']:not([data-in-bounds]) {
+  display: none;
+}
+
+/* Selected-item contract. */
+[data-component='StoreLocatorItem'][data-active] {
+  /* highlight the active store */
+}
+```
+
+:::
+
+The styling contract is entirely data-attribute driven: `data-in-bounds` toggles list visibility, `data-active` (plus `aria-current="true"`) marks the selected item. See the [styling contract](./js-api#styling-contract) for details.

--- a/packages/docs/components/StoreLocator/js-api.md
+++ b/packages/docs/components/StoreLocator/js-api.md
@@ -1,0 +1,161 @@
+---
+title: StoreLocator JS API
+outline: deep
+---
+
+# JS API
+
+The store locator is made of two components:
+
+- `StoreLocator` — the coordinator, wrapping a [`MapboxMap`](/components/MapboxMap/js-api#map) and the sidebar list.
+- `StoreLocatorItem` — a single store entry living in the sidebar.
+
+You only ever register `StoreLocator` with [`registerComponent`](https://js-toolkit.studiometa.dev/api/helpers/registerComponent.html): it declares `MapboxMap` and `StoreLocatorItem` internally, and the optional `MapboxCluster`/`MapboxGeocoder` inside the map are discovered automatically once the map has loaded.
+
+The coordinator reads its options **once, at mount time** — they are **not** reactive, like the rest of the [`MapboxMap` family](/components/MapboxMap/js-api#reactivity-and-updates). To change the store set afterwards, change the DOM of the list (add/remove `StoreLocatorItem` elements) and the coordinator re-derives the map data automatically.
+
+## StoreLocator
+
+The coordinator. It owns no map rendering: it registers the `StoreLocatorItem`s, derives a GeoJSON `FeatureCollection` from them, pushes it to the child `MapboxCluster` once the map is loaded, filters and sorts the list on every map move, and handles selection.
+
+### Options
+
+| Option            | Type      | Default | Description                                                                                             |
+| ----------------- | --------- | ------- | ------------------------------------------------------------------------------------------------------- |
+| `item-zoom-level` | `Number`  | `14`    | The zoom level the map flies to when a store is selected.                                               |
+| `no-sort`         | `Boolean` | `false` | Disable the distance sort. By default the in-view items are reordered nearest-first on every map move.  |
+| `fit-on-update`   | `Boolean` | `false` | Fit the map bounds to the whole item set whenever it changes (on mount and on any add/remove of items). |
+
+<!-- prettier-ignore-start -->
+```html {3}
+<div
+  data-component="StoreLocator"
+  data-option-item-zoom-level="16"
+  data-option-fit-on-update>
+  ...
+</div>
+```
+<!-- prettier-ignore-end -->
+
+### Refs
+
+| Ref    | Type          | Description                                                                                               |
+| ------ | ------------- | --------------------------------------------------------------------------------------------------------- |
+| `list` | `HTMLElement` | The sidebar container holding the `StoreLocatorItem`s. The coordinator reorders its children by distance. |
+
+### Getters
+
+| Getter              | Type                          | Description                                                                     |
+| ------------------- | ----------------------------- | ------------------------------------------------------------------------------- |
+| `isLoaded`          | `boolean`                     | Whether the underlying map has finished loading. (a public field, not a getter) |
+| `mapboxMap`         | `MapboxMap`                   | The closest child `MapboxMap` component.                                        |
+| `map`               | `mapboxgl.Map`                | The underlying Mapbox `Map` instance. Only valid once the map has loaded.       |
+| `cluster`           | `MapboxCluster \| undefined`  | The optional `MapboxCluster` child, mounted by the `MapboxMap`.                 |
+| `geocoder`          | `MapboxGeocoder \| undefined` | The optional `MapboxGeocoder` child, mounted by the `MapboxMap`.                |
+| `featureCollection` | `FeatureCollection`           | The GeoJSON derived from the registered items — the data pushed to the source.  |
+
+### Methods
+
+#### `selectItem(item)`
+
+- Arguments: `StoreLocatorItem`
+
+Select a store: deactivate the previous one, fly the map to the item at `item-zoom-level`, mark it active (`data-active` + `aria-current="true"`) and emit [`select`](#select). Called by an item's own click, by a cluster feature-click, and available for you to call directly.
+
+#### `deselect()`
+
+Clear the current selection, remove the active state and emit [`deselect`](#deselect).
+
+#### `registerItem(item)` / `unregisterItem(item)`
+
+- Arguments: `StoreLocatorItem`
+
+Add/remove an item from the coordinator's registry and schedule a coalesced map-data sync. These are called automatically by the `StoreLocatorItem`s on mount/destroy — you rarely call them yourself, but they are the hook a `Fetch` list swap relies on.
+
+### Events
+
+#### `select`
+
+Emitted when a store is selected, with the selected `StoreLocatorItem` instance. Wire your detail panel here.
+
+```js
+onStoreLocatorSelect({ args: [item] }) {
+  // item.id, item.lngLat, item.$el …
+}
+```
+
+#### `deselect`
+
+Emitted when the selection is cleared through [`deselect()`](#deselect-1).
+
+#### `filter`
+
+Emitted whenever the in-view list is recomputed (on every map `moveend` and after an item-set change), with the array of in-view items in display order (nearest-first unless `no-sort` is set).
+
+```js
+onStoreLocatorFilter({ args: [items] }) {
+  // e.g. update a "N stores in view" counter
+}
+```
+
+## StoreLocatorItem
+
+A single store entry. Unlike the other `@studiometa/ui-mapbox` components, it does **not** live inside the map: its DOM is in the sidebar list, and its context is the parent `StoreLocator` (resolved via `$closest('StoreLocator')`). It is headless — the coordinator only reflects state as data-attributes so you can style it with plain CSS.
+
+### Options
+
+| Option    | Type     | Default  | Description                                                              |
+| --------- | -------- | -------- | ------------------------------------------------------------------------ |
+| `id`      | `String` | —        | Stable identifier, used to match a clicked map feature back to the item. |
+| `lng-lat` | `Array`  | `[0, 0]` | The store coordinates as `[longitude, latitude]`.                        |
+
+### Refs
+
+| Ref      | Type          | Description                                                                                 |
+| -------- | ------------- | ------------------------------------------------------------------------------------------- |
+| `select` | `HTMLElement` | The element (typically a `<button>`) whose click selects the store through the coordinator. |
+
+### Getters
+
+| Getter         | Type               | Description                                    |
+| -------------- | ------------------ | ---------------------------------------------- |
+| `id`           | `string`           | The item's stable identifier.                  |
+| `lngLat`       | `[number, number]` | The item's `[lng, lat]` coordinates.           |
+| `storeLocator` | `StoreLocator`     | The closest parent `StoreLocator` coordinator. |
+
+### Methods
+
+The state setters below are called by the coordinator; you generally read the resulting data-attributes from CSS rather than calling them yourself.
+
+#### `setInBounds(value)`
+
+- Arguments: `boolean`
+
+Toggle the `data-in-bounds` attribute — the [list-visibility](#styling-contract) signal.
+
+#### `setActive(value)`
+
+- Arguments: `boolean`
+
+Toggle the `data-active` attribute and the `aria-current="true"` state — the [selected](#styling-contract) signal.
+
+## Styling contract {#styling-contract}
+
+The coordinator never styles anything: it only reflects state as attributes on each `StoreLocatorItem`. You own the CSS.
+
+| Attribute                      | Meaning                                                        | Typical CSS                                                                   |
+| ------------------------------ | -------------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| `data-in-bounds`               | The item is inside the current map viewport (list visibility). | `[data-component='StoreLocatorItem']:not([data-in-bounds]) { display: none }` |
+| `data-active` + `aria-current` | The item is the selected one.                                  | `[data-component='StoreLocatorItem'][data-active] { /* highlight */ }`        |
+
+```css
+/* Hide out-of-view stores from the list. */
+[data-component='StoreLocatorItem']:not([data-in-bounds]) {
+  display: none;
+}
+
+/* Highlight the selected store. */
+[data-component='StoreLocatorItem'][data-active] {
+  background-color: #ecfdf5;
+}
+```

--- a/packages/docs/components/StoreLocator/stories/basic/app.css
+++ b/packages/docs/components/StoreLocator/stories/basic/app.css
@@ -1,0 +1,8 @@
+html.dark {
+  background-color: #222;
+  color: #eee;
+}
+
+body {
+  padding: 1rem;
+}

--- a/packages/docs/components/StoreLocator/stories/basic/app.js
+++ b/packages/docs/components/StoreLocator/stories/basic/app.js
@@ -1,0 +1,41 @@
+import { Base, registerComponent } from '@studiometa/js-toolkit';
+import { StoreLocator, StoreLocatorItem } from '@studiometa/ui-mapbox';
+import { Action, Dialog, ViewTransition } from '@studiometa/ui';
+
+/**
+ * Root component wiring the detail panel to the store locator.
+ *
+ * The `StoreLocator` stays panel-agnostic: it only emits a `select` event with
+ * the chosen item. Here we react to it through the `on<Component><Event>`
+ * convention, copy the item's `<template>` detail into the drawer and open it.
+ */
+class App extends Base {
+  static config = {
+    name: 'App',
+    components: { StoreLocator, StoreLocatorItem, Dialog, Action, ViewTransition },
+  };
+
+  /**
+   * The detail panel Dialog child.
+   */
+  get panel() {
+    return this.$query('Dialog')[0];
+  }
+
+  /**
+   * Open the drawer with the selected store's detail.
+   * @param {{ args: [StoreLocatorItem] }} props
+   */
+  onStoreLocatorSelect({ args: [item] }) {
+    const template = item.$el.querySelector('template');
+    const content = this.$el.querySelector('#store-panel-content');
+
+    if (template && content) {
+      content.replaceChildren(template.content.cloneNode(true));
+    }
+
+    this.panel?.open();
+  }
+}
+
+registerComponent(App);

--- a/packages/docs/components/StoreLocator/stories/basic/app.twig
+++ b/packages/docs/components/StoreLocator/stories/basic/app.twig
@@ -1,0 +1,196 @@
+<link rel="stylesheet" href="https://esm.sh/mapbox-gl@3.13.0/dist/mapbox-gl.css" />
+
+{% set stores = [
+  { id: 'paris-1', name: 'Paris 1ᵉʳ — Louvre', address: '2 rue de Rivoli, 75001 Paris', hours: 'Mon–Sat, 10am–7pm', lngLat: [2.3364, 48.8592] },
+  { id: 'paris-2', name: 'Paris 2ᵉ — Bourse', address: '14 rue Vivienne, 75002 Paris', hours: 'Mon–Sat, 10am–7pm', lngLat: [2.3412, 48.8697] },
+  { id: 'paris-3', name: 'Paris 3ᵉ — Temple', address: '9 rue de Bretagne, 75003 Paris', hours: 'Tue–Sun, 10am–8pm', lngLat: [2.3620, 48.8637] },
+  { id: 'paris-4', name: 'Paris 4ᵉ — Marais', address: '30 rue des Archives, 75004 Paris', hours: 'Mon–Sun, 11am–8pm', lngLat: [2.3573, 48.8557] },
+  { id: 'paris-5', name: 'Paris 5ᵉ — Panthéon', address: '5 rue Soufflot, 75005 Paris', hours: 'Mon–Sat, 9am–7pm', lngLat: [2.3488, 48.8443] },
+  { id: 'paris-6', name: 'Paris 6ᵉ — Saint-Germain', address: '12 rue de Rennes, 75006 Paris', hours: 'Mon–Sat, 10am–7pm', lngLat: [2.3333, 48.8496] },
+  { id: 'paris-7', name: 'Paris 7ᵉ — Invalides', address: '40 rue de Grenelle, 75007 Paris', hours: 'Mon–Fri, 9am–6pm', lngLat: [2.3125, 48.8565] },
+  { id: 'paris-8', name: 'Paris 8ᵉ — Champs-Élysées', address: '68 avenue des Champs-Élysées, 75008 Paris', hours: 'Mon–Sun, 10am–9pm', lngLat: [2.3126, 48.8726] },
+  { id: 'paris-9', name: 'Paris 9ᵉ — Opéra', address: '22 boulevard Haussmann, 75009 Paris', hours: 'Mon–Sat, 9am–8pm', lngLat: [2.3390, 48.8768] },
+  { id: 'paris-10', name: 'Paris 10ᵉ — Canal', address: '18 quai de Valmy, 75010 Paris', hours: 'Tue–Sun, 10am–7pm', lngLat: [2.3608, 48.8760] },
+  { id: 'paris-11', name: 'Paris 11ᵉ — Bastille', address: '55 rue de la Roquette, 75011 Paris', hours: 'Mon–Sun, 11am–8pm', lngLat: [2.3800, 48.8594] },
+  { id: 'paris-12', name: 'Paris 12ᵉ — Bercy', address: '9 cour Saint-Émilion, 75012 Paris', hours: 'Mon–Sun, 10am–8pm', lngLat: [2.3877, 48.8353] },
+  { id: 'paris-13', name: 'Paris 13ᵉ — Gobelins', address: '30 avenue des Gobelins, 75013 Paris', hours: 'Mon–Sat, 10am–7pm', lngLat: [2.3620, 48.8322] },
+  { id: 'paris-14', name: 'Paris 14ᵉ — Montparnasse', address: '11 rue Daguerre, 75014 Paris', hours: 'Mon–Sat, 9am–7pm', lngLat: [2.3269, 48.8331] },
+  { id: 'paris-15', name: 'Paris 15ᵉ — Vaugirard', address: '76 rue du Commerce, 75015 Paris', hours: 'Mon–Sat, 10am–7pm', lngLat: [2.3000, 48.8412] },
+  { id: 'paris-16', name: 'Paris 16ᵉ — Passy', address: '20 rue de Passy, 75016 Paris', hours: 'Mon–Fri, 9am–6pm', lngLat: [2.2618, 48.8637] },
+  { id: 'paris-17', name: 'Paris 17ᵉ — Batignolles', address: '32 rue des Batignolles, 75017 Paris', hours: 'Tue–Sun, 10am–7pm', lngLat: [2.3068, 48.8848] },
+  { id: 'paris-18', name: 'Paris 18ᵉ — Montmartre', address: '6 rue des Abbesses, 75018 Paris', hours: 'Mon–Sun, 10am–8pm', lngLat: [2.3444, 48.8925] }
+] %}
+
+<div data-component="App">
+  <div
+    data-component="StoreLocator"
+    data-option-fit-on-update
+    class="grid h-[540px] grid-cols-1 overflow-hidden rounded-lg border border-zinc-200 md:grid-cols-[minmax(0,20rem)_1fr] dark:border-zinc-700">
+
+    {# Sidebar list. Out-of-bounds items are hidden through CSS; the coordinator
+       reorders the remaining ones nearest-first on every map move. #}
+    <ul
+      data-ref="list"
+      class="divide-y divide-zinc-200 overflow-y-auto bg-white dark:divide-zinc-700 dark:bg-zinc-900">
+      {% for store in stores %}
+        <li
+          data-component="StoreLocatorItem"
+          data-option-id="{{ store.id }}"
+          data-option-lng-lat="{{ store.lngLat|json_encode }}">
+          <button
+            type="button"
+            data-ref="select"
+            class="block w-full px-4 py-3 text-left hover:bg-zinc-50 dark:hover:bg-zinc-800">
+            <span class="name block font-semibold">
+              {{ store.name }}
+            </span>
+            <span class="mt-0.5 block text-sm text-zinc-500 dark:text-zinc-400">
+              {{ store.address }}
+            </span>
+          </button>
+
+          {# Rich detail, kept out of the flow in a <template>; the panel copies
+             it in on selection. #}
+          <template>
+            <h2 class="text-xl font-bold">{{ store.name }}</h2>
+            <dl class="mt-4 space-y-3 text-sm">
+              <div>
+                <dt class="font-semibold text-zinc-500 dark:text-zinc-400">Address</dt>
+                <dd>{{ store.address }}</dd>
+              </div>
+              <div>
+                <dt class="font-semibold text-zinc-500 dark:text-zinc-400">Opening hours</dt>
+                <dd>{{ store.hours }}</dd>
+              </div>
+              <div>
+                <dt class="font-semibold text-zinc-500 dark:text-zinc-400">Coordinates</dt>
+                <dd>{{ store.lngLat[1] }}, {{ store.lngLat[0] }}</dd>
+              </div>
+            </dl>
+          </template>
+        </li>
+      {% endfor %}
+    </ul>
+
+    {# The map. The MapboxCluster carries NO authored data: the StoreLocator
+       derives a FeatureCollection from the items and pushes it with setData
+       once the map has loaded. #}
+    <div
+      data-component="MapboxMap"
+      data-option-access-token="pk.eyJ1IjoiYWdlbmNlc3R1ZGlvbWV0YSIsImEiOiJjbXM5NTBycHMwa2Z4MndxeW02YndscmQyIn0.UitMikKpq-TRJOXM-rBcMg"
+      data-option-zoom="5"
+      data-option-center="[2.35, 48.86]"
+      data-option-map-options='{"style":"mapbox://styles/mapbox/streets-v12"}'
+      class="h-full min-h-[300px] w-full">
+      <div data-ref="container" class="h-full w-full"></div>
+
+      <div
+        hidden
+        data-component="MapboxCluster"
+        data-option-cluster-radius="60"
+        data-option-clusters-paint='{ "circle-color": "#059669", "circle-radius": 20 }'
+        data-option-cluster-count-paint='{ "text-color": "#ffffff" }'
+        data-option-unclustered-point-paint='{ "circle-color": "#059669", "circle-radius": 7, "circle-stroke-width": 2, "circle-stroke-color": "#ffffff" }'></div>
+    </div>
+  </div>
+
+  {# Detail panel — a Dialog drawer. Which panel to use is the integrator's
+     choice; a MapboxPopup or a static aside would work too. The host carries
+     NO display utility, so a closed drawer stays display:none. #}
+  <dialog
+    id="store-panel"
+    data-component="Action Dialog"
+    data-on:cancel.prevent="Dialog.close()"
+    data-on:click="event.target === $el && Dialog.close()"
+    class="fixed inset-0 m-0 h-full max-h-none w-full max-w-none overflow-hidden bg-transparent p-0">
+
+    <div
+      data-component="Action ViewTransition"
+      data-on:click="Dialog(#store-panel)->target.close()"
+      data-option-view-transition-name="store-panel-backdrop"
+      data-option-leave-to="opacity-0"
+      class="fixed inset-0 bg-black/50 opacity-0"></div>
+
+    <div
+      data-component="ViewTransition"
+      data-option-view-transition-name="store-panel-panel"
+      data-option-leave-to="translate-x-full opacity-0"
+      class="absolute inset-y-0 right-0 w-96 max-w-full translate-x-full overflow-y-auto bg-white p-8 text-black opacity-0 shadow-2xl">
+      <button
+        type="button"
+        data-component="Action"
+        data-on:click="Dialog(#store-panel)->target.close()"
+        class="mb-6 inline-flex items-center gap-1 border-b border-current text-sm">
+        Close
+      </button>
+      <div id="store-panel-content"></div>
+    </div>
+  </dialog>
+</div>
+
+<style>
+  /* List-visibility contract: hide every item whose lngLat is outside the
+     current map viewport. */
+  [data-component='StoreLocatorItem']:not([data-in-bounds]) {
+    display: none;
+  }
+
+  /* Selected-item contract: highlight the active item. */
+  [data-component='StoreLocatorItem'][data-active] > button {
+    background-color: #ecfdf5;
+  }
+  [data-component='StoreLocatorItem'][data-active] .name {
+    color: #047857;
+  }
+  html.dark [data-component='StoreLocatorItem'][data-active] > button {
+    background-color: #022c22;
+  }
+  html.dark [data-component='StoreLocatorItem'][data-active] .name {
+    color: #34d399;
+  }
+
+  dialog::backdrop {
+    background: transparent;
+  }
+
+  ::view-transition-group(store-panel-panel) {
+    z-index: 2;
+  }
+  ::view-transition-group(store-panel-backdrop) {
+    z-index: 1;
+  }
+
+  @keyframes store-panel-slide-in {
+    from {
+      transform: translateX(100%);
+    }
+  }
+  @keyframes store-panel-slide-out {
+    to {
+      transform: translateX(100%);
+    }
+  }
+  ::view-transition-new(store-panel-panel) {
+    animation: 300ms ease-out both store-panel-slide-in;
+  }
+  ::view-transition-old(store-panel-panel) {
+    animation: 300ms ease-in both store-panel-slide-out;
+  }
+
+  @keyframes store-panel-fade-in {
+    from {
+      opacity: 0;
+    }
+  }
+  @keyframes store-panel-fade-out {
+    to {
+      opacity: 0;
+    }
+  }
+  ::view-transition-new(store-panel-backdrop) {
+    animation: 300ms ease-out both store-panel-fade-in;
+  }
+  ::view-transition-old(store-panel-backdrop) {
+    animation: 300ms ease-in both store-panel-fade-out;
+  }
+</style>

--- a/packages/docs/components/StoreLocator/stories/faceted/app.css
+++ b/packages/docs/components/StoreLocator/stories/faceted/app.css
@@ -1,0 +1,8 @@
+html.dark {
+  background-color: #222;
+  color: #eee;
+}
+
+body {
+  padding: 1rem;
+}

--- a/packages/docs/components/StoreLocator/stories/faceted/app.js
+++ b/packages/docs/components/StoreLocator/stories/faceted/app.js
@@ -1,0 +1,101 @@
+import { Base, registerComponent } from '@studiometa/js-toolkit';
+import { StoreLocator, StoreLocatorItem } from '@studiometa/ui-mapbox';
+import { Action, Dialog, ViewTransition } from '@studiometa/ui';
+
+/**
+ * Root component driving both the detail panel and the facets.
+ *
+ * The facets swap the list markup client-side to keep the playground static.
+ * A real integration would `Fetch` the new list fragment from the server
+ * instead — see the prose in the examples page. Either way, the important part
+ * is identical: the DOM of the `data-ref="list"` changes, js-toolkit mounts and
+ * terminates the `StoreLocatorItem`s accordingly, and the `StoreLocator`
+ * re-derives the map data from the new item set (markers and clusters follow).
+ */
+class App extends Base {
+  static config = {
+    name: 'App',
+    refs: ['facet[]'],
+    components: { StoreLocator, StoreLocatorItem, Dialog, Action, ViewTransition },
+  };
+
+  /**
+   * The authored markup of every list item, captured once as `{ category, html }`.
+   * Each facet rebuilds the list from these snippets so every swap produces
+   * **fresh** nodes — exactly like a `Fetch` response would. Reusing the same
+   * elements would leave js-toolkit's terminated instances lingering on them and
+   * block a clean re-mount.
+   */
+  __allItems = [];
+
+  /**
+   * The store locator child.
+   */
+  get storeLocator() {
+    return this.$query('StoreLocator')[0];
+  }
+
+  /**
+   * The detail panel Dialog child.
+   */
+  get panel() {
+    return this.$query('Dialog')[0];
+  }
+
+  /**
+   * Capture the initial (full) item set.
+   */
+  mounted() {
+    const list = this.storeLocator?.$refs.list;
+    if (list) {
+      this.__allItems = [...list.children].map((item) => ({
+        category: item.dataset.category,
+        html: item.outerHTML,
+      }));
+    }
+  }
+
+  /**
+   * Filter the list to the clicked facet's category.
+   * @param {{ index: number }} props
+   */
+  onFacetClick({ index }) {
+    const button = this.$refs.facet[index];
+    const { category } = button.dataset;
+    const list = this.storeLocator?.$refs.list;
+
+    if (!list) {
+      return;
+    }
+
+    for (const facet of this.$refs.facet) {
+      facet.toggleAttribute('data-active', facet === button);
+    }
+
+    // Rebuild the list from fresh markup — the same thing a `Fetch` response
+    // does. js-toolkit terminates the old `StoreLocatorItem`s (→ unregister) and
+    // mounts the new ones (→ register); the coordinator coalesces the batch into
+    // a single map-data update, so markers and clusters follow the new set.
+    list.innerHTML = this.__allItems
+      .filter((item) => category === 'all' || item.category === category)
+      .map((item) => item.html)
+      .join('');
+  }
+
+  /**
+   * Open the drawer with the selected store's detail.
+   * @param {{ args: [StoreLocatorItem] }} props
+   */
+  onStoreLocatorSelect({ args: [item] }) {
+    const template = item.$el.querySelector('template');
+    const content = this.$el.querySelector('#store-panel-content');
+
+    if (template && content) {
+      content.replaceChildren(template.content.cloneNode(true));
+    }
+
+    this.panel?.open();
+  }
+}
+
+registerComponent(App);

--- a/packages/docs/components/StoreLocator/stories/faceted/app.twig
+++ b/packages/docs/components/StoreLocator/stories/faceted/app.twig
@@ -1,0 +1,201 @@
+<link rel="stylesheet" href="https://esm.sh/mapbox-gl@3.13.0/dist/mapbox-gl.css" />
+
+{% set stores = [
+  { id: 'paris-1', name: 'Paris 1ᵉʳ — Louvre', address: '2 rue de Rivoli, 75001 Paris', bank: 'right', lngLat: [2.3364, 48.8592] },
+  { id: 'paris-2', name: 'Paris 2ᵉ — Bourse', address: '14 rue Vivienne, 75002 Paris', bank: 'right', lngLat: [2.3412, 48.8697] },
+  { id: 'paris-3', name: 'Paris 3ᵉ — Temple', address: '9 rue de Bretagne, 75003 Paris', bank: 'right', lngLat: [2.3620, 48.8637] },
+  { id: 'paris-4', name: 'Paris 4ᵉ — Marais', address: '30 rue des Archives, 75004 Paris', bank: 'right', lngLat: [2.3573, 48.8557] },
+  { id: 'paris-5', name: 'Paris 5ᵉ — Panthéon', address: '5 rue Soufflot, 75005 Paris', bank: 'left', lngLat: [2.3488, 48.8443] },
+  { id: 'paris-6', name: 'Paris 6ᵉ — Saint-Germain', address: '12 rue de Rennes, 75006 Paris', bank: 'left', lngLat: [2.3333, 48.8496] },
+  { id: 'paris-7', name: 'Paris 7ᵉ — Invalides', address: '40 rue de Grenelle, 75007 Paris', bank: 'left', lngLat: [2.3125, 48.8565] },
+  { id: 'paris-8', name: 'Paris 8ᵉ — Champs-Élysées', address: '68 avenue des Champs-Élysées, 75008 Paris', bank: 'right', lngLat: [2.3126, 48.8726] },
+  { id: 'paris-9', name: 'Paris 9ᵉ — Opéra', address: '22 boulevard Haussmann, 75009 Paris', bank: 'right', lngLat: [2.3390, 48.8768] },
+  { id: 'paris-10', name: 'Paris 10ᵉ — Canal', address: '18 quai de Valmy, 75010 Paris', bank: 'right', lngLat: [2.3608, 48.8760] },
+  { id: 'paris-11', name: 'Paris 11ᵉ — Bastille', address: '55 rue de la Roquette, 75011 Paris', bank: 'right', lngLat: [2.3800, 48.8594] },
+  { id: 'paris-13', name: 'Paris 13ᵉ — Gobelins', address: '30 avenue des Gobelins, 75013 Paris', bank: 'left', lngLat: [2.3620, 48.8322] },
+  { id: 'paris-14', name: 'Paris 14ᵉ — Montparnasse', address: '11 rue Daguerre, 75014 Paris', bank: 'left', lngLat: [2.3269, 48.8331] },
+  { id: 'paris-15', name: 'Paris 15ᵉ — Vaugirard', address: '76 rue du Commerce, 75015 Paris', bank: 'left', lngLat: [2.3000, 48.8412] },
+  { id: 'paris-16', name: 'Paris 16ᵉ — Passy', address: '20 rue de Passy, 75016 Paris', bank: 'right', lngLat: [2.2618, 48.8637] },
+  { id: 'paris-17', name: 'Paris 17ᵉ — Batignolles', address: '32 rue des Batignolles, 75017 Paris', bank: 'right', lngLat: [2.3068, 48.8848] },
+  { id: 'paris-18', name: 'Paris 18ᵉ — Montmartre', address: '6 rue des Abbesses, 75018 Paris', bank: 'right', lngLat: [2.3444, 48.8925] }
+] %}
+
+<div data-component="App">
+  {# Facet toolbar — lives outside the StoreLocator so its buttons are App refs.
+     Selecting a facet swaps the list markup; the coordinator re-derives the map
+     data from the new item set. #}
+  <div class="mb-3 flex flex-wrap gap-2">
+    <button
+      type="button"
+      data-ref="facet[]"
+      data-category="all"
+      data-active
+      class="facet rounded-full border border-zinc-300 px-3 py-1 text-sm dark:border-zinc-600">
+      All stores
+    </button>
+    <button
+      type="button"
+      data-ref="facet[]"
+      data-category="right"
+      class="facet rounded-full border border-zinc-300 px-3 py-1 text-sm dark:border-zinc-600">
+      Right bank
+    </button>
+    <button
+      type="button"
+      data-ref="facet[]"
+      data-category="left"
+      class="facet rounded-full border border-zinc-300 px-3 py-1 text-sm dark:border-zinc-600">
+      Left bank
+    </button>
+  </div>
+
+  <div
+    data-component="StoreLocator"
+    data-option-fit-on-update
+    class="grid h-[500px] grid-cols-1 overflow-hidden rounded-lg border border-zinc-200 md:grid-cols-[minmax(0,20rem)_1fr] dark:border-zinc-700">
+
+    <ul
+      data-ref="list"
+      class="divide-y divide-zinc-200 overflow-y-auto bg-white dark:divide-zinc-700 dark:bg-zinc-900">
+      {% for store in stores %}
+        <li
+          data-component="StoreLocatorItem"
+          data-option-id="{{ store.id }}"
+          data-option-lng-lat="{{ store.lngLat|json_encode }}"
+          data-category="{{ store.bank }}">
+          <button
+            type="button"
+            data-ref="select"
+            class="block w-full px-4 py-3 text-left hover:bg-zinc-50 dark:hover:bg-zinc-800">
+            <span class="name block font-semibold">{{ store.name }}</span>
+            <span class="mt-0.5 block text-sm text-zinc-500 dark:text-zinc-400">
+              {{ store.address }}
+            </span>
+          </button>
+          <template>
+            <h2 class="text-xl font-bold">{{ store.name }}</h2>
+            <p class="mt-4 text-sm">{{ store.address }}</p>
+          </template>
+        </li>
+      {% endfor %}
+    </ul>
+
+    <div
+      data-component="MapboxMap"
+      data-option-access-token="pk.eyJ1IjoiYWdlbmNlc3R1ZGlvbWV0YSIsImEiOiJjbXM5NTBycHMwa2Z4MndxeW02YndscmQyIn0.UitMikKpq-TRJOXM-rBcMg"
+      data-option-zoom="5"
+      data-option-center="[2.35, 48.86]"
+      data-option-map-options='{"style":"mapbox://styles/mapbox/streets-v12"}'
+      class="h-full min-h-[300px] w-full">
+      <div data-ref="container" class="h-full w-full"></div>
+
+      <div
+        hidden
+        data-component="MapboxCluster"
+        data-option-cluster-radius="60"
+        data-option-clusters-paint='{ "circle-color": "#7c3aed", "circle-radius": 20 }'
+        data-option-cluster-count-paint='{ "text-color": "#ffffff" }'
+        data-option-unclustered-point-paint='{ "circle-color": "#7c3aed", "circle-radius": 7, "circle-stroke-width": 2, "circle-stroke-color": "#ffffff" }'></div>
+    </div>
+  </div>
+
+  <dialog
+    id="store-panel"
+    data-component="Action Dialog"
+    data-on:cancel.prevent="Dialog.close()"
+    data-on:click="event.target === $el && Dialog.close()"
+    class="fixed inset-0 m-0 h-full max-h-none w-full max-w-none overflow-hidden bg-transparent p-0">
+
+    <div
+      data-component="Action ViewTransition"
+      data-on:click="Dialog(#store-panel)->target.close()"
+      data-option-view-transition-name="store-panel-backdrop"
+      data-option-leave-to="opacity-0"
+      class="fixed inset-0 bg-black/50 opacity-0"></div>
+
+    <div
+      data-component="ViewTransition"
+      data-option-view-transition-name="store-panel-panel"
+      data-option-leave-to="translate-x-full opacity-0"
+      class="absolute inset-y-0 right-0 w-96 max-w-full translate-x-full overflow-y-auto bg-white p-8 text-black opacity-0 shadow-2xl">
+      <button
+        type="button"
+        data-component="Action"
+        data-on:click="Dialog(#store-panel)->target.close()"
+        class="mb-6 inline-flex items-center gap-1 border-b border-current text-sm">
+        Close
+      </button>
+      <div id="store-panel-content"></div>
+    </div>
+  </dialog>
+</div>
+
+<style>
+  [data-component='StoreLocatorItem']:not([data-in-bounds]) {
+    display: none;
+  }
+
+  [data-component='StoreLocatorItem'][data-active] > button {
+    background-color: #f5f3ff;
+  }
+  [data-component='StoreLocatorItem'][data-active] .name {
+    color: #6d28d9;
+  }
+  html.dark [data-component='StoreLocatorItem'][data-active] > button {
+    background-color: #2e1065;
+  }
+  html.dark [data-component='StoreLocatorItem'][data-active] .name {
+    color: #a78bfa;
+  }
+
+  .facet[data-active] {
+    background-color: #7c3aed;
+    border-color: #7c3aed;
+    color: #ffffff;
+  }
+
+  dialog::backdrop {
+    background: transparent;
+  }
+
+  ::view-transition-group(store-panel-panel) {
+    z-index: 2;
+  }
+  ::view-transition-group(store-panel-backdrop) {
+    z-index: 1;
+  }
+
+  @keyframes store-panel-slide-in {
+    from {
+      transform: translateX(100%);
+    }
+  }
+  @keyframes store-panel-slide-out {
+    to {
+      transform: translateX(100%);
+    }
+  }
+  ::view-transition-new(store-panel-panel) {
+    animation: 300ms ease-out both store-panel-slide-in;
+  }
+  ::view-transition-old(store-panel-panel) {
+    animation: 300ms ease-in both store-panel-slide-out;
+  }
+
+  @keyframes store-panel-fade-in {
+    from {
+      opacity: 0;
+    }
+  }
+  @keyframes store-panel-fade-out {
+    to {
+      opacity: 0;
+    }
+  }
+  ::view-transition-new(store-panel-backdrop) {
+    animation: 300ms ease-out both store-panel-fade-in;
+  }
+  ::view-transition-old(store-panel-backdrop) {
+    animation: 300ms ease-in both store-panel-fade-out;
+  }
+</style>

--- a/packages/tests/MapboxMap/MapboxCluster.spec.ts
+++ b/packages/tests/MapboxMap/MapboxCluster.spec.ts
@@ -194,6 +194,56 @@ describe('MapboxCluster component', () => {
     expect(mockMap.easeTo).not.toHaveBeenCalled();
   });
 
+  it('should default to an empty FeatureCollection source when no data is authored', async () => {
+    // No `data` URL and no `geojson` ref: the source must still be created with
+    // an empty FeatureCollection so a coordinator can drive it via `setData`.
+    const { instance, mockMap } = createCluster({ 'data-option-data': '' });
+
+    vi.useFakeTimers();
+    instance.$mount();
+    await vi.advanceTimersByTimeAsync(100);
+    vi.useRealTimers();
+
+    const sourceId = (instance as any).__getId('source');
+    expect(mockMap.addSource).toHaveBeenCalledWith(
+      sourceId,
+      expect.objectContaining({
+        type: 'geojson',
+        cluster: true,
+        data: { type: 'FeatureCollection', features: [] },
+      }),
+    );
+  });
+
+  it('should replace the live source data through setData', async () => {
+    const { instance, mockMap } = createCluster();
+
+    vi.useFakeTimers();
+    instance.$mount();
+    await vi.advanceTimersByTimeAsync(100);
+    vi.useRealTimers();
+
+    const sourceId = (instance as any).__getId('source');
+    const source = mockMap.getSource(sourceId);
+    const nextData = {
+      type: 'FeatureCollection',
+      features: [
+        { type: 'Feature', geometry: { type: 'Point', coordinates: [9, 9] }, properties: { id: '1' } },
+      ],
+    };
+
+    instance.setData(nextData as any);
+
+    expect(source.setData).toHaveBeenCalledWith(nextData);
+    expect(source.data).toBe(nextData);
+  });
+
+  it('should not throw when setData is called before mount (no source yet)', () => {
+    const { instance } = createCluster();
+    // Never mounted: the source does not exist. setData must be a safe no-op.
+    expect(() => instance.setData({ type: 'FeatureCollection', features: [] } as any)).not.toThrow();
+  });
+
   it('should remove the three layers and the source on destroy', async () => {
     const { instance, mockMap } = createCluster();
 

--- a/packages/tests/MapboxMap/MapboxGeocoder.spec.ts
+++ b/packages/tests/MapboxMap/MapboxGeocoder.spec.ts
@@ -129,4 +129,23 @@ describe('MapboxGeocoder component', () => {
 
     expect(instance.control).toBe(instance.control);
   });
+
+  it('should re-emit the control `result` event as a component `result` event', async () => {
+    const { instance } = createGeocoder();
+
+    await mountAndFlush(instance);
+
+    const result = vi.fn();
+    instance.$on('result', result);
+
+    const payload = { center: [1, 2], bbox: [0, 0, 3, 3] };
+    // The mocked control captures its `result` handlers; fire one as the real
+    // control would when a suggestion is picked.
+    (instance.control as unknown as { fire(type: string, event: unknown): void }).fire('result', {
+      result: payload,
+    });
+
+    expect(result).toHaveBeenCalledTimes(1);
+    expect(result.mock.calls[0][0].detail[0]).toBe(payload);
+  });
 });

--- a/packages/tests/MapboxMap/StoreLocator.spec.ts
+++ b/packages/tests/MapboxMap/StoreLocator.spec.ts
@@ -49,7 +49,14 @@ function fakeItem(id: string, lngLat: [number, number]) {
  */
 function createStoreLocator(
   items: Array<{ id: string; lngLat: [number, number] }>,
-  options: { attrs?: Record<string, string>; geocoder?: boolean } = {},
+  options: {
+    attrs?: Record<string, string>;
+    geocoder?: boolean;
+    // Simulate a geocoder that mounts *after* the cluster: the `geocoder` getter
+    // returns `undefined` for the first N reads (attempts), then the mock. Lets a
+    // test drive the cluster-before-geocoder wiring race.
+    geocoderReadyAfter?: number;
+  } = {},
 ) {
   const listItems = items.map((item) =>
     h('li', { 'data-component': 'StoreLocatorItem', 'data-option-id': item.id }, [
@@ -98,18 +105,30 @@ function createStoreLocator(
       return off(clusterHandlers[event], callback);
     },
   };
-  const mockGeocoder = options.geocoder
-    ? {
-        $on(event: string, callback: (event: unknown) => void) {
-          (geocoderHandlers[event] ??= []).push(callback);
-          return off(geocoderHandlers[event], callback);
-        },
-      }
-    : undefined;
+  const mockGeocoder =
+    options.geocoder || options.geocoderReadyAfter !== undefined
+      ? {
+          $on(event: string, callback: (event: unknown) => void) {
+            (geocoderHandlers[event] ??= []).push(callback);
+            return off(geocoderHandlers[event], callback);
+          },
+        }
+      : undefined;
+
+  // When `geocoderReadyAfter` is set, the geocoder is not queryable yet: return
+  // `undefined` for the first N reads (mimicking an async mount that lands after
+  // the cluster's), then hand out the mock.
+  let geocoderReads = 0;
+  function geocoderGetter() {
+    if (options.geocoderReadyAfter !== undefined && geocoderReads++ < options.geocoderReadyAfter) {
+      return undefined;
+    }
+    return mockGeocoder;
+  }
 
   Object.defineProperty(instance, 'mapboxMap', { get: () => mockMapbox, configurable: true });
   Object.defineProperty(instance, 'cluster', { get: () => mockCluster, configurable: true });
-  Object.defineProperty(instance, 'geocoder', { get: () => mockGeocoder, configurable: true });
+  Object.defineProperty(instance, 'geocoder', { get: geocoderGetter, configurable: true });
 
   return {
     instance,
@@ -530,6 +549,28 @@ describe('StoreLocator component', () => {
       ctx.fireFeatureClick({ properties: { id: 'b' } });
       expect(select).toHaveBeenCalledTimes(1);
       expect(ctx.mockCluster.setData).toHaveBeenCalled();
+    });
+
+    it('keeps polling for the geocoder even after the cluster is wired first', async () => {
+      // The cluster is mounted and queryable immediately, but the geocoder only
+      // becomes queryable a couple of ticks later. The coordinator must poll
+      // until BOTH children are wired — stopping as soon as the cluster is wired
+      // would leave the geocoder's `result` listener unattached.
+      const ctx = createStoreLocator([{ id: 'a', lngLat: [1, 1] }], { geocoderReadyAfter: 2 });
+      await mountAndLoad(ctx);
+
+      // The cluster wired on the first attempt...
+      expect((ctx.instance as any).__clusterWired).toBe(true);
+      // ...and the poll continued until the late geocoder was wired too.
+      expect((ctx.instance as any).__geocoderWired).toBe(true);
+
+      // Proof the geocoder listener is live: a result frames the map.
+      ctx.mockMap.fitBounds.mockClear();
+      ctx.fireGeocoderResult({ bbox: [10, 20, 30, 40] });
+      expect(ctx.mockMap.fitBounds).toHaveBeenCalledWith([
+        [10, 20],
+        [30, 40],
+      ]);
     });
   });
 

--- a/packages/tests/MapboxMap/StoreLocator.spec.ts
+++ b/packages/tests/MapboxMap/StoreLocator.spec.ts
@@ -1,0 +1,614 @@
+import { describe, it, expect, vi } from 'vitest';
+// Importing the mock first registers the `mapbox-gl` module mock before the
+// package (and its real `mapbox-gl` dependency) is imported below.
+import { MockMap } from './mock-mapbox-gl.js';
+import { h } from '#test-utils';
+import { StoreLocator, StoreLocatorItem } from '@studiometa/ui-mapbox';
+
+/**
+ * A minimal `StoreLocatorItem` stand-in used to exercise the coordinator's
+ * registry, coalesced sync and derived data without mounting a real component.
+ *
+ * It exposes exactly the surface the coordinator touches: `id`, `lngLat`, an
+ * `$el` (moved around by `__reorderList`) and the `setInBounds` / `setActive`
+ * state setters (spied and reflected as data-attributes, mirroring the real
+ * component so DOM assertions stay meaningful).
+ */
+function fakeItem(id: string, lngLat: [number, number]) {
+  const el = h('li', { 'data-component': 'StoreLocatorItem' }) as HTMLElement;
+  return {
+    id,
+    lngLat,
+    $el: el,
+    setInBounds: vi.fn((value: boolean) => el.toggleAttribute('data-in-bounds', value)),
+    setActive: vi.fn((value: boolean) => {
+      el.toggleAttribute('data-active', value);
+      if (value) {
+        el.setAttribute('aria-current', 'true');
+      } else {
+        el.removeAttribute('aria-current');
+      }
+    }),
+  };
+}
+
+/**
+ * Build a `StoreLocator` with a sidebar list of `StoreLocatorItem`s and a mocked
+ * map plumbing.
+ *
+ * Like the other `@studiometa/ui-mapbox` child specs (which mock the parent
+ * `MapboxMap` rather than mounting a real one), the map, cluster and geocoder and
+ * their `map-load` / `feature-click` / `result` events are injected through the
+ * `mapboxMap`, `cluster` and `geocoder` getters. This keeps the test deterministic
+ * and free of the real `mapbox-gl` (which throws in a headless WebGL-less
+ * environment).
+ *
+ * The child `$on` doubles return real unsubscribe callbacks, so the coordinator's
+ * `destroyed()` teardown can be exercised: after destroy, firing an event finds no
+ * handler left.
+ */
+function createStoreLocator(
+  items: Array<{ id: string; lngLat: [number, number] }>,
+  options: { attrs?: Record<string, string>; geocoder?: boolean } = {},
+) {
+  const listItems = items.map((item) =>
+    h('li', { 'data-component': 'StoreLocatorItem', 'data-option-id': item.id }, [
+      h('button', { 'data-ref': 'select' }, [item.id]),
+    ]),
+  );
+  listItems.forEach((el, index) => {
+    el.setAttribute('data-option-lng-lat', JSON.stringify(items[index].lngLat));
+  });
+
+  const root = h('div', { 'data-component': 'StoreLocator', ...(options.attrs ?? {}) }, [
+    h('ul', { 'data-ref': 'list' }, listItems),
+  ]);
+  const instance = new StoreLocator(root);
+
+  const mockMap = new MockMap();
+  const mapLoadHandlers: Array<() => void> = [];
+  const clusterHandlers: Record<string, Array<(event: unknown) => void>> = {};
+  const geocoderHandlers: Record<string, Array<(event: unknown) => void>> = {};
+
+  function off(bucket: Array<(event: unknown) => void>, callback: (event: unknown) => void) {
+    return () => {
+      const index = bucket.indexOf(callback);
+      if (index > -1) bucket.splice(index, 1);
+    };
+  }
+
+  const mockMapbox = {
+    isLoaded: false,
+    map: mockMap,
+    $on(event: string, callback: () => void) {
+      if (event === 'map-load') {
+        mapLoadHandlers.push(callback);
+        return off(mapLoadHandlers as any, callback as any);
+      }
+      return () => {};
+    },
+  };
+  const mockCluster = {
+    setData: vi.fn(),
+    $on(event: string, callback: (event: unknown) => void) {
+      (clusterHandlers[event] ??= []).push(callback);
+      return off(clusterHandlers[event], callback);
+    },
+  };
+  const mockGeocoder = options.geocoder
+    ? {
+        $on(event: string, callback: (event: unknown) => void) {
+          (geocoderHandlers[event] ??= []).push(callback);
+          return off(geocoderHandlers[event], callback);
+        },
+      }
+    : undefined;
+
+  Object.defineProperty(instance, 'mapboxMap', { get: () => mockMapbox, configurable: true });
+  Object.defineProperty(instance, 'cluster', { get: () => mockCluster, configurable: true });
+  Object.defineProperty(instance, 'geocoder', { get: () => mockGeocoder, configurable: true });
+
+  return {
+    instance,
+    mockMap: mockMap as unknown as MockMap,
+    mockCluster,
+    items: () => instance.$query<StoreLocatorItem>('StoreLocatorItem'),
+    item: (id: string) =>
+      instance.$query<StoreLocatorItem>('StoreLocatorItem').find((entry) => entry.id === id)!,
+    fireLoad() {
+      mapLoadHandlers.forEach((callback) => callback());
+    },
+    fireMoveEnd() {
+      mockMap.fire('moveend');
+    },
+    fireFeatureClick(feature: unknown) {
+      (clusterHandlers['feature-click'] ?? []).forEach((callback) =>
+        callback({ detail: [feature, {}] }),
+      );
+    },
+    fireGeocoderResult(result: unknown) {
+      (geocoderHandlers['result'] ?? []).forEach((callback) => callback({ detail: [result] }));
+    },
+  };
+}
+
+/**
+ * Mount the component, let the js-toolkit timer-based mount settle, then simulate
+ * the map load so the coordinator wires itself. Leaves real timers active.
+ */
+async function mountAndLoad(ctx: ReturnType<typeof createStoreLocator>) {
+  vi.useFakeTimers();
+  ctx.instance.$mount();
+  await vi.advanceTimersByTimeAsync(100);
+  ctx.fireLoad();
+  await vi.advanceTimersByTimeAsync(100);
+  vi.useRealTimers();
+}
+
+/**
+ * Configure the mock viewport so only the given longitudes are considered inside
+ * bounds, letting a test drive the in-bounds axis independently of the map data.
+ */
+function boundsContainingLng(ctx: ReturnType<typeof createStoreLocator>, lngs: number[]) {
+  ctx.mockMap.getBounds = vi.fn(() => ({
+    contains: (lngLat: [number, number]) => lngs.includes(lngLat[0]),
+  })) as any;
+}
+
+/**
+ * Read the current DOM order of item ids inside the `list` ref.
+ */
+function listOrder(ctx: ReturnType<typeof createStoreLocator>): string[] {
+  const list = (ctx.instance as any).$refs.list as HTMLElement;
+  return [...list.children]
+    .map((child) => child.getAttribute('data-option-id'))
+    .filter((id): id is string => id !== null);
+}
+
+describe('StoreLocator component', () => {
+  // --- 1. Registry & derived data ------------------------------------------
+  describe('registry & derived FeatureCollection', () => {
+    it('derives one feature per registered item with id + [lng,lat] coordinates', async () => {
+      const ctx = createStoreLocator([
+        { id: 'a', lngLat: [1, 1] },
+        { id: 'b', lngLat: [2, 2] },
+      ]);
+      await mountAndLoad(ctx);
+
+      expect(ctx.items()).toHaveLength(2);
+
+      const { features } = ctx.instance.featureCollection;
+      expect(features).toHaveLength(2);
+      expect(features[0]).toMatchObject({
+        type: 'Feature',
+        geometry: { type: 'Point', coordinates: [1, 1] },
+        properties: { id: 'a' },
+      });
+      expect(features.map((feature) => feature.properties.id)).toEqual(['a', 'b']);
+    });
+
+    it('removes a feature when an item is unregistered', async () => {
+      const ctx = createStoreLocator([
+        { id: 'a', lngLat: [1, 1] },
+        { id: 'b', lngLat: [2, 2] },
+      ]);
+      await mountAndLoad(ctx);
+
+      ctx.instance.unregisterItem(ctx.item('a'));
+
+      expect(ctx.instance.featureCollection.features.map((f) => f.properties.id)).toEqual(['b']);
+    });
+
+    it('treats a duplicate register of the same item as a no-op', async () => {
+      const ctx = createStoreLocator([{ id: 'a', lngLat: [1, 1] }]);
+      await mountAndLoad(ctx);
+
+      const itemA = ctx.item('a');
+      ctx.instance.registerItem(itemA);
+      ctx.instance.registerItem(itemA);
+
+      expect(ctx.instance.featureCollection.features).toHaveLength(1);
+    });
+
+    it('pushes the derived data to the cluster once the item set is registered and loaded', async () => {
+      const ctx = createStoreLocator([{ id: 'a', lngLat: [1, 1] }]);
+      await mountAndLoad(ctx);
+
+      expect(ctx.mockCluster.setData).toHaveBeenCalled();
+      const lastCall = ctx.mockCluster.setData.mock.calls.at(-1)?.[0] as { features: unknown[] };
+      expect(lastCall.features).toHaveLength(1);
+    });
+  });
+
+  // --- 2. Debounced / coalesced sync (the Fetch-swap case) -----------------
+  describe('coalesced item-set sync', () => {
+    it('calls cluster.setData ONCE for a batch registered across the same tick', async () => {
+      const ctx = createStoreLocator([{ id: 'a', lngLat: [1, 1] }]);
+      await mountAndLoad(ctx);
+
+      ctx.mockCluster.setData.mockClear();
+
+      vi.useFakeTimers();
+      // Simulate a Fetch swapping the list: a whole batch registers in one tick.
+      const batch = [
+        fakeItem('x', [3, 3]),
+        fakeItem('y', [4, 4]),
+        fakeItem('z', [5, 5]),
+      ];
+      batch.forEach((item) => ctx.instance.registerItem(item as unknown as StoreLocatorItem));
+      // Nothing has flushed yet: the sync is debounced.
+      expect(ctx.mockCluster.setData).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(100);
+      vi.useRealTimers();
+
+      expect(ctx.mockCluster.setData).toHaveBeenCalledTimes(1);
+      const data = ctx.mockCluster.setData.mock.calls[0][0] as { features: Array<{ properties: { id: string } }> };
+      expect(data.features.map((f) => f.properties.id)).toEqual(['a', 'x', 'y', 'z']);
+    });
+
+    it('ends a swap (unregister old + register new) with the new set on the map', async () => {
+      const ctx = createStoreLocator([
+        { id: 'a', lngLat: [1, 1] },
+        { id: 'b', lngLat: [2, 2] },
+      ]);
+      await mountAndLoad(ctx);
+
+      ctx.mockCluster.setData.mockClear();
+
+      vi.useFakeTimers();
+      // Swap: drop the two mounted items and register a fresh batch in one tick.
+      ctx.instance.unregisterItem(ctx.item('a'));
+      ctx.instance.unregisterItem(ctx.item('b'));
+      const fresh = [fakeItem('c', [7, 7]), fakeItem('d', [8, 8])];
+      fresh.forEach((item) => ctx.instance.registerItem(item as unknown as StoreLocatorItem));
+
+      await vi.advanceTimersByTimeAsync(100);
+      vi.useRealTimers();
+
+      expect(ctx.mockCluster.setData).toHaveBeenCalledTimes(1);
+      const data = ctx.mockCluster.setData.mock.calls[0][0] as { features: Array<{ properties: { id: string } }> };
+      expect(data.features.map((f) => f.properties.id)).toEqual(['c', 'd']);
+    });
+  });
+
+  // --- 3. Two-axis independence (registered vs in-bounds) ------------------
+  describe('two-axis independence: in-bounds filtering never rebuilds map data', () => {
+    it('reflects data-in-bounds only for in-view items and emits filter with them', async () => {
+      const ctx = createStoreLocator([
+        { id: 'a', lngLat: [1, 1] },
+        { id: 'b', lngLat: [2, 2] },
+        { id: 'c', lngLat: [3, 3] },
+      ]);
+      await mountAndLoad(ctx);
+
+      // Only `a` and `c` fall inside the viewport.
+      boundsContainingLng(ctx, [1, 3]);
+
+      const filter = vi.fn();
+      ctx.instance.$on('filter', filter);
+
+      ctx.fireMoveEnd();
+
+      expect(ctx.item('a').$el.hasAttribute('data-in-bounds')).toBe(true);
+      expect(ctx.item('b').$el.hasAttribute('data-in-bounds')).toBe(false);
+      expect(ctx.item('c').$el.hasAttribute('data-in-bounds')).toBe(true);
+
+      expect(filter).toHaveBeenCalledTimes(1);
+      const inView = filter.mock.calls[0][0].detail[0] as StoreLocatorItem[];
+      expect(inView.map((entry) => entry.id).sort()).toEqual(['a', 'c']);
+    });
+
+    it('does NOT call cluster.setData on a moveend (pan must not rebuild map data)', async () => {
+      const ctx = createStoreLocator([
+        { id: 'a', lngLat: [1, 1] },
+        { id: 'b', lngLat: [2, 2] },
+      ]);
+      await mountAndLoad(ctx);
+
+      boundsContainingLng(ctx, [1]);
+
+      const before = ctx.mockCluster.setData.mock.calls.length;
+      ctx.fireMoveEnd();
+      ctx.fireMoveEnd();
+      const after = ctx.mockCluster.setData.mock.calls.length;
+
+      // The critical correctness guarantee: panning recomputes the in-view list
+      // but never pushes data to the source again.
+      expect(after).toBe(before);
+    });
+  });
+
+  // --- 4. Distance sort ----------------------------------------------------
+  describe('distance sort', () => {
+    it('orders the filter payload and the list DOM ascending by distance to center (sort ON)', async () => {
+      // Center is MockLngLat(0,0); planar distances: b(1,1) < c(2,2) < a(3,3).
+      const ctx = createStoreLocator([
+        { id: 'a', lngLat: [3, 3] },
+        { id: 'b', lngLat: [1, 1] },
+        { id: 'c', lngLat: [2, 2] },
+      ]);
+      await mountAndLoad(ctx);
+
+      const filter = vi.fn();
+      ctx.instance.$on('filter', filter);
+
+      ctx.fireMoveEnd();
+
+      const inView = filter.mock.calls[0][0].detail[0] as StoreLocatorItem[];
+      expect(inView.map((entry) => entry.id)).toEqual(['b', 'c', 'a']);
+      expect(listOrder(ctx)).toEqual(['b', 'c', 'a']);
+    });
+
+    it('preserves registration/DOM order when data-option-no-sort is set', async () => {
+      const ctx = createStoreLocator(
+        [
+          { id: 'a', lngLat: [3, 3] },
+          { id: 'b', lngLat: [1, 1] },
+          { id: 'c', lngLat: [2, 2] },
+        ],
+        { attrs: { 'data-option-no-sort': '' } },
+      );
+      await mountAndLoad(ctx);
+
+      const filter = vi.fn();
+      ctx.instance.$on('filter', filter);
+
+      ctx.fireMoveEnd();
+
+      const inView = filter.mock.calls[0][0].detail[0] as StoreLocatorItem[];
+      expect(inView.map((entry) => entry.id)).toEqual(['a', 'b', 'c']);
+      expect(listOrder(ctx)).toEqual(['a', 'b', 'c']);
+    });
+  });
+
+  // --- 5. Selection --------------------------------------------------------
+  describe('selection', () => {
+    it('flies to the item, marks it active/aria-current and emits select', async () => {
+      const ctx = createStoreLocator([{ id: 'a', lngLat: [3, 4] }]);
+      await mountAndLoad(ctx);
+
+      const select = vi.fn();
+      ctx.instance.$on('select', select);
+
+      const itemA = ctx.item('a');
+      ctx.instance.selectItem(itemA);
+
+      expect(ctx.mockMap.flyTo).toHaveBeenCalledWith({ center: [3, 4], zoom: 14 });
+      expect(itemA.$el.hasAttribute('data-active')).toBe(true);
+      expect(itemA.$el.getAttribute('aria-current')).toBe('true');
+      expect(select).toHaveBeenCalledTimes(1);
+      expect(select.mock.calls[0][0].detail[0]).toBe(itemA);
+    });
+
+    it('honors a custom data-option-item-zoom-level on fly-to', async () => {
+      const ctx = createStoreLocator([{ id: 'a', lngLat: [3, 4] }], {
+        attrs: { 'data-option-item-zoom-level': '17' },
+      });
+      await mountAndLoad(ctx);
+
+      ctx.instance.selectItem(ctx.item('a'));
+      expect(ctx.mockMap.flyTo).toHaveBeenCalledWith({ center: [3, 4], zoom: 17 });
+    });
+
+    it('deactivates the previously selected item when a second is selected', async () => {
+      const ctx = createStoreLocator([
+        { id: 'a', lngLat: [1, 1] },
+        { id: 'b', lngLat: [2, 2] },
+      ]);
+      await mountAndLoad(ctx);
+
+      const itemA = ctx.item('a');
+      const itemB = ctx.item('b');
+      ctx.instance.selectItem(itemA);
+      ctx.instance.selectItem(itemB);
+
+      expect(itemA.$el.hasAttribute('data-active')).toBe(false);
+      expect(itemA.$el.hasAttribute('aria-current')).toBe(false);
+      expect(itemB.$el.hasAttribute('data-active')).toBe(true);
+      expect(itemB.$el.getAttribute('aria-current')).toBe('true');
+    });
+
+    it('clears the active state and emits deselect on deselect()', async () => {
+      const ctx = createStoreLocator([{ id: 'a', lngLat: [1, 1] }]);
+      await mountAndLoad(ctx);
+
+      const deselect = vi.fn();
+      ctx.instance.$on('deselect', deselect);
+
+      const itemA = ctx.item('a');
+      ctx.instance.selectItem(itemA);
+      ctx.instance.deselect();
+
+      expect(itemA.$el.hasAttribute('data-active')).toBe(false);
+      expect(itemA.$el.hasAttribute('aria-current')).toBe(false);
+      expect(deselect).toHaveBeenCalledTimes(1);
+      expect((ctx.instance as any).__selected).toBeUndefined();
+    });
+
+    it('clears the internal selection when the selected item is unregistered', async () => {
+      const ctx = createStoreLocator([{ id: 'a', lngLat: [1, 1] }]);
+      await mountAndLoad(ctx);
+
+      const itemA = ctx.item('a');
+      ctx.instance.selectItem(itemA);
+      expect((ctx.instance as any).__selected).toBe(itemA);
+
+      ctx.instance.unregisterItem(itemA);
+      expect((ctx.instance as any).__selected).toBeUndefined();
+    });
+  });
+
+  // --- 6. Cluster feature-click -> select by id ----------------------------
+  describe('cluster feature-click -> select by id', () => {
+    it('selects the item whose feature id matches a string id', async () => {
+      const ctx = createStoreLocator([
+        { id: 'a', lngLat: [1, 1] },
+        { id: 'b', lngLat: [2, 2] },
+      ]);
+      await mountAndLoad(ctx);
+
+      const select = vi.fn();
+      ctx.instance.$on('select', select);
+
+      ctx.fireFeatureClick({ properties: { id: 'b' } });
+
+      const itemB = ctx.item('b');
+      expect(itemB.$el.hasAttribute('data-active')).toBe(true);
+      expect(ctx.mockMap.flyTo).toHaveBeenCalledWith({ center: [2, 2], zoom: 14 });
+      expect(select.mock.calls.at(-1)?.[0].detail[0]).toBe(itemB);
+    });
+
+    it('coerces a numeric feature id with String() before matching', async () => {
+      const ctx = createStoreLocator([{ id: '42', lngLat: [9, 9] }]);
+      await mountAndLoad(ctx);
+
+      const select = vi.fn();
+      ctx.instance.$on('select', select);
+
+      // Numeric id must still match the string id '42' via String(id).
+      ctx.fireFeatureClick({ properties: { id: 42 } });
+
+      expect(ctx.item('42').$el.hasAttribute('data-active')).toBe(true);
+      expect(select).toHaveBeenCalledTimes(1);
+    });
+
+    it('does nothing (no select, no throw) for an unknown feature id', async () => {
+      const ctx = createStoreLocator([{ id: 'a', lngLat: [1, 1] }]);
+      await mountAndLoad(ctx);
+
+      const select = vi.fn();
+      ctx.instance.$on('select', select);
+
+      expect(() => ctx.fireFeatureClick({ properties: { id: 'nope' } })).not.toThrow();
+      expect(select).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when the feature or its id is missing', async () => {
+      const ctx = createStoreLocator([{ id: 'a', lngLat: [1, 1] }]);
+      await mountAndLoad(ctx);
+
+      const select = vi.fn();
+      ctx.instance.$on('select', select);
+
+      expect(() => ctx.fireFeatureClick(undefined)).not.toThrow();
+      expect(() => ctx.fireFeatureClick({ properties: {} })).not.toThrow();
+      expect(() => ctx.fireFeatureClick({})).not.toThrow();
+      expect(select).not.toHaveBeenCalled();
+    });
+  });
+
+  // --- 7. Geocoder result --------------------------------------------------
+  describe('geocoder result', () => {
+    it('fits the map to the bbox when the result has one', async () => {
+      const ctx = createStoreLocator([{ id: 'a', lngLat: [1, 1] }], { geocoder: true });
+      await mountAndLoad(ctx);
+
+      ctx.mockMap.fitBounds.mockClear();
+      ctx.fireGeocoderResult({ bbox: [10, 20, 30, 40] });
+
+      expect(ctx.mockMap.fitBounds).toHaveBeenCalledWith([
+        [10, 20],
+        [30, 40],
+      ]);
+    });
+
+    it('flies to the center when the result has no bbox', async () => {
+      const ctx = createStoreLocator([{ id: 'a', lngLat: [1, 1] }], { geocoder: true });
+      await mountAndLoad(ctx);
+
+      ctx.mockMap.flyTo.mockClear();
+      ctx.fireGeocoderResult({ center: [5, 6] });
+
+      expect(ctx.mockMap.flyTo).toHaveBeenCalledWith({ center: [5, 6] });
+    });
+
+    it('does nothing and does not throw on a missing/empty result', async () => {
+      const ctx = createStoreLocator([{ id: 'a', lngLat: [1, 1] }], { geocoder: true });
+      await mountAndLoad(ctx);
+
+      ctx.mockMap.fitBounds.mockClear();
+      ctx.mockMap.flyTo.mockClear();
+
+      expect(() => ctx.fireGeocoderResult(undefined)).not.toThrow();
+      expect(() => ctx.fireGeocoderResult(null)).not.toThrow();
+      expect(() => ctx.fireGeocoderResult({})).not.toThrow();
+      expect(ctx.mockMap.fitBounds).not.toHaveBeenCalled();
+      expect(ctx.mockMap.flyTo).not.toHaveBeenCalled();
+    });
+  });
+
+  // --- 8. fitOnUpdate ------------------------------------------------------
+  describe('fitOnUpdate', () => {
+    it('fits the map to the item extent on an item-set change when enabled', async () => {
+      const ctx = createStoreLocator(
+        [
+          { id: 'a', lngLat: [1, 2] },
+          { id: 'b', lngLat: [3, 4] },
+          { id: 'c', lngLat: [5, 0] },
+        ],
+        { attrs: { 'data-option-fit-on-update': '' } },
+      );
+      await mountAndLoad(ctx);
+
+      expect(ctx.mockMap.fitBounds).toHaveBeenCalledWith(
+        [
+          [1, 0],
+          [5, 4],
+        ],
+        { padding: 40 },
+      );
+    });
+
+    it('does not fit the map on an item-set change when disabled', async () => {
+      const ctx = createStoreLocator([
+        { id: 'a', lngLat: [1, 2] },
+        { id: 'b', lngLat: [3, 4] },
+      ]);
+      await mountAndLoad(ctx);
+
+      expect(ctx.mockMap.fitBounds).not.toHaveBeenCalled();
+    });
+  });
+
+  // --- 9. Lifecycle --------------------------------------------------------
+  describe('lifecycle teardown', () => {
+    it('detaches listeners and clears the registry on destroy', async () => {
+      const ctx = createStoreLocator(
+        [
+          { id: 'a', lngLat: [1, 1] },
+          { id: 'b', lngLat: [2, 2] },
+        ],
+        { geocoder: true },
+      );
+      await mountAndLoad(ctx);
+
+      const filter = vi.fn();
+      const select = vi.fn();
+      ctx.instance.$on('filter', filter);
+      ctx.instance.$on('select', select);
+
+      vi.useFakeTimers();
+      ctx.instance.$destroy();
+      await vi.advanceTimersByTimeAsync(100);
+      vi.useRealTimers();
+
+      // Registry cleared.
+      expect((ctx.instance as any).__items).toEqual([]);
+      expect((ctx.instance as any).__selected).toBeUndefined();
+      expect(ctx.instance.isLoaded).toBe(false);
+
+      // Detached listeners: subsequent events are inert.
+      ctx.fireMoveEnd();
+      ctx.fireFeatureClick({ properties: { id: 'a' } });
+      ctx.mockMap.fitBounds.mockClear();
+      ctx.mockMap.flyTo.mockClear();
+      ctx.fireGeocoderResult({ center: [1, 1] });
+
+      expect(filter).not.toHaveBeenCalled();
+      expect(select).not.toHaveBeenCalled();
+      expect(ctx.mockMap.flyTo).not.toHaveBeenCalled();
+      expect(ctx.mockMap.fitBounds).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/tests/MapboxMap/StoreLocator.spec.ts
+++ b/packages/tests/MapboxMap/StoreLocator.spec.ts
@@ -89,6 +89,9 @@ function createStoreLocator(
     },
   };
   const mockCluster = {
+    // The coordinator only wires and feeds the cluster once it is fully mounted
+    // (its GeoJSON source is added from `mounted()`), so the mock advertises it.
+    $isMounted: true,
     setData: vi.fn(),
     $on(event: string, callback: (event: unknown) => void) {
       (clusterHandlers[event] ??= []).push(callback);
@@ -495,6 +498,38 @@ describe('StoreLocator component', () => {
       expect(() => ctx.fireFeatureClick({ properties: {} })).not.toThrow();
       expect(() => ctx.fireFeatureClick({})).not.toThrow();
       expect(select).not.toHaveBeenCalled();
+    });
+  });
+
+  // --- 6b. Deferred cluster wiring (async mount timing) --------------------
+  describe('deferred cluster wiring', () => {
+    it('does not wire the cluster until it is mounted, then wires it', async () => {
+      const ctx = createStoreLocator([
+        { id: 'a', lngLat: [1, 1] },
+        { id: 'b', lngLat: [2, 2] },
+      ]);
+      // The MapboxCluster is an async child of the map: it is queryable before
+      // its `mounted()` hook adds the GeoJSON source. Simulate that window.
+      ctx.mockCluster.$isMounted = false;
+      await mountAndLoad(ctx);
+
+      const select = vi.fn();
+      ctx.instance.$on('select', select);
+
+      // Not wired yet: a feature-click is ignored because pushing/wiring before
+      // the source exists would silently no-op.
+      expect((ctx.instance as any).__clusterWired).toBe(false);
+      ctx.fireFeatureClick({ properties: { id: 'b' } });
+      expect(select).not.toHaveBeenCalled();
+
+      // The cluster finishes mounting (source now added): wiring can proceed.
+      ctx.mockCluster.$isMounted = true;
+      (ctx.instance as any).__wireChildren();
+
+      expect((ctx.instance as any).__clusterWired).toBe(true);
+      ctx.fireFeatureClick({ properties: { id: 'b' } });
+      expect(select).toHaveBeenCalledTimes(1);
+      expect(ctx.mockCluster.setData).toHaveBeenCalled();
     });
   });
 

--- a/packages/tests/MapboxMap/StoreLocator.spec.ts
+++ b/packages/tests/MapboxMap/StoreLocator.spec.ts
@@ -647,6 +647,43 @@ describe('StoreLocator component', () => {
     });
   });
 
+  // --- 8b. Single initial sync (no duplicate on load) ----------------------
+  describe('initial load sync', () => {
+    it('runs the initial sync exactly ONCE when the cluster is already mounted at load', async () => {
+      // Regression: with the cluster mounted before `map-load`, `__wireChildren`
+      // used to also sync when wiring it, so `__handleMapLoad`'s own sync made the
+      // first `setData`, `fitBounds` and `filter` emission all fire TWICE. Each
+      // must happen exactly once.
+      const ctx = createStoreLocator(
+        [
+          { id: 'a', lngLat: [1, 2] },
+          { id: 'b', lngLat: [3, 4] },
+        ],
+        { attrs: { 'data-option-fit-on-update': '' } },
+      );
+
+      const filter = vi.fn();
+
+      vi.useFakeTimers();
+      ctx.instance.$mount();
+      // Let the mount-time registration debounce settle *before* load: it runs
+      // while `isLoaded` is still false, so it no-ops and cannot pollute the
+      // post-load counts. This isolates the wiring-vs-handleMapLoad double sync.
+      await vi.advanceTimersByTimeAsync(200);
+      expect(ctx.mockCluster.setData).not.toHaveBeenCalled();
+
+      // Listen before the load so the very first `filter` emission is counted.
+      ctx.instance.$on('filter', filter);
+      ctx.fireLoad();
+      await vi.advanceTimersByTimeAsync(200);
+      vi.useRealTimers();
+
+      expect(ctx.mockCluster.setData).toHaveBeenCalledTimes(1);
+      expect(ctx.mockMap.fitBounds).toHaveBeenCalledTimes(1);
+      expect(filter).toHaveBeenCalledTimes(1);
+    });
+  });
+
   // --- 9. Lifecycle --------------------------------------------------------
   describe('lifecycle teardown', () => {
     it('detaches listeners and clears the registry on destroy', async () => {

--- a/packages/tests/MapboxMap/StoreLocatorItem.spec.ts
+++ b/packages/tests/MapboxMap/StoreLocatorItem.spec.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi } from 'vitest';
+// Importing the mock first registers the `mapbox-gl` module mock before the
+// package (and its real `mapbox-gl` dependency) is imported below.
+import './mock-mapbox-gl.js';
+import { h } from '#test-utils';
+import { StoreLocatorItem } from '@studiometa/ui-mapbox';
+
+/**
+ * A minimal coordinator stand-in exposing only the surface the item touches.
+ */
+function fakeCoordinator() {
+  return {
+    registerItem: vi.fn(),
+    unregisterItem: vi.fn(),
+    selectItem: vi.fn(),
+  };
+}
+
+describe('StoreLocatorItem component', () => {
+  it('registers with the coordinator on mount', () => {
+    const el = h('li', {
+      'data-component': 'StoreLocatorItem',
+      'data-option-id': 'a',
+      'data-option-lng-lat': '[1,2]',
+    }) as HTMLElement;
+    const item = new StoreLocatorItem(el);
+    const coordinator = fakeCoordinator();
+    Object.defineProperty(item, 'storeLocator', { get: () => coordinator, configurable: true });
+
+    item.mounted();
+
+    expect(coordinator.registerItem).toHaveBeenCalledWith(item);
+  });
+
+  it('unregisters on destroy even after the element has been detached', () => {
+    const el = h('li', {
+      'data-component': 'StoreLocatorItem',
+      'data-option-id': 'a',
+      'data-option-lng-lat': '[1,2]',
+    }) as HTMLElement;
+    const item = new StoreLocatorItem(el);
+    const coordinator = fakeCoordinator();
+
+    // The coordinator resolves via `$closest` while the item is connected…
+    let resolved: ReturnType<typeof fakeCoordinator> | undefined = coordinator;
+    Object.defineProperty(item, 'storeLocator', { get: () => resolved, configurable: true });
+
+    item.mounted();
+    expect(coordinator.registerItem).toHaveBeenCalledWith(item);
+
+    // …but a `Fetch`/facet swap detaches the node first, so `$closest` (and thus
+    // the getter) would now return nothing. The cached reference must keep the
+    // unregister path working.
+    resolved = undefined;
+
+    item.destroyed();
+
+    expect(coordinator.unregisterItem).toHaveBeenCalledWith(item);
+  });
+});

--- a/packages/tests/MapboxMap/exports.spec.ts
+++ b/packages/tests/MapboxMap/exports.spec.ts
@@ -23,6 +23,8 @@ test('@studiometa/ui-mapbox exports', () => {
       "MapboxNavigationControl",
       "MapboxPopup",
       "MapboxSource",
+      "StoreLocator",
+      "StoreLocatorItem",
     ]
   `);
 

--- a/packages/tests/MapboxMap/mock-mapbox-gl.ts
+++ b/packages/tests/MapboxMap/mock-mapbox-gl.ts
@@ -1,5 +1,22 @@
 import { vi } from 'vitest';
 
+export class MockLngLat {
+  lng: number;
+  lat: number;
+
+  constructor(lng: number, lat: number) {
+    this.lng = lng;
+    this.lat = lat;
+  }
+
+  /**
+   * Rough planar distance, good enough for the `StoreLocator` distance sort.
+   */
+  distanceTo(other: MockLngLat) {
+    return Math.hypot(this.lng - other.lng, this.lat - other.lat);
+  }
+}
+
 export class MockMap {
   /**
    * Count how many `MockMap` instances have been constructed. Lets tests assert
@@ -68,6 +85,9 @@ export class MockMap {
     this._sources[id] = {
       ...source,
       getClusterExpansionZoom: vi.fn((_clusterId: number, cb: Function) => cb(null, 5)),
+      setData: vi.fn(function (this: any, data: any) {
+        this.data = data;
+      }),
     };
   });
   removeSource = vi.fn((id: string) => {
@@ -79,6 +99,20 @@ export class MockMap {
   queryRenderedFeatures = vi.fn(() => [] as any[]);
   getCanvas = vi.fn(() => ({ style: {} as Record<string, string> }));
   easeTo = vi.fn();
+  flyTo = vi.fn();
+  fitBounds = vi.fn();
+
+  /**
+   * Viewport bounds. `contains` defaults to `true`; override in a test to
+   * exercise the in-bounds vs out-of-bounds filtering of `StoreLocator`.
+   */
+  getBounds = vi.fn(() => ({ contains: vi.fn(() => true) }));
+
+  /**
+   * Viewport center exposed as a `MockLngLat` so `center.distanceTo(...)` works
+   * in the distance sort of `StoreLocator`.
+   */
+  getCenter = vi.fn(() => new MockLngLat(0, 0));
 
   loadImage = vi.fn((_url: string, cb: Function) => cb(null, {}));
   addImage = vi.fn((name: string, image: any, _options?: any) => {
@@ -190,6 +224,7 @@ vi.mock('mapbox-gl', () => ({
     NavigationControl: MockNavigationControl,
     GeolocateControl: MockGeolocateControl,
     FullscreenControl: MockFullscreenControl,
+    LngLat: MockLngLat,
   },
 }));
 
@@ -197,6 +232,22 @@ vi.mock('@mapbox/mapbox-gl-geocoder', () => {
   class MockGeocoder {
     addTo = vi.fn();
     onRemove = vi.fn();
+    /**
+     * Captured `result` (and other) handlers, keyed by event type, so a test can
+     * simulate the underlying control firing a geocoding result through `fire`.
+     */
+    _handlers: Record<string, Function[]> = {};
+    on = vi.fn((type: string, cb: Function) => {
+      (this._handlers[type] ??= []).push(cb);
+    });
+
+    /**
+     * Simulate the geocoder control emitting an event (e.g. `result`), invoking
+     * every handler registered through `on`.
+     */
+    fire(type: string, event: unknown) {
+      (this._handlers[type] || []).forEach((cb) => cb(event));
+    }
   }
   return { default: MockGeocoder };
 });

--- a/packages/ui-mapbox/MapboxCluster.ts
+++ b/packages/ui-mapbox/MapboxCluster.ts
@@ -246,6 +246,23 @@ export class MapboxCluster<T extends BaseProps = BaseProps> extends AbstractMapb
   };
 
   /**
+   * Update the live GeoJSON source data.
+   *
+   * Looks up this cluster's source by id and, when it is a GeoJSON source,
+   * replaces its data. Guards against a missing map or source so it is safe to
+   * call before mount or after teardown.
+   *
+   * @param {GeoJSONSourceSpecification['data']} data
+   */
+  setData(data: GeoJSONSourceSpecification['data']) {
+    const source = this.map?.getSource<GeoJSONSource>(this.__getId('source'));
+
+    if (source && typeof source.setData === 'function') {
+      source.setData(data);
+    }
+  }
+
+  /**
    * Mounted hook.
    */
   mounted() {
@@ -271,7 +288,10 @@ export class MapboxCluster<T extends BaseProps = BaseProps> extends AbstractMapb
     const source: GeoJSONSourceSpecification = {
       type: 'geojson',
       cluster: true,
-      data,
+      // Tolerate no authored data: default to an empty FeatureCollection so a
+      // coordinator (e.g. `StoreLocator`) can drive the source through
+      // `setData` after mount instead of forcing inline/URL data upfront.
+      data: data || { type: 'FeatureCollection', features: [] },
       clusterMaxZoom,
       clusterRadius,
       clusterMinPoints,

--- a/packages/ui-mapbox/MapboxGeocoder.ts
+++ b/packages/ui-mapbox/MapboxGeocoder.ts
@@ -16,6 +16,11 @@ import {
 interface GeocoderControlLike {
   addTo(target: Map | HTMLElement | string): void;
   onRemove(): void;
+  /**
+   * Subscribe to a geocoder control event. Declared optional so the structural
+   * type stays satisfiable by minimal test doubles and older control versions.
+   */
+  on?(type: string, callback: (event: { result: unknown }) => void): void;
 }
 
 export interface MapboxGeocoderProps extends AbstractMapboxMapChildProps {
@@ -52,6 +57,7 @@ export class MapboxGeocoder<T extends BaseProps = BaseProps> extends AbstractMap
    */
   static config: BaseConfig = {
     name: 'MapboxGeocoder',
+    emits: ['result'],
     options: {
       addToMap: Boolean,
       options: Object,
@@ -103,6 +109,9 @@ export class MapboxGeocoder<T extends BaseProps = BaseProps> extends AbstractMap
     this.__control = new GeocoderControlClass(
       options as ConstructorParameters<typeof GeocoderControlClass>[0],
     );
+    // Re-emit the control's `result` event as a component event so coordinators
+    // (e.g. `StoreLocator`) can react to a geocoded address.
+    this.__control.on?.('result', (event) => this.$emit('result', event.result));
     this.__control.addTo(this.target);
   }
 

--- a/packages/ui-mapbox/StoreLocator.ts
+++ b/packages/ui-mapbox/StoreLocator.ts
@@ -444,7 +444,11 @@ export class StoreLocator<T extends BaseProps = BaseProps> extends Base<T & Stor
       this.__clusterWired = true;
       this.__offHandlers.push(cluster.$on('feature-click', this.__handleClusterFeatureClick));
       // The cluster (and its source) are now ready: push the current data to it.
-      this.__syncItems();
+      // Only resync when the cluster became available AFTER the initial pass; on
+      // the first pass `__handleMapLoad`'s own `__syncItems()` call already covers it.
+      if (attempt > 0) {
+        this.__syncItems();
+      }
     }
 
     if (geocoder && !this.__geocoderWired) {

--- a/packages/ui-mapbox/StoreLocator.ts
+++ b/packages/ui-mapbox/StoreLocator.ts
@@ -1,0 +1,486 @@
+import { Base, type BaseProps, type BaseConfig } from '@studiometa/js-toolkit';
+import { debounce, nextTick } from '@studiometa/js-toolkit/utils';
+import mapboxgl from 'mapbox-gl';
+import type { LngLatLike, LngLatBoundsLike, GeoJSONSourceSpecification } from 'mapbox-gl';
+import type { FeatureCollection, Point } from 'geojson';
+import { MapboxMap } from './MapboxMap.js';
+import { StoreLocatorItem } from './StoreLocatorItem.js';
+import type { MapboxCluster } from './MapboxCluster.js';
+import type { MapboxGeocoder } from './MapboxGeocoder.js';
+
+/**
+ * Maximum number of `nextTick` retries used to wire the optional `MapboxCluster`
+ * and `MapboxGeocoder` children. They are mounted asynchronously by the
+ * `MapboxMap` once its map has loaded, so they may not be queryable yet on the
+ * `map-load` event: we poll a few ticks before giving up.
+ */
+const WIRE_CHILDREN_MAX_ATTEMPTS = 10;
+
+export interface StoreLocatorProps extends BaseProps {
+  $refs: {
+    list?: HTMLElement;
+  };
+  $options: {
+    itemZoomLevel: number;
+    noSort: boolean;
+    fitOnUpdate: boolean;
+  };
+}
+
+/**
+ * Coordinate a "find a store near you" experience around a `MapboxMap`.
+ *
+ * The component is a thin, composable coordinator: it owns no map rendering of
+ * its own but wires together a `MapboxMap`, an optional `MapboxCluster` (the map
+ * data source), an optional `MapboxGeocoder` (address search) and a list of
+ * `StoreLocatorItem`s living in a sidebar.
+ *
+ * Each store has three independent states with different sources of truth:
+ *
+ * 1. **Registered** — the item exists in the DOM. Drives the **map data** and
+ *    only changes when the item set changes (e.g. a `Fetch` swaps the list).
+ * 2. **In bounds** — the item's `lngLat` is inside the current viewport. Drives
+ *    **list visibility + distance sort only**, recomputed on map `moveend`, and
+ *    never touches the map.
+ * 3. **Selected** — the chosen item. Drives fly-to, `active` styling and the
+ *    `select` event.
+ *
+ * @see https://ui.studiometa.dev/-/components/MapboxMap/
+ */
+export class StoreLocator<T extends BaseProps = BaseProps> extends Base<T & StoreLocatorProps> {
+  /**
+   * Config.
+   *
+   * Only `MapboxMap` and `StoreLocatorItem` are registered as components:
+   *
+   * - `MapboxMap` is the coordinator's direct child and must be mounted here.
+   * - `StoreLocatorItem`s live in the sidebar, outside the map, so nothing else
+   *   would mount them.
+   *
+   * `MapboxCluster` and `MapboxGeocoder` are intentionally **not** registered
+   * here: they live inside the `MapboxMap` element, which already mounts them
+   * lazily and safely once its map has loaded (registering them again would
+   * either mount them eagerly — before the map style is ready, throwing in
+   * mapbox-gl — or require faking a map-load event on this component). They are
+   * instead discovered through `$query` once available.
+   */
+  static config: BaseConfig = {
+    name: 'StoreLocator',
+    refs: ['list'],
+    emits: ['select', 'deselect', 'filter'],
+    options: {
+      itemZoomLevel: {
+        type: Number,
+        default: 14,
+      },
+      // Boolean options default to `false`, so sorting is ON by default;
+      // `data-option-no-sort` disables the distance sort.
+      noSort: Boolean,
+      // Fit the map bounds to the item set whenever it changes.
+      fitOnUpdate: Boolean,
+    },
+    components: {
+      MapboxMap,
+      StoreLocatorItem,
+    },
+  };
+
+  /**
+   * Whether the underlying map has finished loading.
+   */
+  isLoaded = false;
+
+  /**
+   * Live registry of the mounted `StoreLocatorItem`s, in DOM order.
+   * @private
+   */
+  __items: StoreLocatorItem[] = [];
+
+  /**
+   * The currently selected item, if any.
+   * @private
+   */
+  __selected?: StoreLocatorItem;
+
+  /**
+   * Unsubscribe callbacks for every child/component listener attached at
+   * runtime, flushed on destroy.
+   * @private
+   */
+  __offHandlers: Array<() => void> = [];
+
+  /**
+   * Whether the `MapboxCluster` `feature-click` listener is already attached.
+   * @private
+   */
+  __clusterWired = false;
+
+  /**
+   * Whether the `MapboxGeocoder` `result` listener is already attached.
+   * @private
+   */
+  __geocoderWired = false;
+
+  /**
+   * The closest child `MapboxMap` component.
+   */
+  get mapboxMap() {
+    const mapboxMap = this.$query<MapboxMap>('MapboxMap')[0];
+
+    if (!mapboxMap) {
+      this.$warn('Can not find a child MapboxMap component.');
+    }
+
+    return mapboxMap;
+  }
+
+  /**
+   * The optional child `MapboxCluster` component, mounted by the `MapboxMap`.
+   */
+  get cluster(): MapboxCluster | undefined {
+    return this.$query<MapboxCluster>('MapboxCluster')[0];
+  }
+
+  /**
+   * The optional child `MapboxGeocoder` component, mounted by the `MapboxMap`.
+   */
+  get geocoder(): MapboxGeocoder | undefined {
+    return this.$query<MapboxGeocoder>('MapboxGeocoder')[0];
+  }
+
+  /**
+   * The Mapbox `Map` instance. Only valid once the map has loaded.
+   */
+  get map() {
+    return this.mapboxMap?.map;
+  }
+
+  /**
+   * The GeoJSON `FeatureCollection` derived from the whole registered item set.
+   *
+   * This is the single source of truth pushed to the map source, and only
+   * changes when the item set changes — panning must never rebuild it.
+   */
+  get featureCollection(): FeatureCollection<Point, { id: string }> {
+    return {
+      type: 'FeatureCollection',
+      features: this.__items.map((item) => ({
+        type: 'Feature',
+        geometry: {
+          type: 'Point',
+          coordinates: item.lngLat,
+        },
+        properties: {
+          id: item.id,
+        },
+      })),
+    };
+  }
+
+  /**
+   * Register an item and schedule a coalesced item-set sync so multiple
+   * registrations from a single list swap batch into one update.
+   * @param {StoreLocatorItem} item
+   */
+  registerItem(item: StoreLocatorItem) {
+    if (!this.__items.includes(item)) {
+      this.__items.push(item);
+      this.__scheduleSync();
+    }
+  }
+
+  /**
+   * Unregister an item and schedule a coalesced item-set sync.
+   * @param {StoreLocatorItem} item
+   */
+  unregisterItem(item: StoreLocatorItem) {
+    const index = this.__items.indexOf(item);
+
+    if (index > -1) {
+      this.__items.splice(index, 1);
+
+      if (this.__selected === item) {
+        this.__selected = undefined;
+      }
+
+      this.__scheduleSync();
+    }
+  }
+
+  /**
+   * Select an item: deactivate the previous one, fly to the item, mark it as
+   * active and emit a `select` event.
+   * @param {StoreLocatorItem} item
+   */
+  selectItem(item: StoreLocatorItem) {
+    if (this.__selected && this.__selected !== item) {
+      this.__selected.setActive(false);
+    }
+
+    item.setActive(true);
+    this.__selected = item;
+
+    this.map?.flyTo({
+      center: item.lngLat as LngLatLike,
+      zoom: this.$options.itemZoomLevel,
+    });
+
+    this.$emit('select', item);
+  }
+
+  /**
+   * Clear the current selection and emit a `deselect` event.
+   */
+  deselect() {
+    if (this.__selected) {
+      this.__selected.setActive(false);
+      this.__selected = undefined;
+    }
+
+    this.$emit('deselect');
+  }
+
+  /**
+   * Coalesce item-set syncs into a single trailing call, so a batch of
+   * registrations (e.g. from a `Fetch` swap spanning multiple ticks) results in
+   * one map data update.
+   * @private
+   */
+  __scheduleSync = debounce(() => {
+    if (this.$isMounted) {
+      this.__syncItems();
+    }
+  }, 100);
+
+  /**
+   * Push the derived map data to the cluster, optionally fit the map to the item
+   * set, then recompute the in-view list. Never runs before the map is loaded.
+   * @private
+   */
+  __syncItems() {
+    if (!this.isLoaded) {
+      return;
+    }
+
+    this.cluster?.setData(this.featureCollection as GeoJSONSourceSpecification['data']);
+
+    if (this.$options.fitOnUpdate && this.__items.length > 0) {
+      this.map?.fitBounds(this.__getItemsBounds(), { padding: 40 });
+    }
+
+    this.__filterItemsInView();
+  }
+
+  /**
+   * Compute the bounding box of the whole registered item set as a
+   * `[[minLng, minLat], [maxLng, maxLat]]` tuple.
+   * @private
+   */
+  __getItemsBounds(): LngLatBoundsLike {
+    let minLng = Infinity;
+    let minLat = Infinity;
+    let maxLng = -Infinity;
+    let maxLat = -Infinity;
+
+    for (const item of this.__items) {
+      const [lng, lat] = item.lngLat;
+      minLng = Math.min(minLng, lng);
+      minLat = Math.min(minLat, lat);
+      maxLng = Math.max(maxLng, lng);
+      maxLat = Math.max(maxLat, lat);
+    }
+
+    return [
+      [minLng, minLat],
+      [maxLng, maxLat],
+    ];
+  }
+
+  /**
+   * Recompute the visible/sorted list = registered ∩ in-bounds, distance-sorted.
+   *
+   * Reflects the in-bounds state on every item, reorders the in-view items in
+   * the `list` ref (so DOM order matches distance) and emits `filter` with the
+   * in-view items. Never touches the map.
+   * @private
+   */
+  __filterItemsInView() {
+    const { map } = this;
+
+    if (!map) {
+      return;
+    }
+
+    const bounds = map.getBounds();
+    const center = map.getCenter();
+    const inView: StoreLocatorItem[] = [];
+
+    for (const item of this.__items) {
+      const isInBounds = Boolean(bounds?.contains(item.lngLat as LngLatLike));
+      item.setInBounds(isInBounds);
+
+      if (isInBounds) {
+        inView.push(item);
+      }
+    }
+
+    if (!this.$options.noSort && center) {
+      inView.sort(
+        (a, b) =>
+          center.distanceTo(new mapboxgl.LngLat(a.lngLat[0], a.lngLat[1])) -
+          center.distanceTo(new mapboxgl.LngLat(b.lngLat[0], b.lngLat[1])),
+      );
+    }
+
+    this.__reorderList(inView);
+    this.$emit('filter', inView);
+  }
+
+  /**
+   * Reorder the in-view items inside the `list` ref so their DOM order matches
+   * the distance sort. Appending a connected node moves it, keeping the list
+   * free of duplicates.
+   * @private
+   * @param {StoreLocatorItem[]} items
+   */
+  __reorderList(items: StoreLocatorItem[]) {
+    const list = this.$refs.list;
+
+    if (!list) {
+      return;
+    }
+
+    for (const item of items) {
+      list.append(item.$el);
+    }
+  }
+
+  /**
+   * Handle a `MapboxCluster` `feature-click`: resolve the item behind the
+   * clicked feature and select it.
+   * @private
+   */
+  __handleClusterFeatureClick = (event: Event) => {
+    const [feature] = (event as CustomEvent).detail ?? [];
+    const id = feature?.properties?.id;
+
+    if (id === undefined || id === null) {
+      return;
+    }
+
+    const item = this.__items.find((candidate) => candidate.id === String(id));
+
+    if (item) {
+      this.selectItem(item);
+    }
+  };
+
+  /**
+   * Handle a `MapboxGeocoder` `result`: frame the map on the geocoded location.
+   * @private
+   */
+  __handleGeocoderResult = (event: Event) => {
+    const [result] = (event as CustomEvent).detail ?? [];
+    const { map } = this;
+
+    if (!map || !result) {
+      return;
+    }
+
+    if (Array.isArray(result.bbox)) {
+      const [minLng, minLat, maxLng, maxLat] = result.bbox;
+      map.fitBounds([
+        [minLng, minLat],
+        [maxLng, maxLat],
+      ]);
+    } else if (result.center) {
+      map.flyTo({ center: result.center as LngLatLike });
+    }
+  };
+
+  /**
+   * Recompute the in-view list whenever the viewport settles.
+   * @private
+   */
+  __handleMoveEnd = () => {
+    this.__filterItemsInView();
+  };
+
+  /**
+   * React to the map being ready: bind map listeners, wire the optional
+   * children and run the first sync.
+   * @private
+   */
+  __handleMapLoad = () => {
+    this.isLoaded = true;
+    this.map?.on('moveend', this.__handleMoveEnd);
+    this.__wireChildren();
+    this.__syncItems();
+  };
+
+  /**
+   * Attach the `MapboxCluster`/`MapboxGeocoder` listeners once those children
+   * are available. They mount asynchronously after the map loads, so we retry a
+   * bounded number of ticks until the (optional) cluster is wired.
+   * @private
+   * @param {number} attempt
+   */
+  __wireChildren(attempt = 0) {
+    const { cluster, geocoder } = this;
+
+    if (cluster && !this.__clusterWired) {
+      this.__clusterWired = true;
+      this.__offHandlers.push(cluster.$on('feature-click', this.__handleClusterFeatureClick));
+      // The cluster just became available: push the current data to it.
+      this.__syncItems();
+    }
+
+    if (geocoder && !this.__geocoderWired) {
+      this.__geocoderWired = true;
+      this.__offHandlers.push(geocoder.$on('result', this.__handleGeocoderResult));
+    }
+
+    if (!this.__clusterWired && attempt < WIRE_CHILDREN_MAX_ATTEMPTS) {
+      nextTick(() => {
+        if (this.$isMounted) {
+          this.__wireChildren(attempt + 1);
+        }
+      });
+    }
+  }
+
+  /**
+   * Mounted hook: wait for the map to load before wiring anything.
+   */
+  mounted() {
+    const { mapboxMap } = this;
+
+    if (!mapboxMap) {
+      return;
+    }
+
+    if (mapboxMap.isLoaded) {
+      this.__handleMapLoad();
+    } else {
+      this.__offHandlers.push(mapboxMap.$on('map-load', this.__handleMapLoad, { once: true }));
+    }
+  }
+
+  /**
+   * Destroyed hook: detach every listener and clear the registry.
+   */
+  destroyed() {
+    for (const off of this.__offHandlers) {
+      off();
+    }
+    this.__offHandlers = [];
+
+    this.map?.off('moveend', this.__handleMoveEnd);
+
+    this.__items = [];
+    this.__selected = undefined;
+    this.isLoaded = false;
+    this.__clusterWired = false;
+    this.__geocoderWired = false;
+  }
+}

--- a/packages/ui-mapbox/StoreLocator.ts
+++ b/packages/ui-mapbox/StoreLocator.ts
@@ -420,8 +420,13 @@ export class StoreLocator<T extends BaseProps = BaseProps> extends Base<T & Stor
 
   /**
    * Attach the `MapboxCluster`/`MapboxGeocoder` listeners once those children
-   * are available. They mount asynchronously after the map loads, so we retry a
-   * bounded number of ticks until the (optional) cluster is wired.
+   * are available. Both are optional and mount asynchronously and independently
+   * after the map loads, so we poll a bounded number of ticks until *each* of
+   * them is wired (not just the first to appear): if the cluster mounts before
+   * the geocoder, stopping as soon as the cluster is wired would leave the
+   * geocoder's `result` listener unattached. A `StoreLocator` missing one (or
+   * both) of these children simply polls to the attempt cap — bounded and
+   * harmless.
    * @private
    * @param {number} attempt
    */
@@ -447,7 +452,7 @@ export class StoreLocator<T extends BaseProps = BaseProps> extends Base<T & Stor
       this.__offHandlers.push(geocoder.$on('result', this.__handleGeocoderResult));
     }
 
-    if (!this.__clusterWired && attempt < WIRE_CHILDREN_MAX_ATTEMPTS) {
+    if ((!this.__clusterWired || !this.__geocoderWired) && attempt < WIRE_CHILDREN_MAX_ATTEMPTS) {
       nextTick(() => {
         if (this.$isMounted) {
           this.__wireChildren(attempt + 1);

--- a/packages/ui-mapbox/StoreLocator.ts
+++ b/packages/ui-mapbox/StoreLocator.ts
@@ -428,10 +428,17 @@ export class StoreLocator<T extends BaseProps = BaseProps> extends Base<T & Stor
   __wireChildren(attempt = 0) {
     const { cluster, geocoder } = this;
 
-    if (cluster && !this.__clusterWired) {
+    // The cluster is an async child of the `MapboxMap`: it becomes queryable as
+    // soon as it is constructed, but its GeoJSON source is only added from its
+    // `mounted()` hook. Pushing data before that hook runs would silently no-op
+    // (the source does not exist yet) and leave the map empty, so we wait until
+    // the cluster is fully mounted — `$isMounted` flips to `true` right before
+    // `mounted()` runs synchronously, so observing it here guarantees the source
+    // is ready. Until then we keep polling.
+    if (cluster && cluster.$isMounted && !this.__clusterWired) {
       this.__clusterWired = true;
       this.__offHandlers.push(cluster.$on('feature-click', this.__handleClusterFeatureClick));
-      // The cluster just became available: push the current data to it.
+      // The cluster (and its source) are now ready: push the current data to it.
       this.__syncItems();
     }
 

--- a/packages/ui-mapbox/StoreLocatorItem.ts
+++ b/packages/ui-mapbox/StoreLocatorItem.ts
@@ -64,6 +64,19 @@ export class StoreLocatorItem<T extends BaseProps = BaseProps> extends Base<
   }
 
   /**
+   * The parent `StoreLocator` coordinator resolved at mount, cached so the item
+   * can still reach it on destroy.
+   *
+   * `destroyed()` runs *after* the element has been detached from the DOM (e.g.
+   * when a `Fetch` swaps the list, or a facet filter replaces it), and a
+   * `$closest` lookup on a disconnected node returns nothing — which would leave
+   * the removed item registered and its feature stuck on the map. Caching the
+   * reference keeps the unregister path working through the detach.
+   * @private
+   */
+  __coordinator?: StoreLocator;
+
+  /**
    * The closest parent `StoreLocator` coordinator instance.
    */
   get storeLocator() {
@@ -79,17 +92,20 @@ export class StoreLocatorItem<T extends BaseProps = BaseProps> extends Base<
   }
 
   /**
-   * Mounted hook: register with the coordinator.
+   * Mounted hook: cache the coordinator and register with it.
    */
   mounted() {
-    this.storeLocator?.registerItem(this);
+    this.__coordinator = this.storeLocator;
+    this.__coordinator?.registerItem(this);
   }
 
   /**
-   * Destroyed hook: unregister from the coordinator.
+   * Destroyed hook: unregister from the cached coordinator, even if the element
+   * has already been detached from the DOM.
    */
   destroyed() {
-    this.storeLocator?.unregisterItem(this);
+    this.__coordinator?.unregisterItem(this);
+    this.__coordinator = undefined;
   }
 
   /**

--- a/packages/ui-mapbox/StoreLocatorItem.ts
+++ b/packages/ui-mapbox/StoreLocatorItem.ts
@@ -1,0 +1,126 @@
+import { Base, type BaseProps, type BaseConfig } from '@studiometa/js-toolkit';
+import type { StoreLocator } from './StoreLocator.js';
+
+export interface StoreLocatorItemProps extends BaseProps {
+  $refs: {
+    select?: HTMLElement;
+  };
+  $options: {
+    id: string;
+    lngLat: [number, number];
+  };
+}
+
+/**
+ * A single store entry of a `StoreLocator`.
+ *
+ * Unlike the other `@studiometa/ui-mapbox` components, this one does **not**
+ * extend `AbstractMapboxMapChild`: its DOM lives in the sidebar list, outside
+ * the `MapboxMap` element, so its context is the parent `StoreLocator`
+ * coordinator — resolved via `$closest('StoreLocator')` — rather than a map.
+ *
+ * The component is headless: the state setters called by the coordinator only
+ * reflect state as data-attributes on `$el` so the integrator can style the
+ * item with plain CSS. The chosen convention is:
+ *
+ * - `data-in-bounds` — present when the item's `lngLat` is inside the current
+ *   map viewport. This is the **list-visibility** signal; hide out-of-bounds
+ *   items with `[data-component="StoreLocatorItem"]:not([data-in-bounds]) { display: none }`.
+ * - `data-active` + `aria-current="true"` — present when the item is the
+ *   currently selected one.
+ *
+ * @see https://ui.studiometa.dev/-/components/MapboxMap/
+ */
+export class StoreLocatorItem<T extends BaseProps = BaseProps> extends Base<
+  T & StoreLocatorItemProps
+> {
+  /**
+   * Config.
+   */
+  static config: BaseConfig = {
+    name: 'StoreLocatorItem',
+    refs: ['select'],
+    options: {
+      id: String,
+      lngLat: {
+        type: Array,
+        default: () => [0, 0],
+      },
+    },
+  };
+
+  /**
+   * The item's stable identifier, used to match map features back to the item.
+   */
+  get id(): string {
+    return this.$options.id;
+  }
+
+  /**
+   * The item's coordinates as a `[lng, lat]` tuple.
+   */
+  get lngLat(): [number, number] {
+    return this.$options.lngLat;
+  }
+
+  /**
+   * The closest parent `StoreLocator` coordinator instance.
+   */
+  get storeLocator() {
+    const storeLocator = this.$closest<StoreLocator>('StoreLocator');
+
+    if (!storeLocator) {
+      this.$warn(
+        'Can not find the parent store locator, does this component has a parent StoreLocator component?',
+      );
+    }
+
+    return storeLocator;
+  }
+
+  /**
+   * Mounted hook: register with the coordinator.
+   */
+  mounted() {
+    this.storeLocator?.registerItem(this);
+  }
+
+  /**
+   * Destroyed hook: unregister from the coordinator.
+   */
+  destroyed() {
+    this.storeLocator?.unregisterItem(this);
+  }
+
+  /**
+   * Click handler for the `select` ref, delegating the selection to the
+   * coordinator so the map and the other items stay in sync.
+   */
+  onSelectClick() {
+    this.storeLocator?.selectItem(this);
+  }
+
+  /**
+   * Reflect the "in the current map viewport" state as a `data-in-bounds`
+   * attribute. Called by the coordinator on every map `moveend`.
+   * @param {boolean} value
+   */
+  setInBounds(value: boolean) {
+    this.$el.toggleAttribute('data-in-bounds', value);
+  }
+
+  /**
+   * Reflect the "selected/active" state as a `data-active` attribute and the
+   * `aria-current` state. Called by the coordinator on selection.
+   * @param {boolean} value
+   */
+  setActive(value: boolean) {
+    this.$el.toggleAttribute('data-active', value);
+
+    if (value) {
+      this.$el.setAttribute('aria-current', 'true');
+    } else {
+      this.$el.removeAttribute('aria-current');
+    }
+  }
+}

--- a/packages/ui-mapbox/index.ts
+++ b/packages/ui-mapbox/index.ts
@@ -12,3 +12,5 @@ export * from './MapboxMarker.js';
 export * from './MapboxNavigationControl.js';
 export * from './MapboxPopup.js';
 export * from './MapboxSource.js';
+export * from './StoreLocator.js';
+export * from './StoreLocatorItem.js';


### PR DESCRIPTION
Stacked on #561 (targets `feat/ui-mapbox-package`; will retarget to `main` once #561 merges).

### 📚 Description

Adds a composable **store locator** to `@studiometa/ui-mapbox`, porting the behaviour of `@studiometa/vue-mapbox-gl`'s `StoreLocator` — the last deferred piece — but rebuilt the js-toolkit way: **two thin components + two small additions to existing ones, no monolith.**

- **`StoreLocatorItem`** — one sidebar list entry. Resolves its coordinator via `$closest('StoreLocator')`, self-registers on mount, and reflects its state as data-attributes for the integrator to style (`data-in-bounds`, `data-active`/`aria-current`).
- **`StoreLocator`** — the coordinator. Wires a `MapboxMap`, an optional `MapboxCluster` (the map data source) and an optional `MapboxGeocoder` around the list.

### 🧭 The three-state model

Each store has three independent states with different sources of truth:

| State | Driven by | Affects |
| --- | --- | --- |
| **Registered** (in the DOM) | list markup / a `Fetch` swap | the **map data** (derived FeatureCollection) |
| **In bounds** | map `moveend` | **list visibility + distance sort** — never the map |
| **Selected** | click / cluster feature-click | fly-to, `active` styling, `select` event |

So **panning updates the list, not the map; a facet-driven list swap updates both.** The coordinator derives the map's GeoJSON from the live item set and pushes it via a new `MapboxCluster.setData()`, so the list is the single source of truth.

### 🔎 Faceted search via `Fetch`

Because items self-register/unregister, swapping the list (e.g. with `Fetch`) "just works": the new items re-derive the map data and refit — no `StoreLocator`↔`Fetch` coupling. The faceted playground story demonstrates the list + map updating together.

### 🧩 Small additions to existing components

- `MapboxCluster` gains `setData()` and tolerates empty initial data (so the coordinator can feed it).
- `MapboxGeocoder` emits a `result` event so the coordinator can frame the map on a search.

### ✅ Tests, docs & real-browser validation

- ~28 StoreLocator unit tests, including the key guarantee that **map data is not rebuilt on pan**. Full suite green.
- Dedicated docs (three-state model, API, styling contract) + two live playground stories: a **Dialog-drawer** MVP and a **faceted** example.
- Validated in a real browser (rendering, viewport sync, select→fly→drawer, cluster click, faceted map update) — which surfaced and fixed two real bugs: the cluster map-load timing and item unregister-on-detach.

### ❓ Type of change

- [x] ✨ New feature (a non-breaking change that adds functionality)

🤖 Generated with [Claude Code](https://claude.com/claude-code)