### PR TITLE
Add subpath imports and lazy-registration docs for the Mapbox components

### DIFF
--- a/packages/docs/components/MapboxMap/index.md
+++ b/packages/docs/components/MapboxMap/index.md
@@ -72,3 +72,22 @@ registerComponent(MapboxMap);
 ::: tip Options are read once at mount
 Component options are read a single time when the map mounts and are **not** reactive, unlike the Vue library. To move the map or update its data afterwards, call the underlying Mapbox objects directly (e.g. `instance.map.setCenter(...)`). See the [reactivity note](./js-api#reactivity-and-updates) for details.
 :::
+
+## Lazy loading
+
+`mapbox-gl` is a heavy dependency (~230&nbsp;kB gzipped, more with the geocoder). Registering `MapboxMap` eagerly pulls it into your main bundle even on pages that never render a map. Prefer **lazy registration** so the map is code-split into its own chunk and only loaded when it is actually needed.
+
+js-toolkit ships [`importWhen*` helpers](https://js-toolkit.studiometa.dev/api/helpers/importWhenVisible.html) for this. `importWhenVisible` defers the dynamic import until a `MapboxMap` element scrolls into view, then hands the resolved component to `registerComponent`:
+
+```js
+import { registerComponent, importWhenVisible } from '@studiometa/js-toolkit';
+
+registerComponent(
+  importWhenVisible(
+    () => import('@studiometa/ui-mapbox').then(({ MapboxMap }) => MapboxMap),
+    'MapboxMap',
+  ),
+);
+```
+
+Because every marker, popup, control, source, layer, image and cluster is a child of `MapboxMap`, deferring the map defers the whole family — `mapbox-gl` included. Reach for a different trigger when it fits better: `importWhenIdle` (load during browser idle time), `importOnInteraction` (wait for a first click/focus/touch on the element) or `importOnMediaQuery` (load only above a breakpoint, e.g. to skip the map on small screens).

--- a/packages/docs/components/MapboxMap/index.md
+++ b/packages/docs/components/MapboxMap/index.md
@@ -82,12 +82,9 @@ js-toolkit ships [`importWhen*` helpers](https://js-toolkit.studiometa.dev/api/h
 ```js
 import { registerComponent, importWhenVisible } from '@studiometa/js-toolkit';
 
-registerComponent(
-  importWhenVisible(
-    () => import('@studiometa/ui-mapbox').then(({ MapboxMap }) => MapboxMap),
-    'MapboxMap',
-  ),
-);
+registerComponent(importWhenVisible(() => import('@studiometa/ui-mapbox/MapboxMap'), 'MapboxMap'));
 ```
+
+Every component is also available at its own subpath (`@studiometa/ui-mapbox/<Component>`), whose default export is the component class — so the dynamic import needs no destructuring.
 
 Because every marker, popup, control, source, layer, image and cluster is a child of `MapboxMap`, deferring the map defers the whole family — `mapbox-gl` included. Reach for a different trigger when it fits better: `importWhenIdle` (load during browser idle time), `importOnInteraction` (wait for a first click/focus/touch on the element) or `importOnMediaQuery` (load only above a breakpoint, e.g. to skip the map on small screens).

--- a/packages/docs/components/StoreLocator/index.md
+++ b/packages/docs/components/StoreLocator/index.md
@@ -106,11 +106,10 @@ Registering `StoreLocator` pulls in `MapboxMap` and its heavy `mapbox-gl` depend
 import { registerComponent, importWhenVisible } from '@studiometa/js-toolkit';
 
 registerComponent(
-  importWhenVisible(
-    () => import('@studiometa/ui-mapbox').then(({ StoreLocator }) => StoreLocator),
-    'StoreLocator',
-  ),
+  importWhenVisible(() => import('@studiometa/ui-mapbox/StoreLocator'), 'StoreLocator'),
 );
 ```
+
+Every component is also available at its own subpath (`@studiometa/ui-mapbox/<Component>`), whose default export is the component class — so the dynamic import needs no destructuring.
 
 `importWhenIdle`, `importOnInteraction` and `importOnMediaQuery` are available too — see the [MapboxMap lazy-loading note](/components/MapboxMap/#lazy-loading).

--- a/packages/docs/components/StoreLocator/index.md
+++ b/packages/docs/components/StoreLocator/index.md
@@ -97,3 +97,20 @@ registerComponent(StoreLocator);
 :::
 
 The styling contract is entirely data-attribute driven: `data-in-bounds` toggles list visibility, `data-active` (plus `aria-current="true"`) marks the selected item. See the [styling contract](./js-api#styling-contract) for details.
+
+## Lazy loading
+
+Registering `StoreLocator` pulls in `MapboxMap` and its heavy `mapbox-gl` dependency (~230&nbsp;kB gzipped). Register it lazily so it is code-split into its own chunk and only loaded when the locator is on the page, using the same [`importWhen*` helpers](https://js-toolkit.studiometa.dev/api/helpers/importWhenVisible.html) as the rest of the [`MapboxMap` family](/components/MapboxMap/#lazy-loading):
+
+```js
+import { registerComponent, importWhenVisible } from '@studiometa/js-toolkit';
+
+registerComponent(
+  importWhenVisible(
+    () => import('@studiometa/ui-mapbox').then(({ StoreLocator }) => StoreLocator),
+    'StoreLocator',
+  ),
+);
+```
+
+`importWhenIdle`, `importOnInteraction` and `importOnMediaQuery` are available too — see the [MapboxMap lazy-loading note](/components/MapboxMap/#lazy-loading).

--- a/packages/tests/MapboxMap/subpath-exports.spec.ts
+++ b/packages/tests/MapboxMap/subpath-exports.spec.ts
@@ -10,6 +10,17 @@ import StoreLocatorDefault, {
 import MapboxClusterDefault, {
   MapboxCluster as MapboxClusterNamed,
 } from '@studiometa/ui-mapbox/MapboxCluster';
+// The `.js`-extensioned subpaths must resolve to the same modules as the
+// extensionless ones above.
+import MapboxMapJsDefault, {
+  MapboxMap as MapboxMapJsNamed,
+} from '@studiometa/ui-mapbox/MapboxMap.js';
+import StoreLocatorJsDefault, {
+  StoreLocator as StoreLocatorJsNamed,
+} from '@studiometa/ui-mapbox/StoreLocator.js';
+import MapboxClusterJsDefault, {
+  MapboxCluster as MapboxClusterJsNamed,
+} from '@studiometa/ui-mapbox/MapboxCluster.js';
 
 test.each([
   ['MapboxMap', MapboxMapDefault, MapboxMapNamed, barrel.MapboxMap],
@@ -24,3 +35,21 @@ test.each([
   expect(def).toBe(named);
   expect(def).toBe(fromBarrel);
 });
+
+test.each([
+  ['MapboxMap', MapboxMapJsDefault, MapboxMapJsNamed, barrel.MapboxMap],
+  ['StoreLocator', StoreLocatorJsDefault, StoreLocatorJsNamed, barrel.StoreLocator],
+  ['MapboxCluster', MapboxClusterJsDefault, MapboxClusterJsNamed, barrel.MapboxCluster],
+])(
+  '%s is available at its `.js`-extensioned subpath as default and named export',
+  (_name, def, named, fromBarrel) => {
+    // Ensure the `mapbox-gl` mock is registered before the package is imported.
+    expect(MockMap).toBeDefined();
+    // The default export is a js-toolkit `Base` subclass.
+    expect('$isBase' in def).toBe(true);
+    // The `.js`-extensioned subpath resolves to the same class as the
+    // extensionless subpath and the barrel export.
+    expect(def).toBe(named);
+    expect(def).toBe(fromBarrel);
+  },
+);

--- a/packages/tests/MapboxMap/subpath-exports.spec.ts
+++ b/packages/tests/MapboxMap/subpath-exports.spec.ts
@@ -1,0 +1,26 @@
+import { test, expect } from 'vitest';
+// Importing the mock registers the `mapbox-gl` module mock before the package
+// (and its real `mapbox-gl` dependency) is imported below.
+import { MockMap } from './mock-mapbox-gl.js';
+import * as barrel from '@studiometa/ui-mapbox';
+import MapboxMapDefault, { MapboxMap as MapboxMapNamed } from '@studiometa/ui-mapbox/MapboxMap';
+import StoreLocatorDefault, {
+  StoreLocator as StoreLocatorNamed,
+} from '@studiometa/ui-mapbox/StoreLocator';
+import MapboxClusterDefault, {
+  MapboxCluster as MapboxClusterNamed,
+} from '@studiometa/ui-mapbox/MapboxCluster';
+
+test.each([
+  ['MapboxMap', MapboxMapDefault, MapboxMapNamed, barrel.MapboxMap],
+  ['StoreLocator', StoreLocatorDefault, StoreLocatorNamed, barrel.StoreLocator],
+  ['MapboxCluster', MapboxClusterDefault, MapboxClusterNamed, barrel.MapboxCluster],
+])('%s is available at its own subpath as default and named export', (_name, def, named, fromBarrel) => {
+  // Ensure the `mapbox-gl` mock is registered before the package is imported.
+  expect(MockMap).toBeDefined();
+  // The default export is a js-toolkit `Base` subclass.
+  expect('$isBase' in def).toBe(true);
+  // The default, named and barrel exports all reference the exact same class.
+  expect(def).toBe(named);
+  expect(def).toBe(fromBarrel);
+});

--- a/packages/ui-mapbox/AbstractMapboxControl.ts
+++ b/packages/ui-mapbox/AbstractMapboxControl.ts
@@ -89,3 +89,5 @@ export class AbstractMapboxControl<T extends BaseProps = BaseProps> extends Abst
     }
   }
 }
+
+export default AbstractMapboxControl;

--- a/packages/ui-mapbox/AbstractMapboxMapChild.ts
+++ b/packages/ui-mapbox/AbstractMapboxMapChild.ts
@@ -37,3 +37,5 @@ export class AbstractMapboxMapChild<T extends BaseProps = BaseProps> extends Bas
     return this.mapboxMap?.map;
   }
 }
+
+export default AbstractMapboxMapChild;

--- a/packages/ui-mapbox/MapboxCluster.ts
+++ b/packages/ui-mapbox/MapboxCluster.ts
@@ -369,3 +369,5 @@ export class MapboxCluster<T extends BaseProps = BaseProps> extends AbstractMapb
     }
   }
 }
+
+export default MapboxCluster;

--- a/packages/ui-mapbox/MapboxFullscreenControl.ts
+++ b/packages/ui-mapbox/MapboxFullscreenControl.ts
@@ -23,3 +23,5 @@ export class MapboxFullscreenControl extends withExtraConfig(AbstractMapboxContr
     return new mapboxgl.FullscreenControl(options);
   }
 }
+
+export default MapboxFullscreenControl;

--- a/packages/ui-mapbox/MapboxGeocoder.ts
+++ b/packages/ui-mapbox/MapboxGeocoder.ts
@@ -133,3 +133,5 @@ export class MapboxGeocoder<T extends BaseProps = BaseProps> extends AbstractMap
     this.__control = undefined;
   }
 }
+
+export default MapboxGeocoder;

--- a/packages/ui-mapbox/MapboxGeolocateControl.ts
+++ b/packages/ui-mapbox/MapboxGeolocateControl.ts
@@ -33,3 +33,5 @@ export class MapboxGeolocateControl extends withExtraConfig(AbstractMapboxContro
     return new mapboxgl.GeolocateControl(options);
   }
 }
+
+export default MapboxGeolocateControl;

--- a/packages/ui-mapbox/MapboxImage.ts
+++ b/packages/ui-mapbox/MapboxImage.ts
@@ -82,3 +82,5 @@ export class MapboxImage<T extends BaseProps = BaseProps> extends AbstractMapbox
     }
   }
 }
+
+export default MapboxImage;

--- a/packages/ui-mapbox/MapboxImages.ts
+++ b/packages/ui-mapbox/MapboxImages.ts
@@ -89,3 +89,5 @@ export class MapboxImages<T extends BaseProps = BaseProps> extends AbstractMapbo
     }
   }
 }
+
+export default MapboxImages;

--- a/packages/ui-mapbox/MapboxLayer.ts
+++ b/packages/ui-mapbox/MapboxLayer.ts
@@ -102,3 +102,5 @@ export class MapboxLayer<T extends BaseProps = BaseProps> extends AbstractMapbox
     }
   }
 }
+
+export default MapboxLayer;

--- a/packages/ui-mapbox/MapboxMap.ts
+++ b/packages/ui-mapbox/MapboxMap.ts
@@ -156,3 +156,5 @@ export class MapboxMap<T extends BaseProps = BaseProps> extends Base<T & MapboxM
     this.isLoaded = false;
   }
 }
+
+export default MapboxMap;

--- a/packages/ui-mapbox/MapboxMarker.ts
+++ b/packages/ui-mapbox/MapboxMarker.ts
@@ -81,3 +81,5 @@ export class MapboxMarker<T extends BaseProps = BaseProps> extends AbstractMapbo
     this.__marker = undefined;
   }
 }
+
+export default MapboxMarker;

--- a/packages/ui-mapbox/MapboxNavigationControl.ts
+++ b/packages/ui-mapbox/MapboxNavigationControl.ts
@@ -34,3 +34,5 @@ export class MapboxNavigationControl extends withExtraConfig(AbstractMapboxContr
     return new mapboxgl.NavigationControl(options);
   }
 }
+
+export default MapboxNavigationControl;

--- a/packages/ui-mapbox/MapboxPopup.ts
+++ b/packages/ui-mapbox/MapboxPopup.ts
@@ -87,3 +87,5 @@ export class MapboxPopup<T extends BaseProps = BaseProps> extends AbstractMapbox
     this.__popup = undefined;
   }
 }
+
+export default MapboxPopup;

--- a/packages/ui-mapbox/MapboxSource.ts
+++ b/packages/ui-mapbox/MapboxSource.ts
@@ -113,3 +113,5 @@ export class MapboxSource<T extends BaseProps = BaseProps> extends AbstractMapbo
     this.map.removeSource(id);
   }
 }
+
+export default MapboxSource;

--- a/packages/ui-mapbox/StoreLocator.ts
+++ b/packages/ui-mapbox/StoreLocator.ts
@@ -500,3 +500,5 @@ export class StoreLocator<T extends BaseProps = BaseProps> extends Base<T & Stor
     this.__geocoderWired = false;
   }
 }
+
+export default StoreLocator;

--- a/packages/ui-mapbox/StoreLocatorItem.ts
+++ b/packages/ui-mapbox/StoreLocatorItem.ts
@@ -140,3 +140,5 @@ export class StoreLocatorItem<T extends BaseProps = BaseProps> extends Base<
     }
   }
 }
+
+export default StoreLocatorItem;

--- a/packages/ui-mapbox/package.json
+++ b/packages/ui-mapbox/package.json
@@ -9,6 +9,10 @@
   "sideEffects": false,
   "main": "index.ts",
   "types": "index.d.ts",
+  "exports": {
+    ".": "./index.ts",
+    "./*": "./*.ts"
+  },
   "scripts": {
     "build": "npm run build:pkg && npm run build:types",
     "build:pkg": "node scripts/build.js",

--- a/packages/ui-mapbox/package.json
+++ b/packages/ui-mapbox/package.json
@@ -11,6 +11,7 @@
   "types": "index.d.ts",
   "exports": {
     ".": "./index.ts",
+    "./*.js": "./*.ts",
     "./*": "./*.ts"
   },
   "scripts": {

--- a/packages/ui-mapbox/scripts/build.js
+++ b/packages/ui-mapbox/scripts/build.js
@@ -54,6 +54,7 @@ function writePublishedFiles() {
   pkg.types = 'index.d.ts';
   pkg.exports = {
     '.': { types: './index.d.ts', import: './index.js' },
+    './*.js': { types: './*.d.ts', import: './*.js' },
     './*': { types: './*.d.ts', import: './*.js' },
   };
 

--- a/packages/ui-mapbox/scripts/build.js
+++ b/packages/ui-mapbox/scripts/build.js
@@ -36,16 +36,28 @@ async function build() {
 /**
  * Write the files consumed when publishing the `dist/` folder to NPM:
  *
- * - a `package.json` derived from the source one, with the `index.ts`
- *   entrypoints rewritten to the emitted `index.js` (mirrors the root
- *   `build:cp-files` script);
+ * - a `package.json` derived from the source one, with the entrypoints and
+ *   `exports` map rewritten to point at the emitted `.js`/`.d.ts` files
+ *   (the source ones resolve to `.ts` for in-repo consumption);
  * - the `README.md` and `LICENSE`/`LICENSE.md`, copied from the package root
  *   when available or from the repository root otherwise.
  */
 function writePublishedFiles() {
   console.log('Writing dist/package.json...');
-  const pkg = fs.readFileSync(resolve('../package.json'), 'utf8');
-  fs.writeFileSync(resolve('../dist/package.json'), pkg.replaceAll('index.ts', 'index.js'));
+  const pkg = JSON.parse(fs.readFileSync(resolve('../package.json'), 'utf8'));
+
+  // The published package sits at the `dist/` root and ships built `.js`
+  // modules alongside their `.d.ts` type declarations. Point the entrypoints
+  // and the per-component subpaths at those artefacts instead of the `.ts`
+  // sources used when consuming the package from within the monorepo.
+  pkg.main = 'index.js';
+  pkg.types = 'index.d.ts';
+  pkg.exports = {
+    '.': { types: './index.d.ts', import: './index.js' },
+    './*': { types: './*.d.ts', import: './*.js' },
+  };
+
+  fs.writeFileSync(resolve('../dist/package.json'), `${JSON.stringify(pkg, null, 2)}\n`);
 
   for (const file of ['README.md', 'LICENSE', 'LICENSE.md']) {
     const source = [resolve(`../${file}`), resolve(`../../../${file}`)].find((path) =>


### PR DESCRIPTION
### 📚 Description

Two related improvements for the `@studiometa/ui-mapbox` components, driven by `mapbox-gl` being a heavy dependency.

**1. Per-component subpath imports.** Each component is now importable directly, without the barrel:

```js
import MapboxMap from '@studiometa/ui-mapbox/MapboxMap';        // default
import { MapboxMap } from '@studiometa/ui-mapbox/MapboxMap';    // named
import { MapboxMap } from '@studiometa/ui-mapbox';              // barrel (unchanged)
```

- A default export was added to every component alongside its named export (the barrel keeps working).
- An `exports` map (`.` + a `./*` wildcard) is declared; the source resolves to `.ts` (monorepo) and the published `dist/package.json` maps each subpath to its built `.js`/`.d.ts`.
- The dist `package.json` is now generated by an object transform rather than a string replacement.

**2. Lazy-registration docs.** New "Lazy loading" sections on `MapboxMap` and `StoreLocator` recommend deferring the map so `mapbox-gl` is code-split and only loaded when needed, using js-toolkit's `importWhen*` helpers and the clean subpath form (no destructuring):

```js
import { registerComponent, importWhenVisible } from '@studiometa/js-toolkit';

registerComponent(importWhenVisible(() => import('@studiometa/ui-mapbox/MapboxMap'), 'MapboxMap'));
```

### Notes

- Subpaths give cleaner imports and let a leaf component (or one that skips `StoreLocator`) be imported alone. They do **not** shrink the `MapboxMap` chunk itself, since `MapboxMap` statically imports its whole child family for declarative resolution — lazy child resolvers would be the lever there, as a possible follow-up.
- A follow-up PR can apply the same subpath pattern to the main `@studiometa/ui` package.

### ✅ Verification

Build, `lint:static`/`lint:types`, `npm run test` (incl. a new subpath-resolution spec), `docs:build` (playground resolves the package fine with the new `exports`) and prettier all pass.

### ❓ Type of change

- [x] 👌 Enhancement
- [x] 📖 Documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)