### PR TITLE
Lazy-load MapboxMap child components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21817,7 +21817,7 @@
       "name": "@studiometa/ui-playground",
       "version": "1.9.0",
       "dependencies": {
-        "@studiometa/playground": "0.3.10"
+        "@studiometa/playground": "0.3.11"
       },
       "devDependencies": {
         "@mapbox/mapbox-gl-geocoder": "^5.1.0",
@@ -21830,9 +21830,9 @@
       }
     },
     "packages/playground/node_modules/@studiometa/playground": {
-      "version": "0.3.10",
-      "resolved": "https://registry.npmjs.org/@studiometa/playground/-/playground-0.3.10.tgz",
-      "integrity": "sha512-UdBgyvOAfA3NK6cfnGP4qzQc+GjnBGIK3pWKDKYa61WWLfxWIKSHRiofMBoqEeSel1WF2tUwc/s4i60l52xUKw==",
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@studiometa/playground/-/playground-0.3.11.tgz",
+      "integrity": "sha512-z2qLYbuW1TpRR/Pbi3WY3tXJXyydcGvqZ+eu2/PAPJI6EZxoU5+0V9mQ6bMGox7IrBqosZf9QDNGBdzclDm4xQ==",
       "license": "MIT",
       "dependencies": {
         "@studiometa/js-toolkit": "^3.4.3",

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -9,7 +9,7 @@
     "build": "meta build"
   },
   "dependencies": {
-    "@studiometa/playground": "0.3.10"
+    "@studiometa/playground": "0.3.11"
   },
   "devDependencies": {
     "@mapbox/mapbox-gl-geocoder": "^5.1.0",

--- a/packages/tests/MapboxMap/StoreLocator.spec.ts
+++ b/packages/tests/MapboxMap/StoreLocator.spec.ts
@@ -155,15 +155,26 @@ function createStoreLocator(
 }
 
 /**
+ * Upper bound (ms) of the coordinator's time-based child-wiring retry window
+ * (`WIRE_CHILDREN_POLL_INTERVAL * WIRE_CHILDREN_MAX_POLLS`, ~5s). Flushing past
+ * it under fake timers lets the retry loop settle — wiring whatever appears and
+ * releasing its timer for the absent case — before real timers resume, so no
+ * background timer leaks across tests.
+ */
+const WIRE_WINDOW = 5500;
+
+/**
  * Mount the component, let the js-toolkit timer-based mount settle, then simulate
- * the map load so the coordinator wires itself. Leaves real timers active.
+ * the map load so the coordinator wires itself. Flushes the full child-wiring
+ * retry window so the coordinator settles (no pending timer) before real timers
+ * resume. Leaves real timers active.
  */
 async function mountAndLoad(ctx: ReturnType<typeof createStoreLocator>) {
   vi.useFakeTimers();
   ctx.instance.$mount();
   await vi.advanceTimersByTimeAsync(100);
   ctx.fireLoad();
-  await vi.advanceTimersByTimeAsync(100);
+  await vi.advanceTimersByTimeAsync(WIRE_WINDOW);
   vi.useRealTimers();
 }
 
@@ -675,7 +686,9 @@ describe('StoreLocator component', () => {
       // Listen before the load so the very first `filter` emission is counted.
       ctx.instance.$on('filter', filter);
       ctx.fireLoad();
-      await vi.advanceTimersByTimeAsync(200);
+      // Flush the full wiring-retry window (the geocoder is absent here, so the
+      // poll runs to its cap) to settle the coordinator before real timers.
+      await vi.advanceTimersByTimeAsync(WIRE_WINDOW);
       vi.useRealTimers();
 
       expect(ctx.mockCluster.setData).toHaveBeenCalledTimes(1);

--- a/packages/tests/MapboxMap/utils.spec.ts
+++ b/packages/tests/MapboxMap/utils.spec.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi } from 'vitest';
+import { Base } from '@studiometa/js-toolkit';
+import { resolveWhenMapboxMapIsLoaded } from '@studiometa/ui-mapbox/utils.js';
+
+/**
+ * A minimal `Base` subclass standing in for a `MapboxMap` child constructor. It
+ * carries the static `$isBase` flag (inherited from `Base`) that
+ * `resolveWhenMapboxMapIsLoaded` uses to tell a constructor from a loader.
+ */
+class FakeChild extends Base {
+  static config = { name: 'FakeChild' };
+}
+
+/**
+ * A minimal `MapboxMap` stand-in exposing only what the resolver touches:
+ * `isLoaded` and a `map-load` subscription.
+ */
+function fakeMap(isLoaded = false) {
+  const handlers: Record<string, Array<() => void>> = {};
+  return {
+    isLoaded,
+    $on(event: string, callback: () => void) {
+      (handlers[event] ??= []).push(callback);
+      return () => {};
+    },
+    fire(event: string) {
+      (handlers[event] ?? []).forEach((callback) => callback());
+    },
+  };
+}
+
+describe('resolveWhenMapboxMapIsLoaded', () => {
+  it('accepts a Base constructor and resolves with it once already loaded', async () => {
+    const resolver = resolveWhenMapboxMapIsLoaded(FakeChild);
+    await expect(resolver(fakeMap(true) as any)).resolves.toBe(FakeChild);
+  });
+
+  it('accepts a Base constructor and waits for map-load before resolving', async () => {
+    const map = fakeMap(false);
+    const resolver = resolveWhenMapboxMapIsLoaded(FakeChild);
+
+    let resolved = false;
+    const promise = resolver(map as any).then((ctor) => {
+      resolved = true;
+      return ctor;
+    });
+
+    // Nothing resolves until the map fires `map-load`.
+    await Promise.resolve();
+    expect(resolved).toBe(false);
+
+    map.fire('map-load');
+    await expect(promise).resolves.toBe(FakeChild);
+    expect(resolved).toBe(true);
+  });
+
+  it('accepts a loader factory returning the constructor synchronously', async () => {
+    const map = fakeMap(false);
+    const resolver = resolveWhenMapboxMapIsLoaded(() => FakeChild);
+
+    const promise = resolver(map as any);
+    map.fire('map-load');
+    await expect(promise).resolves.toBe(FakeChild);
+  });
+
+  it('accepts a loader factory returning a promise of the constructor', async () => {
+    const map = fakeMap(false);
+    const resolver = resolveWhenMapboxMapIsLoaded(() => Promise.resolve(FakeChild));
+
+    const promise = resolver(map as any);
+    map.fire('map-load');
+    await expect(promise).resolves.toBe(FakeChild);
+  });
+
+  it('unwraps a `{ default }` module namespace resolved by the loader', async () => {
+    // Mirrors a code-split `() => import('./Child.js')` whose default export is
+    // the constructor.
+    const map = fakeMap(false);
+    const resolver = resolveWhenMapboxMapIsLoaded(() => Promise.resolve({ default: FakeChild }));
+
+    const promise = resolver(map as any);
+    map.fire('map-load');
+    await expect(promise).resolves.toBe(FakeChild);
+  });
+
+  it('invokes the loader only AFTER map-load (lazy import timing)', async () => {
+    const map = fakeMap(false);
+    const loader = vi.fn(() => FakeChild);
+    const resolver = resolveWhenMapboxMapIsLoaded(loader);
+
+    resolver(map as any);
+    // The loader (and its dynamic import, in real usage) must not run before the
+    // map is ready.
+    expect(loader).not.toHaveBeenCalled();
+
+    map.fire('map-load');
+    await Promise.resolve();
+    expect(loader).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/ui-mapbox/MapboxMap.ts
+++ b/packages/ui-mapbox/MapboxMap.ts
@@ -84,39 +84,23 @@ export class MapboxMap<T extends BaseProps = BaseProps> extends Base<T & MapboxM
     // geocoder, ... chunks. `resolveWhenMapboxMapIsLoaded` still defers the
     // actual import until the map has fired `load`.
     components: {
-      MapboxSource: resolveWhenMapboxMapIsLoaded(() =>
-        import('./MapboxSource.js').then((m) => m.MapboxSource),
+      MapboxSource: resolveWhenMapboxMapIsLoaded(() => import('./MapboxSource.js')),
+      MapboxImage: resolveWhenMapboxMapIsLoaded(() => import('./MapboxImage.js')),
+      MapboxImages: resolveWhenMapboxMapIsLoaded(() => import('./MapboxImages.js')),
+      MapboxLayer: resolveWhenMapboxMapIsLoaded(() => import('./MapboxLayer.js')),
+      MapboxCluster: resolveWhenMapboxMapIsLoaded(() => import('./MapboxCluster.js')),
+      MapboxFullscreenControl: resolveWhenMapboxMapIsLoaded(
+        () => import('./MapboxFullscreenControl.js'),
       ),
-      MapboxImage: resolveWhenMapboxMapIsLoaded(() =>
-        import('./MapboxImage.js').then((m) => m.MapboxImage),
+      MapboxGeocoder: resolveWhenMapboxMapIsLoaded(() => import('./MapboxGeocoder.js')),
+      MapboxGeolocateControl: resolveWhenMapboxMapIsLoaded(
+        () => import('./MapboxGeolocateControl.js'),
       ),
-      MapboxImages: resolveWhenMapboxMapIsLoaded(() =>
-        import('./MapboxImages.js').then((m) => m.MapboxImages),
+      MapboxMarker: resolveWhenMapboxMapIsLoaded(() => import('./MapboxMarker.js')),
+      MapboxNavigationControl: resolveWhenMapboxMapIsLoaded(
+        () => import('./MapboxNavigationControl.js'),
       ),
-      MapboxLayer: resolveWhenMapboxMapIsLoaded(() =>
-        import('./MapboxLayer.js').then((m) => m.MapboxLayer),
-      ),
-      MapboxCluster: resolveWhenMapboxMapIsLoaded(() =>
-        import('./MapboxCluster.js').then((m) => m.MapboxCluster),
-      ),
-      MapboxFullscreenControl: resolveWhenMapboxMapIsLoaded(() =>
-        import('./MapboxFullscreenControl.js').then((m) => m.MapboxFullscreenControl),
-      ),
-      MapboxGeocoder: resolveWhenMapboxMapIsLoaded(() =>
-        import('./MapboxGeocoder.js').then((m) => m.MapboxGeocoder),
-      ),
-      MapboxGeolocateControl: resolveWhenMapboxMapIsLoaded(() =>
-        import('./MapboxGeolocateControl.js').then((m) => m.MapboxGeolocateControl),
-      ),
-      MapboxMarker: resolveWhenMapboxMapIsLoaded(() =>
-        import('./MapboxMarker.js').then((m) => m.MapboxMarker),
-      ),
-      MapboxNavigationControl: resolveWhenMapboxMapIsLoaded(() =>
-        import('./MapboxNavigationControl.js').then((m) => m.MapboxNavigationControl),
-      ),
-      MapboxPopup: resolveWhenMapboxMapIsLoaded(() =>
-        import('./MapboxPopup.js').then((m) => m.MapboxPopup),
-      ),
+      MapboxPopup: resolveWhenMapboxMapIsLoaded(() => import('./MapboxPopup.js')),
     },
   };
 

--- a/packages/ui-mapbox/MapboxMap.ts
+++ b/packages/ui-mapbox/MapboxMap.ts
@@ -1,17 +1,6 @@
 import { Base, type BaseConfig, type BaseProps } from '@studiometa/js-toolkit';
 import mapboxgl from 'mapbox-gl';
 import type { Map, MapOptions } from 'mapbox-gl';
-import { MapboxMarker } from './MapboxMarker.js';
-import { MapboxPopup } from './MapboxPopup.js';
-import { MapboxNavigationControl } from './MapboxNavigationControl.js';
-import { MapboxGeolocateControl } from './MapboxGeolocateControl.js';
-import { MapboxGeocoder } from './MapboxGeocoder.js';
-import { MapboxLayer } from './MapboxLayer.js';
-import { MapboxFullscreenControl } from './MapboxFullscreenControl.js';
-import { MapboxSource } from './MapboxSource.js';
-import { MapboxImage } from './MapboxImage.js';
-import { MapboxImages } from './MapboxImages.js';
-import { MapboxCluster } from './MapboxCluster.js';
 import { resolveWhenMapboxMapIsLoaded } from './utils.js';
 
 const MAP_EVENTS = [
@@ -88,18 +77,46 @@ export class MapboxMap<T extends BaseProps = BaseProps> extends Base<T & MapboxM
     // declared before `MapboxLayer`. This lets `MapboxLayer` add its layer
     // directly on mount (its source already exists) instead of from inside a
     // map event handler, which mapbox-gl does not always handle safely.
+    // Each child is a lazy `() => import(...)` loader rather than a static
+    // import, so a downstream bundler code-splits the child wrapper code into
+    // its own chunk. js-toolkit only invokes a loader when a matching child
+    // element exists, so a page using only a marker never fetches the cluster,
+    // geocoder, ... chunks. `resolveWhenMapboxMapIsLoaded` still defers the
+    // actual import until the map has fired `load`.
     components: {
-      MapboxSource: resolveWhenMapboxMapIsLoaded(MapboxSource),
-      MapboxImage: resolveWhenMapboxMapIsLoaded(MapboxImage),
-      MapboxImages: resolveWhenMapboxMapIsLoaded(MapboxImages),
-      MapboxLayer: resolveWhenMapboxMapIsLoaded(MapboxLayer),
-      MapboxCluster: resolveWhenMapboxMapIsLoaded(MapboxCluster),
-      MapboxFullscreenControl: resolveWhenMapboxMapIsLoaded(MapboxFullscreenControl),
-      MapboxGeocoder: resolveWhenMapboxMapIsLoaded(MapboxGeocoder),
-      MapboxGeolocateControl: resolveWhenMapboxMapIsLoaded(MapboxGeolocateControl),
-      MapboxMarker: resolveWhenMapboxMapIsLoaded(MapboxMarker),
-      MapboxNavigationControl: resolveWhenMapboxMapIsLoaded(MapboxNavigationControl),
-      MapboxPopup: resolveWhenMapboxMapIsLoaded(MapboxPopup),
+      MapboxSource: resolveWhenMapboxMapIsLoaded(() =>
+        import('./MapboxSource.js').then((m) => m.MapboxSource),
+      ),
+      MapboxImage: resolveWhenMapboxMapIsLoaded(() =>
+        import('./MapboxImage.js').then((m) => m.MapboxImage),
+      ),
+      MapboxImages: resolveWhenMapboxMapIsLoaded(() =>
+        import('./MapboxImages.js').then((m) => m.MapboxImages),
+      ),
+      MapboxLayer: resolveWhenMapboxMapIsLoaded(() =>
+        import('./MapboxLayer.js').then((m) => m.MapboxLayer),
+      ),
+      MapboxCluster: resolveWhenMapboxMapIsLoaded(() =>
+        import('./MapboxCluster.js').then((m) => m.MapboxCluster),
+      ),
+      MapboxFullscreenControl: resolveWhenMapboxMapIsLoaded(() =>
+        import('./MapboxFullscreenControl.js').then((m) => m.MapboxFullscreenControl),
+      ),
+      MapboxGeocoder: resolveWhenMapboxMapIsLoaded(() =>
+        import('./MapboxGeocoder.js').then((m) => m.MapboxGeocoder),
+      ),
+      MapboxGeolocateControl: resolveWhenMapboxMapIsLoaded(() =>
+        import('./MapboxGeolocateControl.js').then((m) => m.MapboxGeolocateControl),
+      ),
+      MapboxMarker: resolveWhenMapboxMapIsLoaded(() =>
+        import('./MapboxMarker.js').then((m) => m.MapboxMarker),
+      ),
+      MapboxNavigationControl: resolveWhenMapboxMapIsLoaded(() =>
+        import('./MapboxNavigationControl.js').then((m) => m.MapboxNavigationControl),
+      ),
+      MapboxPopup: resolveWhenMapboxMapIsLoaded(() =>
+        import('./MapboxPopup.js').then((m) => m.MapboxPopup),
+      ),
     },
   };
 

--- a/packages/ui-mapbox/StoreLocator.ts
+++ b/packages/ui-mapbox/StoreLocator.ts
@@ -1,5 +1,5 @@
 import { Base, type BaseProps, type BaseConfig } from '@studiometa/js-toolkit';
-import { debounce, nextTick } from '@studiometa/js-toolkit/utils';
+import { debounce } from '@studiometa/js-toolkit/utils';
 import mapboxgl from 'mapbox-gl';
 import type { LngLatLike, LngLatBoundsLike, GeoJSONSourceSpecification } from 'mapbox-gl';
 import type { FeatureCollection, Point } from 'geojson';
@@ -9,12 +9,26 @@ import type { MapboxCluster } from './MapboxCluster.js';
 import type { MapboxGeocoder } from './MapboxGeocoder.js';
 
 /**
- * Maximum number of `nextTick` retries used to wire the optional `MapboxCluster`
- * and `MapboxGeocoder` children. They are mounted asynchronously by the
- * `MapboxMap` once its map has loaded, so they may not be queryable yet on the
- * `map-load` event: we poll a few ticks before giving up.
+ * Wall-clock delay, in milliseconds, between two attempts to wire the optional
+ * `MapboxCluster`/`MapboxGeocoder` children.
+ *
+ * The children are now **lazy-loaded**: the `MapboxMap` fetches each child's
+ * chunk over the network before mounting it, so a child can appear hundreds of
+ * milliseconds after `map-load`. Retrying on a real time interval (rather than
+ * on `nextTick`/microtasks, which all drain within a millisecond or two and can
+ * exhaust long before a network round-trip) makes wiring survive that latency.
  */
-const WIRE_CHILDREN_MAX_ATTEMPTS = 10;
+const WIRE_CHILDREN_POLL_INTERVAL = 250;
+
+/**
+ * Maximum number of wiring re-checks, capping the total wait at
+ * `WIRE_CHILDREN_POLL_INTERVAL * WIRE_CHILDREN_MAX_POLLS` (~5s) of wall-clock
+ * time. This is the latency budget for a still-loading child; it dwarfs a
+ * realistic chunk fetch (tens to a few hundred ms) yet stays bounded so a
+ * `StoreLocator` whose optional children are simply absent settles and stops
+ * retrying instead of spinning forever.
+ */
+const WIRE_CHILDREN_MAX_POLLS = 20;
 
 export interface StoreLocatorProps extends BaseProps {
   $refs: {
@@ -120,6 +134,28 @@ export class StoreLocator<T extends BaseProps = BaseProps> extends Base<T & Stor
    * @private
    */
   __geocoderWired = false;
+
+  /**
+   * Whether the initial `__handleMapLoad` sync has run. Until it does, a
+   * cluster wired on the first synchronous pass must NOT trigger its own sync
+   * (that first sync is `__handleMapLoad`'s responsibility); afterwards, a
+   * cluster that mounts late DOES sync so its freshly-added source gets the
+   * derived data.
+   * @private
+   */
+  __initialWireDone = false;
+
+  /**
+   * Pending wiring-retry timer id, if a retry is scheduled.
+   * @private
+   */
+  __wireTimer?: ReturnType<typeof setTimeout>;
+
+  /**
+   * Number of wiring re-checks performed so far, bounding the retry loop.
+   * @private
+   */
+  __wirePolls = 0;
 
   /**
    * The closest child `MapboxMap` component.
@@ -414,39 +450,41 @@ export class StoreLocator<T extends BaseProps = BaseProps> extends Base<T & Stor
   __handleMapLoad = () => {
     this.isLoaded = true;
     this.map?.on('moveend', this.__handleMoveEnd);
+    // First synchronous wiring pass: covers children already mounted at load.
     this.__wireChildren();
+    this.__initialWireDone = true;
+    // The single initial data push (a cluster wired above intentionally did not
+    // sync yet, deferring to this call).
     this.__syncItems();
+    // Anything still missing (a lazily-fetched child not mounted yet) is wired
+    // by the latency-safe retry machinery below.
+    this.__armWiringRetries();
   };
 
   /**
-   * Attach the `MapboxCluster`/`MapboxGeocoder` listeners once those children
-   * are available. Both are optional and mount asynchronously and independently
-   * after the map loads, so we poll a bounded number of ticks until *each* of
-   * them is wired (not just the first to appear): if the cluster mounts before
-   * the geocoder, stopping as soon as the cluster is wired would leave the
-   * geocoder's `result` listener unattached. A `StoreLocator` missing one (or
-   * both) of these children simply polls to the attempt cap — bounded and
-   * harmless.
+   * Attach the `MapboxCluster`/`MapboxGeocoder` listeners for whichever of those
+   * children is currently available. Idempotent: each child is wired at most
+   * once, so it is safe to call any number of times from any wiring trigger.
+   *
+   * The cluster is an async child of the `MapboxMap`: it becomes queryable as
+   * soon as it is constructed, but its GeoJSON source is only added from its
+   * `mounted()` hook. Pushing data before that hook runs would silently no-op
+   * (the source does not exist yet) and leave the map empty, so we wait until
+   * the cluster is fully mounted — `$isMounted` flips to `true` right before
+   * `mounted()` runs synchronously, so observing it here guarantees the source
+   * is ready.
    * @private
-   * @param {number} attempt
    */
-  __wireChildren(attempt = 0) {
+  __wireChildren() {
     const { cluster, geocoder } = this;
 
-    // The cluster is an async child of the `MapboxMap`: it becomes queryable as
-    // soon as it is constructed, but its GeoJSON source is only added from its
-    // `mounted()` hook. Pushing data before that hook runs would silently no-op
-    // (the source does not exist yet) and leave the map empty, so we wait until
-    // the cluster is fully mounted — `$isMounted` flips to `true` right before
-    // `mounted()` runs synchronously, so observing it here guarantees the source
-    // is ready. Until then we keep polling.
     if (cluster && cluster.$isMounted && !this.__clusterWired) {
       this.__clusterWired = true;
       this.__offHandlers.push(cluster.$on('feature-click', this.__handleClusterFeatureClick));
       // The cluster (and its source) are now ready: push the current data to it.
-      // Only resync when the cluster became available AFTER the initial pass; on
-      // the first pass `__handleMapLoad`'s own `__syncItems()` call already covers it.
-      if (attempt > 0) {
+      // Skip only on the initial synchronous pass, whose sync `__handleMapLoad`
+      // performs itself; a cluster that mounts later must (re)push here.
+      if (this.__initialWireDone) {
         this.__syncItems();
       }
     }
@@ -455,14 +493,105 @@ export class StoreLocator<T extends BaseProps = BaseProps> extends Base<T & Stor
       this.__geocoderWired = true;
       this.__offHandlers.push(geocoder.$on('result', this.__handleGeocoderResult));
     }
+  }
 
-    if ((!this.__clusterWired || !this.__geocoderWired) && attempt < WIRE_CHILDREN_MAX_ATTEMPTS) {
-      nextTick(() => {
-        if (this.$isMounted) {
-          this.__wireChildren(attempt + 1);
-        }
-      });
+  /**
+   * Whether every optional child that can be wired has been wired, i.e. there is
+   * nothing left to wait for.
+   * @private
+   * @returns {boolean}
+   */
+  __wiringSettled(): boolean {
+    return this.__clusterWired && this.__geocoderWired;
+  }
+
+  /**
+   * Arm the latency-safe wiring retries for any child not yet wired.
+   *
+   * With lazy-loaded children the cluster/geocoder can mount well after
+   * `map-load`, once their code-split chunks have been fetched. Two independent
+   * triggers make wiring robust to that delay:
+   *
+   * 1. A **real signal** — the map's `sourcedata` event. The cluster adds its
+   *    GeoJSON source from `mounted()`, which fires `sourcedata` no matter how
+   *    long its chunk took to arrive, so we re-check wiring immediately then.
+   *    This is what guarantees the cluster invariant (push `setData` + wire
+   *    `feature-click`) survives arbitrary network latency within the budget.
+   * 2. A **time-based poll** — a re-check every `WIRE_CHILDREN_POLL_INTERVAL`ms,
+   *    capped at `WIRE_CHILDREN_MAX_POLLS`. The geocoder adds no map source, so
+   *    it has no equivalent signal; the poll covers it (and doubles as a cluster
+   *    safety net). Being time-based rather than microtask-based is the actual
+   *    fix: it keeps checking across real network time instead of exhausting in
+   *    a couple of milliseconds.
+   *
+   * Both triggers are torn down as soon as wiring settles or the poll cap is
+   * reached, so a `StoreLocator` whose children are absent settles cleanly with
+   * no leaked timer or listener.
+   * @private
+   */
+  __armWiringRetries() {
+    if (this.__wiringSettled()) {
+      return;
     }
+
+    this.map?.on('sourcedata', this.__handleWireSignal);
+    this.__scheduleWirePoll();
+  }
+
+  /**
+   * Re-check wiring in response to a map `sourcedata` event (the cluster's
+   * source landing), and stop retrying once nothing is left to wire.
+   * @private
+   */
+  __handleWireSignal = () => {
+    if (!this.$isMounted) {
+      return;
+    }
+
+    this.__wireChildren();
+
+    if (this.__wiringSettled()) {
+      this.__stopWiringRetries();
+    }
+  };
+
+  /**
+   * Schedule the next time-based wiring re-check, unless the poll cap is hit.
+   * @private
+   */
+  __scheduleWirePoll() {
+    this.__wireTimer = setTimeout(() => {
+      this.__wireTimer = undefined;
+
+      if (!this.$isMounted) {
+        return;
+      }
+
+      this.__wirePolls += 1;
+      this.__wireChildren();
+
+      if (this.__wiringSettled() || this.__wirePolls >= WIRE_CHILDREN_MAX_POLLS) {
+        // Either everything is wired, or we have waited out the latency budget
+        // for a child that never appeared: settle and release the triggers.
+        this.__stopWiringRetries();
+      } else {
+        this.__scheduleWirePoll();
+      }
+    }, WIRE_CHILDREN_POLL_INTERVAL);
+  }
+
+  /**
+   * Tear down both wiring triggers (the pending poll timer and the `sourcedata`
+   * listener). Safe to call when nothing is armed.
+   * @private
+   */
+  __stopWiringRetries() {
+    if (this.__wireTimer !== undefined) {
+      clearTimeout(this.__wireTimer);
+      this.__wireTimer = undefined;
+    }
+
+    this.map?.off('sourcedata', this.__handleWireSignal);
   }
 
   /**
@@ -486,6 +615,10 @@ export class StoreLocator<T extends BaseProps = BaseProps> extends Base<T & Stor
    * Destroyed hook: detach every listener and clear the registry.
    */
   destroyed() {
+    // Release the wiring triggers first, so a poll or `sourcedata` callback can
+    // never fire after teardown.
+    this.__stopWiringRetries();
+
     for (const off of this.__offHandlers) {
       off();
     }
@@ -498,6 +631,8 @@ export class StoreLocator<T extends BaseProps = BaseProps> extends Base<T & Stor
     this.isLoaded = false;
     this.__clusterWired = false;
     this.__geocoderWired = false;
+    this.__initialWireDone = false;
+    this.__wirePolls = 0;
   }
 }
 

--- a/packages/ui-mapbox/utils.ts
+++ b/packages/ui-mapbox/utils.ts
@@ -100,6 +100,30 @@ export async function addMapboxImage(
 }
 
 /**
+ * A lazy loader for a `MapboxMap` child component constructor.
+ *
+ * It may return the constructor directly, a module namespace exposing it as the
+ * `default` export, or a promise of either — the latter enabling a code-split
+ * `() => import('./MapboxChild.js').then((m) => m.MapboxChild)` so the child's
+ * chunk is fetched only when a matching element exists on the page.
+ */
+export type MapboxMapChildLoader<T extends BaseConstructor> = () =>
+  | T
+  | { default: T }
+  | Promise<T | { default: T }>;
+
+/**
+ * Normalize a resolved loader value — a constructor or a `{ default }` module
+ * namespace — down to the bare constructor.
+ *
+ * @param   {T | { default: T }} module The value a loader resolved with.
+ * @returns {T}
+ */
+function toConstructor<T extends BaseConstructor>(module: T | { default: T }): T {
+  return (module as { default?: T }).default ?? (module as T);
+}
+
+/**
  * Wrap a `MapboxMap` child component into an async constructor that resolves
  * only once the parent Mapbox map instance has finished loading.
  *
@@ -107,22 +131,38 @@ export async function addMapboxImage(
  * the `MapboxMap`) and awaits the returned promise before mounting the child,
  * which guarantees the child can safely access the fully loaded map.
  *
- * @param   {T} Component The child component constructor to resolve.
+ * The argument is either:
+ *
+ * - a `Base` constructor (detected through its static `$isBase` flag), kept for
+ *   backward compatibility with callers still passing a class directly; or
+ * - a {@link MapboxMapChildLoader} factory, invoked **after** the map has loaded
+ *   so a `() => import(...)` only fetches the child's chunk once js-toolkit has
+ *   found a matching element AND the map is ready.
+ *
+ * @param   {T | MapboxMapChildLoader<T>} componentOrLoader The child constructor or its lazy loader.
  * @returns {(mapboxMap: MapboxMap) => Promise<T>}
  */
-export function resolveWhenMapboxMapIsLoaded<T extends BaseConstructor>(Component: T) {
+export function resolveWhenMapboxMapIsLoaded<T extends BaseConstructor>(
+  componentOrLoader: T | MapboxMapChildLoader<T>,
+) {
+  // A `Base` constructor carries the static `$isBase` flag; anything else is
+  // treated as a loader factory. This keeps the historical "pass a class"
+  // signature working while enabling the lazy `() => import(...)` form.
+  const loader: MapboxMapChildLoader<T> =
+    '$isBase' in componentOrLoader ? () => componentOrLoader : componentOrLoader;
+
   return (mapboxMap: MapboxMap): Promise<T> =>
     new Promise((resolve) => {
+      // Invoke the loader (and await its dynamic import, if any) only once the
+      // map has loaded, then hand js-toolkit the resolved constructor.
+      function resolveComponent() {
+        resolve(Promise.resolve(loader()).then(toConstructor));
+      }
+
       if (mapboxMap.isLoaded) {
-        resolve(Component);
+        resolveComponent();
       } else {
-        mapboxMap.$on(
-          'map-load',
-          () => {
-            resolve(Component);
-          },
-          { once: true },
-        );
+        mapboxMap.$on('map-load', resolveComponent, { once: true });
       }
     });
 }


### PR DESCRIPTION
Follow-up optimization for `@studiometa/ui-mapbox`.

### 📚 Description

`MapboxMap` statically imported all 11 children (markers, popups, controls, source, layer, images, cluster), so importing the map dragged the whole family's wrapper code into its chunk even for a page that only uses, say, a marker. This registers each child with a **dynamic-import loader** instead, so js-toolkit fetches a child's code only when a matching element exists on the page.

- `resolveWhenMapboxMapIsLoaded` now accepts a loader factory `() => import(...)` (or a class, for backward-compat) and awaits the dynamic import after the map's `load`.
- Each `config.components` entry is now `resolveWhenMapboxMapIsLoaded(() => import('./X.js').then((m) => m.X))`.

### ⚖️ Honest impact

This is a **pay-per-use** win on the child *wrapper* code, not the heavyweight:
- `mapbox-gl` (~230 kB) is loaded by `MapboxMap` regardless — **unaffected**.
- The `@mapbox/mapbox-gl-geocoder` peer was already lazy (dynamic import inside `MapboxGeocoder`).
- Measured (esbuild, `mapbox-gl` external): a "MapboxMap + one marker" page goes from an **11.4 kB** up-front child chunk to **~2.5 kB** (entry + the marker chunk), with the cluster (~4 kB min), geocoder, controls, etc. never fetched. Total across all chunks grows slightly from split boilerplate — paid only by a page using every child.

### 🔧 StoreLocator hardening (required)

With lazy children, the cluster mounts only after its chunk is **network-fetched**, which outlasts StoreLocator's old microtask-bound wiring poll. The poll is replaced with the map's `sourcedata` signal (fires when the cluster adds its source, at any latency) plus a real-time retry (~5 s budget), both torn down once wiring settles or on destroy.

### ✅ Verification

Build, lint, `npm run test` (689 pass incl. a new resolver spec) all pass. **Real-browser verification of the StoreLocator timing under network-latency chunk loading is being done via the playground stories** (jsdom can't reproduce it) — results to follow on this PR.

### ❓ Type of change

- [x] 👌 Enhancement (performance)

🤖 Generated with [Claude Code](https://claude.com/claude-code)