### PR TITLE
Prefix all Mapbox component events

### DIFF
--- a/packages/docs/migration-guides/vue-mapbox-gl/index.md
+++ b/packages/docs/migration-guides/vue-mapbox-gl/index.md
@@ -39,31 +39,35 @@ import { registerComponent, importWhenVisible } from '@studiometa/js-toolkit';
 
 // Register only the components your page uses; order doesn't matter.
 registerComponent(importWhenVisible(() => import('@studiometa/ui-mapbox/MapboxMap'), 'MapboxMap'));
-registerComponent(importWhenVisible(() => import('@studiometa/ui-mapbox/MapboxMarker'), 'MapboxMarker'));
-registerComponent(importWhenVisible(() => import('@studiometa/ui-mapbox/MapboxPopup'), 'MapboxPopup'));
+registerComponent(
+  importWhenVisible(() => import('@studiometa/ui-mapbox/MapboxMarker'), 'MapboxMarker'),
+);
+registerComponent(
+  importWhenVisible(() => import('@studiometa/ui-mapbox/MapboxPopup'), 'MapboxPopup'),
+);
 ```
 
 ## Component mapping
 
 Most Vue components have a same-named js-toolkit equivalent, which you author as `data-component` elements nested inside a `MapboxMap` instead of Vue templates. The clustering and store-locator components are the exception — they were re-architected around a new `MapboxClusterItem`, detailed below the table.
 
-| `@studiometa/vue-mapbox-gl` | `@studiometa/ui-mapbox`   | Notes                                                                                                                                                |
-| --------------------------- | ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `MapboxMap`                 | `MapboxMap`               | Root component, owns the map instance.                                                                                                               |
-| `MapboxMarker`              | `MapboxMarker`            |                                                                                                                                                      |
-| `MapboxPopup`               | `MapboxPopup`             | Content comes from the element's inner HTML.                                                                                                         |
-| `MapboxNavigationControl`   | `MapboxNavigationControl` |                                                                                                                                                      |
-| `MapboxGeolocateControl`    | `MapboxGeolocateControl`  |                                                                                                                                                      |
-| `MapboxFullscreenControl`   | `MapboxFullscreenControl` | Ported.                                                                                                                                              |
-| `MapboxGeocoder`            | `MapboxGeocoder`          | Needs the optional `@mapbox/mapbox-gl-geocoder`.                                                                                                     |
-| `MapboxSource`              | `MapboxSource`            | Ported.                                                                                                                                              |
-| `MapboxLayer`               | `MapboxLayer`             |                                                                                                                                                      |
-| `MapboxImage`               | `MapboxImage`             | Ported.                                                                                                                                              |
-| `MapboxImages`              | `MapboxImages`            | Ported.                                                                                                                                              |
-| `MapboxCluster`             | `MapboxCluster`           | Re-architected — the source is derived from child `MapboxClusterItem`s, not a `data` prop. See [below](#mapboxcluster-data).                         |
-| —                           | `MapboxClusterItem`       | **New** — a rendered cluster entry (list item + map feature). See [below](#mapboxcluster-data).                                                      |
+| `@studiometa/vue-mapbox-gl` | `@studiometa/ui-mapbox`   | Notes                                                                                                                                                     |
+| --------------------------- | ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `MapboxMap`                 | `MapboxMap`               | Root component, owns the map instance.                                                                                                                    |
+| `MapboxMarker`              | `MapboxMarker`            |                                                                                                                                                           |
+| `MapboxPopup`               | `MapboxPopup`             | Content comes from the element's inner HTML.                                                                                                              |
+| `MapboxNavigationControl`   | `MapboxNavigationControl` |                                                                                                                                                           |
+| `MapboxGeolocateControl`    | `MapboxGeolocateControl`  |                                                                                                                                                           |
+| `MapboxFullscreenControl`   | `MapboxFullscreenControl` | Ported.                                                                                                                                                   |
+| `MapboxGeocoder`            | `MapboxGeocoder`          | Needs the optional `@mapbox/mapbox-gl-geocoder`.                                                                                                          |
+| `MapboxSource`              | `MapboxSource`            | Ported.                                                                                                                                                   |
+| `MapboxLayer`               | `MapboxLayer`             |                                                                                                                                                           |
+| `MapboxImage`               | `MapboxImage`             | Ported.                                                                                                                                                   |
+| `MapboxImages`              | `MapboxImages`            | Ported.                                                                                                                                                   |
+| `MapboxCluster`             | `MapboxCluster`           | Re-architected — the source is derived from child `MapboxClusterItem`s, not a `data` prop. See [below](#mapboxcluster-data).                              |
+| —                           | `MapboxClusterItem`       | **New** — a rendered cluster entry (list item + map feature). See [below](#mapboxcluster-data).                                                           |
 | `StoreLocator`              | `StoreLocator`            | Re-implemented as a thin orchestrator over `MapboxMap` + `MapboxCluster` + `MapboxClusterItem`s. See its [documentation](/reference/items/StoreLocator/). |
-| `VueScroller`               | —                         | No equivalent needed — the store list is a plain scrollable element, styled with CSS.                                                                |
+| `VueScroller`               | —                         | No equivalent needed — the store list is a plain scrollable element, styled with CSS.                                                                     |
 
 ::: tip StoreLocator is now available
 `StoreLocator` has been re-implemented as a thin **orchestrator** over a `MapboxMap` + `MapboxCluster` + `MapboxClusterItem`s (plus an optional `MapboxGeocoder`). The single-purpose `StoreLocatorItem` class of the Vue library is gone: each store is a `MapboxClusterItem` that is at once the sidebar list entry and the map feature. The `VueScroller` helper has no equivalent — the list is a plain scrollable element you style with CSS. See the [`StoreLocator` documentation](/reference/items/StoreLocator/).
@@ -104,18 +108,18 @@ A key structural difference: the map needs an explicit **`container` ref** child
 
 ### Event listeners → emitted events
 
-The Vue library re-emits Mapbox map events prefixed with `mb-` (e.g. `@mb-load`, `@mb-click`). In js-toolkit, listen to the emitted events from a parent component with `on<ComponentName><EventName>` handler methods.
+The Vue library re-emits Mapbox map events prefixed with `mb-` (e.g. `@mb-load`, `@mb-click`). The js-toolkit components use the `map-` prefix instead. Listen to the emitted events from a parent component with `on<ComponentName><EventName>` handler methods.
 
 | Vue listener                  | js-toolkit emitted event | Parent handler method         |
 | ----------------------------- | ------------------------ | ----------------------------- |
 | `@mb-load` (map loaded)       | `map-load`               | `onMapboxMapMapLoad`          |
-| `@mb-click`                   | `click`                  | `onMapboxMapClick`            |
-| `@mb-moveend`                 | `moveend`                | `onMapboxMapMoveend`          |
-| `@mb-zoomend`                 | `zoomend`                | `onMapboxMapZoomend`          |
+| `@mb-click`                   | `map-click`              | `onMapboxMapMapClick`         |
+| `@mb-moveend`                 | `map-moveend`            | `onMapboxMapMapMoveend`       |
+| `@mb-zoomend`                 | `map-zoomend`            | `onMapboxMapMapZoomend`       |
 | `MapboxCluster` cluster click | `cluster-click`          | `onMapboxClusterClusterClick` |
 | `MapboxCluster` feature click | `item-click`             | `onMapboxClusterItemClick`    |
 
-The `MapboxMap` component re-emits the full list of Mapbox map events; `MapboxCluster` emits `cluster-click`, `item-click` (an unclustered point, resolved back to the registered `MapboxClusterItem` behind it) and `update` (the item set changed); `MapboxGeocoder` emits `result`; `MapboxImage` and `MapboxImages` emit `ready`. See each component's events in the [JS API](/reference/items/MapboxMap/js-api).
+The `MapboxMap` component re-emits the full list of Mapbox map events with the `map-` prefix; `MapboxCluster` emits `cluster-click`, `item-click` (an unclustered point, resolved back to the registered `MapboxClusterItem` behind it) and `update` (the item set changed); `MapboxGeocoder` emits `result`; `MapboxImage` and `MapboxImages` emit `ready`. See each component's events in the [JS API](/reference/items/MapboxMap/js-api).
 
 ```js
 import { Base, createApp } from '@studiometa/js-toolkit';
@@ -131,7 +135,7 @@ class App extends Base {
     console.log('Map is ready', map);
   }
 
-  onMapboxMapClick(event) {
+  onMapboxMapMapClick(event) {
     console.log('Clicked at', event.lngLat);
   }
 }

--- a/packages/docs/migration-guides/vue-mapbox-gl/index.md
+++ b/packages/docs/migration-guides/vue-mapbox-gl/index.md
@@ -110,16 +110,16 @@ A key structural difference: the map needs an explicit **`container` ref** child
 
 The Vue library re-emits Mapbox map events prefixed with `mb-` (e.g. `@mb-load`, `@mb-click`). The js-toolkit components use the `map-` prefix instead. Listen to the emitted events from a parent component with `on<ComponentName><EventName>` handler methods.
 
-| Vue listener                  | js-toolkit emitted event | Parent handler method         |
-| ----------------------------- | ------------------------ | ----------------------------- |
-| `@mb-load` (map loaded)       | `map-load`               | `onMapboxMapMapLoad`          |
-| `@mb-click`                   | `map-click`              | `onMapboxMapMapClick`         |
-| `@mb-moveend`                 | `map-moveend`            | `onMapboxMapMapMoveend`       |
-| `@mb-zoomend`                 | `map-zoomend`            | `onMapboxMapMapZoomend`       |
-| `MapboxCluster` cluster click | `cluster-click`          | `onMapboxClusterClusterClick` |
-| `MapboxCluster` feature click | `item-click`             | `onMapboxClusterItemClick`    |
+| Vue listener                  | js-toolkit emitted event | Parent handler method            |
+| ----------------------------- | ------------------------ | -------------------------------- |
+| `@mb-load` (map loaded)       | `map-load`               | `onMapboxMapMapLoad`             |
+| `@mb-click`                   | `map-click`              | `onMapboxMapMapClick`            |
+| `@mb-moveend`                 | `map-moveend`            | `onMapboxMapMapMoveend`          |
+| `@mb-zoomend`                 | `map-zoomend`            | `onMapboxMapMapZoomend`          |
+| `MapboxCluster` cluster click | `map-cluster-click`      | `onMapboxClusterMapClusterClick` |
+| `MapboxCluster` feature click | `map-item-click`         | `onMapboxClusterMapItemClick`    |
 
-The `MapboxMap` component re-emits the full list of Mapbox map events with the `map-` prefix; `MapboxCluster` emits `cluster-click`, `item-click` (an unclustered point, resolved back to the registered `MapboxClusterItem` behind it) and `update` (the item set changed); `MapboxGeocoder` emits `result`; `MapboxImage` and `MapboxImages` emit `ready`. See each component's events in the [JS API](/reference/items/MapboxMap/js-api).
+Every public event uses the `map-` prefix. The `MapboxMap` component re-emits the full list of Mapbox map events; `MapboxCluster` emits `map-cluster-click`, `map-item-click` (an unclustered point, resolved back to the registered `MapboxClusterItem` behind it) and `map-update` (the item set changed); `MapboxGeocoder` emits `map-result`; `MapboxImage` and `MapboxImages` emit `map-ready`; map children emit `map-error` when guarded lifecycle work fails; and `StoreLocator` emits `map-select`, `map-deselect` and `map-filter`. See each component's events in the [JS API](/reference/items/MapboxMap/js-api).
 
 ```js
 import { Base, createApp } from '@studiometa/js-toolkit';
@@ -131,11 +131,11 @@ class App extends Base {
     components: { MapboxMap },
   };
 
-  onMapboxMapMapLoad(map) {
+  onMapboxMapMapLoad({ args: [map] }) {
     console.log('Map is ready', map);
   }
 
-  onMapboxMapMapClick(event) {
+  onMapboxMapMapClick({ args: [event] }) {
     console.log('Clicked at', event.lngLat);
   }
 }
@@ -271,7 +271,7 @@ class App extends Base {
     components: { MapboxMap },
   };
 
-  onMapboxMapMapLoad(map) {
+  onMapboxMapMapLoad({ args: [map] }) {
     // former @mb-load handler
   }
 }

--- a/packages/docs/reference/items/MapboxMap/examples.md
+++ b/packages/docs/reference/items/MapboxMap/examples.md
@@ -92,7 +92,7 @@ Add a [source](https://docs.mapbox.com/style-spec/reference/sources/) with `Mapb
 
 ## Images
 
-Register images against the map sprite so they can be referenced from a symbol layer's `icon-image`. Use `MapboxImage` for a single image, or `MapboxImages` to load several at once through its `sources` option. Both emit a `ready` event once the image(s) are loaded. The symbol layer below pairs each `icon-image` with a `text-field` label.
+Register images against the map sprite so they can be referenced from a symbol layer's `icon-image`. Use `MapboxImage` for a single image, or `MapboxImages` to load several at once through its `sources` option. Both emit a `map-ready` event once the image(s) are loaded. The symbol layer below pairs each `icon-image` with a `text-field` label.
 
 <PreviewPlayground
   :html="() => import('./stories/images/app.twig')"
@@ -133,7 +133,7 @@ The cluster owns no authored data. Each point is a `MapboxClusterItem` that self
 </div>
 ```
 
-The cluster reports a click on an unclustered point through its `item-click` event but never selects or flies on its own. To turn this into a full "find a store near you" experience — selection, popups, viewport filtering and address search — wrap the cluster in a [`StoreLocator`](/reference/items/StoreLocator/) orchestrator.
+The cluster reports a click on an unclustered point through its `map-item-click` event but never selects or flies on its own. To turn this into a full "find a store near you" experience — selection, popups, viewport filtering and address search — wrap the cluster in a [`StoreLocator`](/reference/items/StoreLocator/) orchestrator.
 
 ## Listening to map events
 
@@ -149,11 +149,11 @@ class App extends Base {
     components: { MapboxMap },
   };
 
-  onMapboxMapMapLoad(map) {
+  onMapboxMapMapLoad({ args: [map] }) {
     console.log('Map loaded', map);
   }
 
-  onMapboxMapMapClick(event) {
+  onMapboxMapMapClick({ args: [event] }) {
     console.log('Clicked at', event.lngLat);
   }
 }

--- a/packages/docs/reference/items/MapboxMap/examples.md
+++ b/packages/docs/reference/items/MapboxMap/examples.md
@@ -137,7 +137,7 @@ The cluster reports a click on an unclustered point through its `item-click` eve
 
 ## Listening to map events
 
-The `MapboxMap` component re-emits the Mapbox map events. Listen to them from a parent component by defining `on<ComponentName><EventName>` methods — for example `onMapboxMapClick` or `onMapboxMapMapLoad` for the custom `map-load` event.
+The `MapboxMap` component re-emits the Mapbox map events with a `map-` prefix to avoid conflicts with native events. Listen to them from a parent component by defining `on<ComponentName><EventName>` methods — for example `onMapboxMapMapClick` or `onMapboxMapMapLoad`.
 
 ```js
 import { Base, createApp } from '@studiometa/js-toolkit';
@@ -153,7 +153,7 @@ class App extends Base {
     console.log('Map loaded', map);
   }
 
-  onMapboxMapClick(event) {
+  onMapboxMapMapClick(event) {
     console.log('Clicked at', event.lngLat);
   }
 }

--- a/packages/docs/reference/items/MapboxMap/js-api.md
+++ b/packages/docs/reference/items/MapboxMap/js-api.md
@@ -107,113 +107,109 @@ Whether the map has finished loading.
 
 #### Events
 
-The component emits a custom `map-load` event, plus all the common Mapbox GL map events, re-emitted under the same name. Each handler receives the corresponding Mapbox event object (the `map-load` handler receives the `map` instance).
+The component emits a custom `map-load` event, plus all the common Mapbox GL map events prefixed with `map-` to avoid conflicts with native events. Each handler receives the corresponding Mapbox event object (the `map-load` handler receives the `map` instance).
 
 ##### `map-load`
 
 The map finished loading (custom event).
 
-##### `load`
-
-Map resources are loaded.
-
-##### `idle`
+##### `map-idle`
 
 The map is idle after rendering.
 
-##### `render`
+##### `map-render`
 
 A frame is rendered.
 
-##### `resize`
+##### `map-resize`
 
 The map container is resized.
 
-##### `remove`
+##### `map-remove`
 
 The map is removed.
 
-##### `error`
+##### `map-error`
 
 An error occurred.
 
-##### `click`
+##### `map-click`
 
 A click on the map.
 
-##### `dblclick`
+##### `map-dblclick`
 
 A double-click on the map.
 
-##### `mouseenter`
+##### `map-mouseenter`
 
 The pointer enters the map canvas.
 
-##### `mouseleave`
+##### `map-mouseleave`
 
 The pointer leaves the map canvas.
 
-##### `mousemove`
+##### `map-mousemove`
 
 The pointer moves over the map.
 
-##### `movestart`
+##### `map-movestart`
 
 Map movement starts (pan, zoom, rotate).
 
-##### `move`
+##### `map-move`
 
 The map is moving.
 
-##### `moveend`
+##### `map-moveend`
 
 Map movement ends.
 
-##### `zoomstart`
+##### `map-zoomstart`
 
 A zoom transition starts.
 
-##### `zoom`
+##### `map-zoom`
 
 The zoom level changes.
 
-##### `zoomend`
+##### `map-zoomend`
 
 A zoom transition ends.
 
-##### `rotatestart`
+##### `map-rotatestart`
 
 Rotation starts.
 
-##### `rotate`
+##### `map-rotate`
 
 The map is rotating.
 
-##### `rotateend`
+##### `map-rotateend`
 
 Rotation ends.
 
-##### `pitchstart`
+##### `map-pitchstart`
 
 A pitch transition starts.
 
-##### `pitch`
+##### `map-pitch`
 
 The pitch changes.
 
-##### `pitchend`
+##### `map-pitchend`
 
 A pitch transition ends.
 
-##### `dragstart`
+##### `map-dragstart`
 
 A drag starts.
 
-##### `drag`
+##### `map-drag`
 
 The map is being dragged.
 
-##### `dragend`
+##### `map-dragend`
 
 A drag ends.
 
@@ -233,11 +229,11 @@ class App extends Base {
     console.log('Map is ready', map);
   }
 
-  onMapboxMapClick(event) {
+  onMapboxMapMapClick(event) {
     console.log('Clicked at', event.lngLat);
   }
 
-  onMapboxMapZoomend(event) {
+  onMapboxMapMapZoomend(event) {
     console.log('New zoom level', event.target.getZoom());
   }
 }

--- a/packages/docs/reference/items/MapboxMap/js-api.md
+++ b/packages/docs/reference/items/MapboxMap/js-api.md
@@ -225,15 +225,15 @@ class App extends Base {
     components: { MapboxMap },
   };
 
-  onMapboxMapMapLoad(map) {
+  onMapboxMapMapLoad({ args: [map] }) {
     console.log('Map is ready', map);
   }
 
-  onMapboxMapMapClick(event) {
+  onMapboxMapMapClick({ args: [event] }) {
     console.log('Clicked at', event.lngLat);
   }
 
-  onMapboxMapMapZoomend(event) {
+  onMapboxMapMapZoomend({ args: [event] }) {
     console.log('New zoom level', event.target.getZoom());
   }
 }
@@ -451,7 +451,7 @@ Where the control is mounted, depending on `add-to-map`.
 
 #### Events
 
-##### `result`
+##### `map-result`
 
 - Payload: `result`
 
@@ -544,7 +544,7 @@ Options forwarded to [`map.addImage`](https://docs.mapbox.com/mapbox-gl-js/api/m
 
 #### Events
 
-##### `ready`
+##### `map-ready`
 
 - Payload: `{ name, image, options }`
 
@@ -565,7 +565,7 @@ A list of image definitions, each `{ name, url, options? }`. See [`MapboxImage`]
 
 #### Events
 
-##### `ready`
+##### `map-ready`
 
 - Payload: `MapboxImage[]`
 
@@ -577,7 +577,7 @@ Emitted once every image has been loaded and added.
 
 A clustered GeoJSON **source driver** whose features ARE its rendered items. The `MapboxClusterItem`s living in its subtree self-register, and the cluster derives its clustered GeoJSON source from that registry — the same markup drives both a sidebar list and the clustered points on the map. It sets up the clustered source, the cluster circles layer, the cluster count labels layer and the unclustered points layer, together with the click-to-zoom interaction on clusters and pointer feedback on features.
 
-The cluster is deliberately thin: it owns only the map data and the clustering interaction. It does **not** select, fly to, filter by viewport or open popups — those search-UX concerns belong to the optional [`StoreLocator`](/reference/items/StoreLocator/) orchestrator, which drives them on top of a cluster. Used on its own, a `MapboxCluster` still renders a working clustered map + list; it simply reports a click on an unclustered point through the `item-click` event and lets the caller decide what it means.
+The cluster is deliberately thin: it owns only the map data and the clustering interaction. It does **not** select, fly to, filter by viewport or open popups — those search-UX concerns belong to the optional [`StoreLocator`](/reference/items/StoreLocator/) orchestrator, which drives them on top of a cluster. Used on its own, a `MapboxCluster` still renders a working clustered map + list; it simply reports a click on an unclustered point through the `map-item-click` event and lets the caller decide what it means.
 
 #### Options
 
@@ -688,19 +688,19 @@ Replace the live source data directly, bypassing the item registry — for imper
 
 #### Events
 
-##### `cluster-click`
+##### `map-cluster-click`
 
 - Payload: `(clusterId, event)`
 
 A cluster was clicked. Call `event.preventDefault()` to skip the default zoom-to-cluster behavior.
 
-##### `item-click`
+##### `map-item-click`
 
 - Payload: `(item, feature, event)`
 
 An unclustered point was clicked. `item` is the registered `MapboxClusterItem` behind the feature, or `undefined` when none could be resolved.
 
-##### `update`
+##### `map-update`
 
 - Payload: `(items)`
 
@@ -778,6 +778,12 @@ Toggle the `data-in-bounds` attribute — the list-visibility signal.
 
 Toggle the `data-active` attribute and the `aria-current="true"` state — the selected signal.
 
+#### Events
+
+##### `map-error`
+
+Emitted when unregistering the item throws. The error is contained and passed as the payload.
+
 ## AbstractMapboxMapChild
 
 The base class every child component extends (controls extend `AbstractMapboxControl`, itself a thin subclass that adds the shared `position` option and the `map.addControl`/`removeControl` lifecycle). It resolves the closest parent `MapboxMap` and exposes its Mapbox `Map` instance so children can register themselves against it. Beyond `mapboxMap`/`map`, it hardens the whole family's lifecycle: guarded injection and teardown, dead-map safety, retryable parent resolution (a child mounted before its map re-resolves on `mapbox-map:connected`), and automatic re-injection after a `map.setStyle(…)`. Extend it to build your own map children.
@@ -795,6 +801,12 @@ The closest parent `MapboxMap` component instance.
 - Type: `mapboxgl.Map`
 
 The Mapbox `Map` instance of the parent map.
+
+#### Events
+
+##### `map-error`
+
+Emitted when guarded map injection or teardown throws. The error is contained and passed as the payload.
 
 ```js
 import { AbstractMapboxMapChild } from '@studiometa/ui-mapbox';

--- a/packages/docs/reference/items/StoreLocator/examples.md
+++ b/packages/docs/reference/items/StoreLocator/examples.md
@@ -16,7 +16,7 @@ Try it out:
 - **Click a store in the list** — the map flies there, the item is marked active, a popup opens and the detail drawer opens.
 - **Click a cluster** — the map zooms in and splits it; click an individual pin to select its store.
 
-The detail panel is the integrator's choice. Here it is a [`Dialog`](/reference/items/Dialog/) drawer, opened from the [`select`](./js-api#select) event through a small root component's `onStoreLocatorSelect` handler, which copies the selected item's `<template>` detail into the drawer. A static `aside` bound to the same event would work too.
+The detail panel is the integrator's choice. Here it is a [`Dialog`](/reference/items/Dialog/) drawer, opened from the [`map-select`](./js-api#map-select) event through a small root component's `onStoreLocatorMapSelect` handler, which copies the selected item's `<template>` detail into the drawer. A static `aside` bound to the same event would work too.
 
 <PreviewPlayground
   :html="() => import('./stories/basic/app.twig')"
@@ -26,7 +26,7 @@ The detail panel is the integrator's choice. Here it is a [`Dialog`](/reference/
 
 ## Faceted list {#faceted-list}
 
-Because the map data is [derived from the registered items](./#the-three-state-model), replacing the list updates both the list **and** the map. This example swaps the list markup when a facet is picked: js-toolkit mounts and terminates the `MapboxClusterItem`s accordingly, the cluster re-derives the map data from the new item set and emits an `update`, and the orchestrator re-fits and re-filters. With `fit-on-update` set, the map also re-frames to the new subset.
+Because the map data is [derived from the registered items](./#the-three-state-model), replacing the list updates both the list **and** the map. This example swaps the list markup when a facet is picked: js-toolkit mounts and terminates the `MapboxClusterItem`s accordingly, the cluster re-derives the map data from the new item set and emits a `map-update`, and the orchestrator re-fits and re-filters. With `fit-on-update` set, the map also re-frames to the new subset.
 
 <PreviewPlayground
   :html="() => import('./stories/faceted/app.twig')"
@@ -36,7 +36,7 @@ Because the map data is [derived from the registered items](./#the-three-state-m
 
 ### Doing it with `Fetch`
 
-The example above swaps the list client-side so it runs on a static page. In a real integration you would instead [`Fetch`](/reference/items/Fetch/) the new list fragment from a server endpoint and let it replace the list container — the cluster reacts to the mounted/terminated `MapboxClusterItem`s exactly the same way, so nothing else changes. The cluster's debounced rebuild coalesces a whole `Fetch` swap into a single map-data update and a single `update` the orchestrator reacts to.
+The example above swaps the list client-side so it runs on a static page. In a real integration you would instead [`Fetch`](/reference/items/Fetch/) the new list fragment from a server endpoint and let it replace the list container — the cluster reacts to the mounted/terminated `MapboxClusterItem`s exactly the same way, so nothing else changes. The cluster's debounced rebuild coalesces a whole `Fetch` swap into a single map-data update and a single `map-update` the orchestrator reacts to.
 
 ```html
 <form data-component="Fetch" action="/stores" method="GET" data-option-selector="#store-list">

--- a/packages/docs/reference/items/StoreLocator/index.md
+++ b/packages/docs/reference/items/StoreLocator/index.md
@@ -12,24 +12,24 @@ It is part of the [`@studiometa/ui-mapbox`](https://www.npmjs.com/package/@studi
 
 The responsibilities are split in two:
 
-- The **`MapboxCluster`** is a pure source driver. Its `MapboxClusterItem`s self-register, and it derives a clustered GeoJSON source from that registry (the map data), handles the click-to-zoom on clusters, and reports a click on an unclustered point through an `item-click` event. Used on its own it renders a working clustered map + list, but it never selects, flies, filters by viewport or opens popups.
+- The **`MapboxCluster`** is a pure source driver. Its `MapboxClusterItem`s self-register, and it derives a clustered GeoJSON source from that registry (the map data), handles the click-to-zoom on clusters, and reports a click on an unclustered point through a `map-item-click` event. Used on its own it renders a working clustered map + list, but it never selects, flies, filters by viewport or opens popups.
 - The **`StoreLocator`** wraps such a cluster and adds exactly those search-UX concerns: it selects items (fly-to, `active` styling, popup), filters and sorts the list on every map move, wires the geocoder, and re-frames the map on item-set changes.
 
 ## The three-state model
 
 Each store has three independent states, each with its own source of truth. Keeping them separate is what makes the orchestrator predictable — panning the map never rebuilds the map data, and updating the item set never fights with the current viewport.
 
-| State          | Source of truth                            | Owner           | Drives                                          | Recomputed on        |
-| -------------- | ------------------------------------------ | --------------- | ----------------------------------------------- | -------------------- |
-| **Registered** | the item exists in the DOM                 | `MapboxCluster` | the **map data** (markers/clusters)             | item-set change only |
-| **In bounds**  | the item's `lngLat` is inside the viewport | `StoreLocator`  | **list visibility + distance sort** only        | every map `moveend`  |
-| **Selected**   | the chosen item                            | `StoreLocator`  | fly-to, popup, `active` styling, `select` event | selection            |
+| State          | Source of truth                            | Owner           | Drives                                              | Recomputed on        |
+| -------------- | ------------------------------------------ | --------------- | --------------------------------------------------- | -------------------- |
+| **Registered** | the item exists in the DOM                 | `MapboxCluster` | the **map data** (markers/clusters)                 | item-set change only |
+| **In bounds**  | the item's `lngLat` is inside the viewport | `StoreLocator`  | **list visibility + distance sort** only            | every map `moveend`  |
+| **Selected**   | the chosen item                            | `StoreLocator`  | fly-to, popup, `active` styling, `map-select` event | selection            |
 
-Because the map data is derived only from the cluster's registered items, swapping the list (for instance through a [`Fetch`](/reference/items/Fetch/)) updates both the list **and** the map at once: the cluster re-derives its source and emits an `update`, and the orchestrator re-fits and re-filters in response. See the [faceted example](./examples#faceted-list).
+Because the map data is derived only from the cluster's registered items, swapping the list (for instance through a [`Fetch`](/reference/items/Fetch/)) updates both the list **and** the map at once: the cluster re-derives its source and emits a `map-update`, and the orchestrator re-fits and re-filters in response. See the [faceted example](./examples#faceted-list).
 
 ## Composability
 
-The `StoreLocator` emits events and reflects state as data-attributes on each `MapboxClusterItem`; it makes no decision about how a selected store is presented beyond the built-in popup. The [examples](./examples.md) use a [`Dialog`](/reference/items/Dialog/) drawer as the detail panel, but a static `aside` would work just as well — wire whichever you like to the [`select`](./js-api#select) event.
+The `StoreLocator` emits events and reflects state as data-attributes on each `MapboxClusterItem`; it makes no decision about how a selected store is presented beyond the built-in popup. The [examples](./examples.md) use a [`Dialog`](/reference/items/Dialog/) drawer as the detail panel, but a static `aside` would work just as well — wire whichever you like to the [`map-select`](./js-api#map-select) event.
 
 ## Table of content
 

--- a/packages/docs/reference/items/StoreLocator/js-api.md
+++ b/packages/docs/reference/items/StoreLocator/js-api.md
@@ -12,7 +12,7 @@ The store locator is an **orchestrator** built on the [`MapboxMap` family](/refe
 
 The `StoreLocator` declares no child components, so nothing is ever double-mounted. [Register](/guide/usage/#registering-components) `StoreLocator`, `MapboxMap`, `MapboxCluster` and `MapboxClusterItem` each independently — ideally behind a lazy [`importWhen*` helper](https://js-toolkit.studiometa.dev/api/helpers/importWhenVisible.html) (see [Lazy loading](/reference/items/MapboxMap/#lazy-loading)). The orchestrator discovers them in its subtree with `$query` once mounted, retrying a few ticks for asynchronously-mounted children (the geocoder lazy-imports its module).
 
-To change the store set after mount, change the DOM of the list (add/remove `MapboxClusterItem` elements): the cluster re-derives the map data and emits an `update`, and the orchestrator re-fits and re-filters automatically.
+To change the store set after mount, change the DOM of the list (add/remove `MapboxClusterItem` elements): the cluster re-derives the map data and emits a `map-update`, and the orchestrator re-fits and re-filters automatically.
 
 ## StoreLocator
 
@@ -103,34 +103,34 @@ The registered items, read from the cluster (their single source of truth).
 
 - Arguments: `MapboxClusterItem`
 
-Select a store: deactivate the previous one, fly the map to the item at `item-zoom-level`, open a popup from the item's [`popupContent`](/reference/items/MapboxMap/js-api#mapboxclusteritem), mark it active (`data-active` + `aria-current="true"`) and emit [`select`](#select). Called automatically on a sidebar click (delegated on the root), on the cluster's `item-click` (an unclustered pin), and available for you to call directly.
+Select a store: deactivate the previous one, fly the map to the item at `item-zoom-level`, open a popup from the item's [`popupContent`](/reference/items/MapboxMap/js-api#mapboxclusteritem), mark it active (`data-active` + `aria-current="true"`) and emit [`map-select`](#map-select). Called automatically on a sidebar click (delegated on the root), on the cluster's `map-item-click` (an unclustered pin), and available for you to call directly.
 
 #### `deselect()`
 
-Clear the current selection, close the popup, remove the active state and emit [`deselect`](#deselect).
+Clear the current selection, close the popup, remove the active state and emit [`map-deselect`](#map-deselect).
 
 ### Events
 
-#### `select`
+#### `map-select`
 
 Emitted when a store is selected, with the selected `MapboxClusterItem` instance. Wire your detail panel here.
 
 ```js
-onStoreLocatorSelect({ args: [item] }) {
+onStoreLocatorMapSelect({ args: [item] }) {
   // item.id, item.lngLat, item.$el …
 }
 ```
 
-#### `deselect`
+#### `map-deselect`
 
-Emitted when the selection is cleared through [`deselect()`](#deselect-1).
+Emitted when the selection is cleared through [`deselect()`](#deselect).
 
-#### `filter`
+#### `map-filter`
 
 Emitted whenever the in-view list is recomputed (on every map `moveend` and after an item-set change), with the array of in-view items in display order (nearest-first unless `no-sort` is set).
 
 ```js
-onStoreLocatorFilter({ args: [items] }) {
+onStoreLocatorMapFilter({ args: [items] }) {
   // e.g. update a "N stores in view" counter
 }
 ```

--- a/packages/docs/reference/items/StoreLocator/stories/basic/app.js
+++ b/packages/docs/reference/items/StoreLocator/stories/basic/app.js
@@ -12,7 +12,7 @@ import { Action, Dialog, ViewTransition } from '@studiometa/ui';
  *
  * It declares the whole Mapbox family so a single `registerComponent(App)` call
  * mounts everything without double-registration. The `StoreLocator` stays
- * panel-agnostic: it only emits a `select` event with the chosen item. Here we
+ * panel-agnostic: it only emits a `map-select` event with the chosen item. Here we
  * react to it through the `on<Component><Event>` convention, copy the item's
  * `<template>` detail into the drawer and open it.
  */
@@ -41,7 +41,7 @@ class App extends Base {
    * Open the drawer with the selected store's detail.
    * @param {{ args: [MapboxClusterItem] }} props
    */
-  onStoreLocatorSelect({ args: [item] }) {
+  onStoreLocatorMapSelect({ args: [item] }) {
     const template = item.$el.querySelector('template');
     const content = this.$el.querySelector('#store-panel-content');
 

--- a/packages/docs/reference/items/StoreLocator/stories/faceted/app.js
+++ b/packages/docs/reference/items/StoreLocator/stories/faceted/app.js
@@ -15,7 +15,7 @@ import { Action, Dialog, ViewTransition } from '@studiometa/ui';
  * instead — see the prose in the examples page. Either way, the important part
  * is identical: the DOM of the `#store-list` changes, js-toolkit mounts and
  * terminates the `MapboxClusterItem`s accordingly, and the `MapboxCluster`
- * re-derives the map data from the new item set and emits an `update` the
+ * re-derives the map data from the new item set and emits a `map-update` the
  * `StoreLocator` reacts to (markers and clusters follow).
  */
 class App extends Base {
@@ -100,7 +100,7 @@ class App extends Base {
    * Open the drawer with the selected store's detail.
    * @param {{ args: [MapboxClusterItem] }} props
    */
-  onStoreLocatorSelect({ args: [item] }) {
+  onStoreLocatorMapSelect({ args: [item] }) {
     const template = item.$el.querySelector('template');
     const content = this.$el.querySelector('#store-panel-content');
 

--- a/packages/tests/MapboxMap/AbstractMapboxMapChild.async.spec.ts
+++ b/packages/tests/MapboxMap/AbstractMapboxMapChild.async.spec.ts
@@ -11,7 +11,7 @@ import { AbstractMapboxMapChild, MapboxMarker } from '@studiometa/ui-mapbox';
 class AsyncChild extends AbstractMapboxMapChild {
   static config = {
     name: 'AsyncChild',
-    emits: ['error', 'done'],
+    emits: ['map-error', 'done'],
   };
 
   rejectWith?: Error;
@@ -52,7 +52,7 @@ function createAsyncChild(mapboxMap: unknown) {
 }
 
 describe('AbstractMapboxMapChild — async ready callbacks (F-async)', () => {
-  it('should contain a rejected async callback: no unhandled rejection, warns + emits error', async () => {
+  it('should contain a rejected async callback: no unhandled rejection, warns + emits map-error', async () => {
     const mockMap = new MockMap();
     const mapboxMap = { map: mockMap, isLoaded: true, $options: { accessToken: 't' } };
     const instance = createAsyncChild(mapboxMap);
@@ -62,7 +62,7 @@ describe('AbstractMapboxMapChild — async ready callbacks (F-async)', () => {
     const onError = vi.fn();
     const boom = new Error('async boom');
     instance.rejectWith = boom;
-    instance.$on('error', onError);
+    instance.$on('map-error', onError);
 
     // A global unhandledrejection would fail the test run, so assert none fires.
     const onUnhandled = vi.fn();

--- a/packages/tests/MapboxMap/AbstractMapboxMapChild.hardening.spec.ts
+++ b/packages/tests/MapboxMap/AbstractMapboxMapChild.hardening.spec.ts
@@ -10,7 +10,7 @@ import { AbstractMapboxMapChild, MapboxMarker } from '@studiometa/ui-mapbox';
 class ThrowingChild extends AbstractMapboxMapChild {
   static config = {
     name: 'ThrowingChild',
-    emits: ['error'],
+    emits: ['map-error'],
   };
 
   readyError?: Error;
@@ -76,14 +76,14 @@ function createDeferredMap(mockMap: MockMap) {
 }
 
 describe('AbstractMapboxMapChild — B1: guarded lifecycle', () => {
-  it('should contain a throwing ready callback: no rethrow, warns + emits error', async () => {
+  it('should contain a throwing ready callback: no rethrow, warns + emits map-error', async () => {
     const { instance } = createChild();
     instance.$options.log = true;
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const onError = vi.fn();
     const boom = new Error('ready boom');
     instance.readyError = boom;
-    instance.$on('error', onError);
+    instance.$on('map-error', onError);
 
     vi.useFakeTimers();
     // `$mount` resolves even though the ready callback threw: the throw was
@@ -103,13 +103,13 @@ describe('AbstractMapboxMapChild — B1: guarded lifecycle', () => {
     warn.mockRestore();
   });
 
-  it('should contain a throwing teardown: no rethrow, warns + emits error', async () => {
+  it('should contain a throwing teardown: no rethrow, warns + emits map-error', async () => {
     const { instance } = createChild();
     instance.$options.log = true;
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const onError = vi.fn();
     const boom = new Error('teardown boom');
-    instance.$on('error', onError);
+    instance.$on('map-error', onError);
 
     vi.useFakeTimers();
     instance.$mount();

--- a/packages/tests/MapboxMap/MapboxCluster.spec.ts
+++ b/packages/tests/MapboxMap/MapboxCluster.spec.ts
@@ -132,12 +132,12 @@ describe('MapboxCluster component', () => {
     expect(lastData.features).toHaveLength(0);
   });
 
-  it('should emit an update event carrying the item set when it rebuilds', async () => {
+  it('should emit a map-update event carrying the item set when it rebuilds', async () => {
     const { instance } = createCluster();
     await mountAndFlush(instance);
 
     const update = vi.fn();
-    instance.$on('update', update);
+    instance.$on('map-update', update);
 
     const item = createItem(instance, { 'data-option-id': 'x', 'data-option-lng-lat': '[5, 6]' });
     await mountAndFlush(item);
@@ -151,7 +151,7 @@ describe('MapboxCluster component', () => {
     expect(instance.items).toHaveLength(1);
   });
 
-  it('should emit cluster-click and ease to the expansion zoom on cluster click', async () => {
+  it('should emit map-cluster-click and ease to the expansion zoom on cluster click', async () => {
     const { instance, mockMap } = createCluster();
     const handler = vi.fn();
 
@@ -160,7 +160,7 @@ describe('MapboxCluster component', () => {
     ]) as any;
 
     await mountAndFlush(instance);
-    instance.$on('cluster-click', handler);
+    instance.$on('map-cluster-click', handler);
 
     const clustersId = (instance as any).__getId('clusters');
     mockMap.fire('click', clustersId, {
@@ -208,7 +208,7 @@ describe('MapboxCluster component', () => {
     expect(mockMap.easeTo).not.toHaveBeenCalled();
   });
 
-  it('should emit item-click with the resolved item on unclustered point click', async () => {
+  it('should emit map-item-click with the resolved item on unclustered point click', async () => {
     const { instance, mockMap } = createCluster();
     await mountAndFlush(instance);
 
@@ -216,7 +216,7 @@ describe('MapboxCluster component', () => {
     await mountAndFlush(item);
 
     const itemClick = vi.fn();
-    instance.$on('item-click', itemClick);
+    instance.$on('map-item-click', itemClick);
 
     const unclusteredId = (instance as any).__getId('unclustered-point');
     mockMap.fire('click', unclusteredId, {
@@ -233,12 +233,12 @@ describe('MapboxCluster component', () => {
     expect(mockMap.flyTo).not.toHaveBeenCalled();
   });
 
-  it('should emit item-click with an undefined item for an unknown feature id', async () => {
+  it('should emit map-item-click with an undefined item for an unknown feature id', async () => {
     const { instance, mockMap } = createCluster();
     await mountAndFlush(instance);
 
     const itemClick = vi.fn();
-    instance.$on('item-click', itemClick);
+    instance.$on('map-item-click', itemClick);
 
     const unclusteredId = (instance as any).__getId('unclustered-point');
     mockMap.fire('click', unclusteredId, {

--- a/packages/tests/MapboxMap/MapboxGeocoder.spec.ts
+++ b/packages/tests/MapboxMap/MapboxGeocoder.spec.ts
@@ -178,13 +178,13 @@ describe('MapboxGeocoder component', () => {
     expect(control2.addTo).toHaveBeenCalledWith(el);
   });
 
-  it('should re-emit the control `result` event as a component `result` event', async () => {
+  it('should re-emit the control `result` event as a component `map-result` event', async () => {
     const { instance } = createGeocoder();
 
     await mountAndFlush(instance);
 
     const result = vi.fn();
-    instance.$on('result', result);
+    instance.$on('map-result', result);
 
     const payload = { center: [1, 2], bbox: [0, 0, 3, 3] };
     // The mocked control captures its `result` handlers; fire one as the real

--- a/packages/tests/MapboxMap/MapboxImage.spec.ts
+++ b/packages/tests/MapboxMap/MapboxImage.spec.ts
@@ -50,13 +50,13 @@ describe('MapboxImage component', () => {
     expect(mockMap.addImage).not.toHaveBeenCalled();
   });
 
-  it('should emit a ready event once the image is registered', async () => {
+  it('should emit a map-ready event once the image is registered', async () => {
     const { instance } = createImage();
     const handler = vi.fn();
 
     vi.useFakeTimers();
     instance.$mount();
-    instance.$on('ready', handler);
+    instance.$on('map-ready', handler);
     await vi.advanceTimersByTimeAsync(100);
     vi.useRealTimers();
 
@@ -197,7 +197,7 @@ describe('MapboxImage component', () => {
 
     vi.useFakeTimers();
     instance.$mount();
-    instance.$on('ready', ready);
+    instance.$on('map-ready', ready);
     await vi.advanceTimersByTimeAsync(100);
 
     // The load is still pending: nothing has been added to the sprite yet.
@@ -211,7 +211,7 @@ describe('MapboxImage component', () => {
     vi.useRealTimers();
 
     // The image added after teardown must be removed again: no orphan sprite and
-    // no `ready` event emitted after destroy.
+    // no `map-ready` event emitted after destroy.
     expect(mockMap.removeImage).toHaveBeenCalledWith('my-image');
     expect(mockMap._images).toEqual({});
     expect(ready).not.toHaveBeenCalled();

--- a/packages/tests/MapboxMap/MapboxImages.spec.ts
+++ b/packages/tests/MapboxMap/MapboxImages.spec.ts
@@ -38,13 +38,13 @@ describe('MapboxImages component', () => {
     expect(mockMap.addImage).toHaveBeenCalledWith('two', expect.anything(), undefined);
   });
 
-  it('should emit a single ready event with every image', async () => {
+  it('should emit a single map-ready event with every image', async () => {
     const { instance } = createImages();
     const handler = vi.fn();
 
     vi.useFakeTimers();
     instance.$mount();
-    instance.$on('ready', handler);
+    instance.$on('map-ready', handler);
     await vi.advanceTimersByTimeAsync(100);
     vi.useRealTimers();
 
@@ -127,7 +127,7 @@ describe('MapboxImages component', () => {
     });
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const onError = vi.fn();
-    instance.$on('error', onError);
+    instance.$on('map-error', onError);
 
     vi.useFakeTimers();
     instance.$mount();
@@ -136,7 +136,7 @@ describe('MapboxImages component', () => {
     vi.useRealTimers();
 
     // `one` was added before `two` rejected; the rejection is contained (routed
-    // to the `error` event, not an unhandled rejection).
+    // to the `map-error` event, not an unhandled rejection).
     expect(mockMap.addImage).toHaveBeenCalledWith('one', expect.anything(), undefined);
     expect(onError).toHaveBeenCalled();
 
@@ -165,7 +165,7 @@ describe('MapboxImages component', () => {
 
     vi.useFakeTimers();
     instance.$mount();
-    instance.$on('ready', ready);
+    instance.$on('map-ready', ready);
     await vi.advanceTimersByTimeAsync(100);
 
     // The loads are still pending: nothing has been added to the sprite yet.
@@ -179,7 +179,7 @@ describe('MapboxImages component', () => {
     vi.useRealTimers();
 
     // Every image added after teardown must be removed again: no orphan sprites
-    // and no `ready` event emitted after destroy.
+    // and no `map-ready` event emitted after destroy.
     expect(mockMap.removeImage).toHaveBeenCalledWith('one');
     expect(mockMap.removeImage).toHaveBeenCalledWith('two');
     expect(mockMap._images).toEqual({});

--- a/packages/tests/MapboxMap/MapboxMap.spec.ts
+++ b/packages/tests/MapboxMap/MapboxMap.spec.ts
@@ -86,34 +86,39 @@ describe('MapboxMap component', () => {
     (instance.map as unknown as MockMap).fire('load');
     await vi.advanceTimersByTimeAsync(100);
 
-    expect(handler).toHaveBeenCalled();
+    expect(handler).toHaveBeenCalledOnce();
     vi.useRealTimers();
   });
 
-  it('should forward map events', async () => {
+  it('should forward map events with a map- prefix', async () => {
     const root = createMapboxMap();
     const instance = new MapboxMap(root);
     const clickHandler = vi.fn();
     const zoomHandler = vi.fn();
     const dragHandler = vi.fn();
+    const unprefixedClickHandler = vi.fn();
 
     vi.useFakeTimers();
     instance.$mount();
     await vi.advanceTimersByTimeAsync(100);
 
-    instance.$on('click', clickHandler);
-    instance.$on('zoom', zoomHandler);
-    instance.$on('drag', dragHandler);
+    instance.$on('map-click', clickHandler);
+    instance.$on('map-zoom', zoomHandler);
+    instance.$on('map-drag', dragHandler);
+    instance.$on('click', unprefixedClickHandler);
 
     const mockMap = instance.map as unknown as MockMap;
-    mockMap.fire('click', { type: 'click' });
+    const clickEvent = { type: 'click' };
+    mockMap.fire('click', clickEvent);
     mockMap.fire('zoom', { type: 'zoom' });
     mockMap.fire('drag', { type: 'drag' });
     await vi.advanceTimersByTimeAsync(100);
 
-    expect(clickHandler).toHaveBeenCalled();
+    const [emittedClickEvent] = clickHandler.mock.calls[0] as [CustomEvent];
+    expect(emittedClickEvent.detail[0]).toEqual(clickEvent);
     expect(zoomHandler).toHaveBeenCalled();
     expect(dragHandler).toHaveBeenCalled();
+    expect(unprefixedClickHandler).not.toHaveBeenCalled();
     vi.useRealTimers();
   });
 

--- a/packages/tests/MapboxMap/StoreLocator.spec.ts
+++ b/packages/tests/MapboxMap/StoreLocator.spec.ts
@@ -36,7 +36,7 @@ function fakeItem(el: HTMLElement, id: string, lngLat: [number, number]) {
  * `MapboxCluster` (owner of the item registry) plus an optional `MapboxGeocoder`.
  *
  * Like the other `@studiometa/ui-mapbox` child specs, the map/cluster/geocoder
- * and their `map-load` / `item-click` / `update` / `result` events are injected
+ * and their `map-load` / `map-item-click` / `map-update` / `map-result` events are injected
  * through the `mapboxMap`, `cluster` and `geocoder` getters, keeping the test
  * deterministic and free of the real `mapbox-gl`.
  */
@@ -118,17 +118,17 @@ function createStoreLocator(
       mockMap.fire('moveend');
     },
     fireItemClick(item: unknown) {
-      (clusterHandlers['item-click'] ?? []).forEach((callback) =>
+      (clusterHandlers['map-item-click'] ?? []).forEach((callback) =>
         callback({ detail: [item, {}, {}] }),
       );
     },
     fireUpdate() {
-      (clusterHandlers['update'] ?? []).forEach((callback) =>
+      (clusterHandlers['map-update'] ?? []).forEach((callback) =>
         callback({ detail: [mockCluster.items] }),
       );
     },
     fireGeocoderResult(result: unknown) {
-      (geocoderHandlers['result'] ?? []).forEach((callback) => callback({ detail: [result] }));
+      (geocoderHandlers['map-result'] ?? []).forEach((callback) => callback({ detail: [result] }));
     },
   };
 }
@@ -168,12 +168,12 @@ function listOrder(ctx: ReturnType<typeof createStoreLocator>): string[] {
 describe('StoreLocator orchestrator', () => {
   // --- 1. Selection --------------------------------------------------------
   describe('selection', () => {
-    it('flies to the item, marks it active/aria-current, opens a popup and emits select', async () => {
+    it('flies to the item, marks it active/aria-current, opens a popup and emits map-select', async () => {
       const ctx = createStoreLocator([{ id: 'a', lngLat: [3, 4] }]);
       await mountAndLoad(ctx);
 
       const select = vi.fn();
-      ctx.instance.$on('select', select);
+      ctx.instance.$on('map-select', select);
 
       const itemA = ctx.item('a');
       ctx.instance.selectItem(itemA);
@@ -214,12 +214,12 @@ describe('StoreLocator orchestrator', () => {
       expect(itemB.$el.getAttribute('aria-current')).toBe('true');
     });
 
-    it('clears the active state and emits deselect on deselect()', async () => {
+    it('clears the active state and emits map-deselect on deselect()', async () => {
       const ctx = createStoreLocator([{ id: 'a', lngLat: [1, 1] }]);
       await mountAndLoad(ctx);
 
       const deselect = vi.fn();
-      ctx.instance.$on('deselect', deselect);
+      ctx.instance.$on('map-deselect', deselect);
 
       const itemA = ctx.item('a');
       ctx.instance.selectItem(itemA);
@@ -239,7 +239,7 @@ describe('StoreLocator orchestrator', () => {
       await mountAndLoad(ctx);
 
       const select = vi.fn();
-      ctx.instance.$on('select', select);
+      ctx.instance.$on('map-select', select);
 
       // Click the inner button of item `b`: the delegated handler resolves the
       // closest MapboxClusterItem element and selects its instance.
@@ -261,7 +261,7 @@ describe('StoreLocator orchestrator', () => {
       await mountAndLoad(ctx);
 
       const select = vi.fn();
-      ctx.instance.$on('select', select);
+      ctx.instance.$on('map-select', select);
 
       ctx.fireItemClick(ctx.item('b'));
 
@@ -275,7 +275,7 @@ describe('StoreLocator orchestrator', () => {
       await mountAndLoad(ctx);
 
       const select = vi.fn();
-      ctx.instance.$on('select', select);
+      ctx.instance.$on('map-select', select);
 
       expect(() => ctx.fireItemClick(undefined)).not.toThrow();
       expect(select).not.toHaveBeenCalled();
@@ -284,7 +284,7 @@ describe('StoreLocator orchestrator', () => {
 
   // --- 3. Viewport filtering (in-bounds + sort + filter) -------------------
   describe('viewport filtering on moveend', () => {
-    it('reflects data-in-bounds only for in-view items and emits filter with them', async () => {
+    it('reflects data-in-bounds only for in-view items and emits map-filter with them', async () => {
       const ctx = createStoreLocator([
         { id: 'a', lngLat: [1, 1] },
         { id: 'b', lngLat: [2, 2] },
@@ -296,7 +296,7 @@ describe('StoreLocator orchestrator', () => {
       boundsContainingLng(ctx, [1, 3]);
 
       const filter = vi.fn();
-      ctx.instance.$on('filter', filter);
+      ctx.instance.$on('map-filter', filter);
 
       ctx.fireMoveEnd();
 
@@ -333,7 +333,7 @@ describe('StoreLocator orchestrator', () => {
       await mountAndLoad(ctx);
 
       const filter = vi.fn();
-      ctx.instance.$on('filter', filter);
+      ctx.instance.$on('map-filter', filter);
 
       ctx.fireMoveEnd();
 
@@ -354,7 +354,7 @@ describe('StoreLocator orchestrator', () => {
       await mountAndLoad(ctx);
 
       const filter = vi.fn();
-      ctx.instance.$on('filter', filter);
+      ctx.instance.$on('map-filter', filter);
 
       ctx.fireMoveEnd();
 
@@ -461,7 +461,7 @@ describe('StoreLocator orchestrator', () => {
 
       boundsContainingLng(ctx, [7, 8]);
       const filter = vi.fn();
-      ctx.instance.$on('filter', filter);
+      ctx.instance.$on('map-filter', filter);
       ctx.mockMap.fitBounds.mockClear();
 
       // The cluster announces the item-set change; the orchestrator re-fits and
@@ -498,14 +498,14 @@ describe('StoreLocator orchestrator', () => {
       await mountAndLoad(ctx);
 
       const deselect = vi.fn();
-      ctx.instance.$on('deselect', deselect);
+      ctx.instance.$on('map-deselect', deselect);
 
       ctx.instance.selectItem(ctx.item('a'));
       const popup = (ctx.instance as any).__popup;
       expect(popup).toBeDefined();
 
       // The selected store leaves the registry: the popup must be removed and
-      // `deselect` emitted, not just `__selected` cleared.
+      // `map-deselect` emitted, not just `__selected` cleared.
       ctx.mockCluster.items = [] as any;
       ctx.fireUpdate();
 
@@ -538,14 +538,14 @@ describe('StoreLocator orchestrator', () => {
       Object.defineProperty(ctx.instance, 'cluster', { get: () => newCluster, configurable: true });
 
       const select = vi.fn();
-      ctx.instance.$on('select', select);
+      ctx.instance.$on('map-select', select);
 
       document.dispatchEvent(new CustomEvent('mapbox-cluster:connected', { detail: newCluster }));
 
       // The stale wiring was dropped and the new cluster wired: an item-click
       // through the REPLACEMENT cluster selects its item.
       expect((ctx.instance as any).__cluster).toBe(newCluster);
-      (newHandlers['item-click'] ?? []).forEach((callback) =>
+      (newHandlers['map-item-click'] ?? []).forEach((callback) =>
         callback({ detail: [newItem, {}, {}] }),
       );
       expect(select).toHaveBeenCalledTimes(1);
@@ -566,7 +566,7 @@ describe('StoreLocator orchestrator', () => {
       await mountAndLoad(ctx);
 
       const select = vi.fn();
-      ctx.instance.$on('select', select);
+      ctx.instance.$on('map-select', select);
 
       // Not wired yet: an item-click is ignored because the listener is not
       // attached until the cluster's source is ready.
@@ -598,8 +598,8 @@ describe('StoreLocator orchestrator', () => {
 
       const filter = vi.fn();
       const select = vi.fn();
-      ctx.instance.$on('filter', filter);
-      ctx.instance.$on('select', select);
+      ctx.instance.$on('map-filter', filter);
+      ctx.instance.$on('map-select', select);
 
       vi.useFakeTimers();
       ctx.instance.$destroy();

--- a/packages/tests/MapboxMap/exports.spec.ts
+++ b/packages/tests/MapboxMap/exports.spec.ts
@@ -34,3 +34,20 @@ test('@studiometa/ui-mapbox exports', () => {
     expect(exported).toBeDefined();
   }
 });
+
+test('@studiometa/ui-mapbox public events use the map- prefix', () => {
+  const emitters = [
+    components.AbstractMapboxMapChild,
+    components.MapboxCluster,
+    components.MapboxClusterItem,
+    components.MapboxGeocoder,
+    components.MapboxImage,
+    components.MapboxImages,
+    components.MapboxMap,
+    components.StoreLocator,
+  ];
+
+  for (const component of emitters) {
+    expect(component.config.emits?.every((event) => event.startsWith('map-'))).toBe(true);
+  }
+});

--- a/packages/ui-mapbox/AbstractMapboxMapChild.ts
+++ b/packages/ui-mapbox/AbstractMapboxMapChild.ts
@@ -34,7 +34,7 @@ export const MAPBOX_MAP_CONNECTED = 'mapbox-map:connected';
  *    global queue runs lifecycle hooks with no try/catch: a single synchronous
  *    throw wedges the queue and freezes every mount/destroy on the page. The
  *    ready callback and the subclass teardown (`__onDestroyed`) are both run
- *    inside a try/catch that routes to `$warn` + an `error` event and never
+ *    inside a try/catch that routes to `$warn` + a `map-error` event and never
  *    rethrows.
  * 2. **Dead-map safety** — once ready, the child subscribes to the map's own
  *    `remove` event; when it fires the cached map reference is dropped so no
@@ -62,7 +62,7 @@ export class AbstractMapboxMapChild<T extends BaseProps = BaseProps> extends Bas
    */
   static config: BaseConfig = {
     name: 'AbstractMapboxMapChild',
-    emits: ['error'],
+    emits: ['map-error'],
   };
 
   /**
@@ -92,7 +92,7 @@ export class AbstractMapboxMapChild<T extends BaseProps = BaseProps> extends Bas
    *
    * The callback may be synchronous or `async`: a returned promise is awaited
    * inside the same containment as a synchronous body, so a rejection routes to
-   * `$warn` + the `error` event instead of surfacing as an unhandled rejection.
+   * `$warn` + the `map-error` event instead of surfacing as an unhandled rejection.
    * @private
    */
   __readyCallback?: (map: Map) => void | Promise<void>;
@@ -262,7 +262,7 @@ export class AbstractMapboxMapChild<T extends BaseProps = BaseProps> extends Bas
    * Run the ready callback inside a uniform containment for both synchronous
    * throws and rejected promises: a synchronous body is wrapped in `try/catch`,
    * and an `async` body's returned promise is awaited so its rejection routes to
-   * `$warn` + the `error` event instead of becoming an unhandled rejection.
+   * `$warn` + the `map-error` event instead of becoming an unhandled rejection.
    * Neither path ever rethrows into the global lifecycle queue.
    * @private
    * @param {Map} map
@@ -379,13 +379,13 @@ export class AbstractMapboxMapChild<T extends BaseProps = BaseProps> extends Bas
 
   /**
    * Contain an error raised by a guarded injection or teardown: warn and emit an
-   * `error` event, but never rethrow into the global queue.
+   * `map-error` event, but never rethrow into the global queue.
    * @private
    * @param {unknown} err
    */
   __handleError(err: unknown): void {
     this.$warn(err);
-    this.$emit('error', err);
+    this.$emit('map-error', err);
   }
 
   /**

--- a/packages/ui-mapbox/MapboxCluster.ts
+++ b/packages/ui-mapbox/MapboxCluster.ts
@@ -74,7 +74,7 @@ export interface MapboxClusterProps extends AbstractMapboxMapChildProps {
  * [`StoreLocator`](./StoreLocator.js) orchestrator, which drives them on top of a
  * cluster. Used standalone, a `MapboxCluster` still renders a working clustered
  * map + list (points render, clusters zoom on click); it simply reports a click
- * on an unclustered point through the `item-click` event and lets the caller
+ * on an unclustered point through the `map-item-click` event and lets the caller
  * decide what it means.
  *
  * @see https://ui.studiometa.dev/reference/items/MapboxMap/
@@ -87,7 +87,7 @@ export class MapboxCluster<T extends BaseProps = BaseProps> extends AbstractMapb
    */
   static config: BaseConfig = {
     name: 'MapboxCluster',
-    emits: ['cluster-click', 'item-click', 'update'],
+    emits: ['map-cluster-click', 'map-item-click', 'map-update'],
     options: {
       clusterMaxZoom: {
         type: Number,
@@ -277,7 +277,7 @@ export class MapboxCluster<T extends BaseProps = BaseProps> extends AbstractMapb
     this.setData(this.featureCollection as GeoJSONSourceSpecification['data']);
     // Let an orchestrator react to the new item set (fit the map, refilter the
     // list). The cluster itself never fits or filters — it only reports.
-    this.$emit('update', this.items);
+    this.$emit('map-update', this.items);
   }
 
   /**
@@ -301,7 +301,7 @@ export class MapboxCluster<T extends BaseProps = BaseProps> extends AbstractMapb
 
     const clusterId = feature.properties?.cluster_id as number;
 
-    this.$emit('cluster-click', clusterId, event);
+    this.$emit('map-cluster-click', clusterId, event);
 
     if (event.defaultPrevented) {
       return;
@@ -362,7 +362,7 @@ export class MapboxCluster<T extends BaseProps = BaseProps> extends AbstractMapb
 
   /**
    * Report a click on an unclustered point: resolve the feature back to the
-   * registered item behind it and emit `item-click`. The cluster makes no
+   * registered item behind it and emit `map-item-click`. The cluster makes no
    * decision about what a click means — an orchestrator (e.g. `StoreLocator`)
    * listens and selects, opens a popup, etc.
    * @private
@@ -375,7 +375,7 @@ export class MapboxCluster<T extends BaseProps = BaseProps> extends AbstractMapb
         ? undefined
         : this.__items.find((candidate) => candidate.id === String(id));
 
-    this.$emit('item-click', item, feature, event);
+    this.$emit('map-item-click', item, feature, event);
   };
 
   /**
@@ -504,7 +504,7 @@ export class MapboxCluster<T extends BaseProps = BaseProps> extends AbstractMapb
 
     // Announce the seeded item set so an orchestrator can run its first fit +
     // viewport filter against a cluster that was already populated at load.
-    this.$emit('update', this.items);
+    this.$emit('map-update', this.items);
   }
 
   /**

--- a/packages/ui-mapbox/MapboxClusterItem.ts
+++ b/packages/ui-mapbox/MapboxClusterItem.ts
@@ -36,7 +36,7 @@ export interface MapboxClusterItemProps extends BaseProps {
  *
  * Used under a bare `MapboxCluster` (no orchestrator) the item still registers
  * and renders as a clustered point; it just carries no selection affordance of
- * its own — a click is reported by the cluster's `item-click` event for a
+ * its own — a click is reported by the cluster's `map-item-click` event for a
  * caller to act on.
  *
  * @see https://ui.studiometa.dev/reference/items/MapboxMap/
@@ -49,7 +49,7 @@ export class MapboxClusterItem<T extends BaseProps = BaseProps> extends Base<
    */
   static config: BaseConfig = {
     name: 'MapboxClusterItem',
-    emits: ['error'],
+    emits: ['map-error'],
     options: {
       id: String,
       lngLat: {
@@ -184,7 +184,7 @@ export class MapboxClusterItem<T extends BaseProps = BaseProps> extends Base<
       this.__cluster?.unregister(this);
     } catch (err) {
       this.$warn(err);
-      this.$emit('error', err);
+      this.$emit('map-error', err);
     }
 
     this.__cluster = undefined;

--- a/packages/ui-mapbox/MapboxGeocoder.ts
+++ b/packages/ui-mapbox/MapboxGeocoder.ts
@@ -57,7 +57,7 @@ export class MapboxGeocoder<T extends BaseProps = BaseProps> extends AbstractMap
    */
   static config: BaseConfig = {
     name: 'MapboxGeocoder',
-    emits: ['result'],
+    emits: ['map-result'],
     options: {
       addToMap: Boolean,
       options: Object,
@@ -125,9 +125,9 @@ export class MapboxGeocoder<T extends BaseProps = BaseProps> extends AbstractMap
       this.__control = new GeocoderControlClass(
         options as ConstructorParameters<typeof GeocoderControlClass>[0],
       );
-      // Re-emit the control's `result` event as a component event so consumers
-      // (e.g. a `MapboxCluster`) can react to a geocoded address.
-      this.__control.on?.('result', (event) => this.$emit('result', event.result));
+      // Re-emit the control's `result` event as a prefixed component event so
+      // consumers (e.g. a `StoreLocator`) can react to a geocoded address.
+      this.__control.on?.('result', (event) => this.$emit('map-result', event.result));
       this.__control.addTo(this.target);
     });
   }

--- a/packages/ui-mapbox/MapboxImage.ts
+++ b/packages/ui-mapbox/MapboxImage.ts
@@ -35,7 +35,7 @@ export class MapboxImage<T extends BaseProps = BaseProps> extends AbstractMapbox
    */
   static config: BaseConfig = {
     name: 'MapboxImage',
-    emits: ['ready'],
+    emits: ['map-ready'],
     options: {
       name: String,
       url: String,
@@ -95,7 +95,7 @@ export class MapboxImage<T extends BaseProps = BaseProps> extends AbstractMapbox
         this.__owned = true;
       }
 
-      this.$emit('ready', { name, image, options });
+      this.$emit('map-ready', { name, image, options });
     });
   }
 

--- a/packages/ui-mapbox/MapboxImages.ts
+++ b/packages/ui-mapbox/MapboxImages.ts
@@ -34,7 +34,7 @@ export class MapboxImages<T extends BaseProps = BaseProps> extends AbstractMapbo
    */
   static config: BaseConfig = {
     name: 'MapboxImages',
-    emits: ['ready'],
+    emits: ['map-ready'],
     options: {
       sources: {
         type: Array,
@@ -89,7 +89,7 @@ export class MapboxImages<T extends BaseProps = BaseProps> extends AbstractMapbo
         return;
       }
 
-      this.$emit('ready', images);
+      this.$emit('map-ready', images);
     });
   }
 

--- a/packages/ui-mapbox/MapboxMap.ts
+++ b/packages/ui-mapbox/MapboxMap.ts
@@ -3,7 +3,7 @@ import mapboxgl from 'mapbox-gl';
 import type { Map, MapOptions } from 'mapbox-gl';
 import { MAPBOX_MAP_CONNECTED } from './AbstractMapboxMapChild.js';
 
-const MAP_EVENTS = [
+const FORWARDED_MAP_EVENTS = [
   'click',
   'dblclick',
   'mouseenter',
@@ -24,7 +24,6 @@ const MAP_EVENTS = [
   'dragstart',
   'drag',
   'dragend',
-  'load',
   'idle',
   'render',
   'resize',
@@ -54,7 +53,7 @@ export class MapboxMap<T extends BaseProps = BaseProps> extends Base<T & MapboxM
    */
   static config: BaseConfig = {
     name: 'MapboxMap',
-    emits: ['map-load', ...MAP_EVENTS],
+    emits: ['map-load', ...FORWARDED_MAP_EVENTS.map((event) => `map-${event}`)],
     refs: ['container'],
     options: {
       accessToken: String,
@@ -127,9 +126,9 @@ export class MapboxMap<T extends BaseProps = BaseProps> extends Base<T & MapboxM
     this.map.on('load', onLoad);
     this.__offMapListeners.push(() => this.__map?.off('load', onLoad));
 
-    for (const event of MAP_EVENTS) {
+    for (const event of FORWARDED_MAP_EVENTS) {
       const handler = (e: unknown) => {
-        this.$emit(event, e);
+        this.$emit(`map-${event}`, e);
       };
       this.map.on(event, handler);
       this.__offMapListeners.push(() => this.__map?.off(event, handler));

--- a/packages/ui-mapbox/StoreLocator.ts
+++ b/packages/ui-mapbox/StoreLocator.ts
@@ -43,12 +43,12 @@ export interface StoreLocatorProps extends BaseProps {
  * 1. **Registered** — the item exists in the DOM. Owned by the `MapboxCluster`,
  *    it drives the **map data** and only changes when the item set changes (e.g.
  *    a `Fetch` swaps the list). The orchestrator is notified through the
- *    cluster's `update` event.
+ *    cluster's `map-update` event.
  * 2. **In bounds** — the item's `lngLat` is inside the current viewport. Drives
  *    **list visibility + distance sort only**, recomputed on map `moveend`, and
  *    never touches the map data.
  * 3. **Selected** — the chosen item. Drives fly-to, the popup, `active` styling
- *    and the `select` event.
+ *    and the `map-select` event.
  *
  * The orchestrator requires its `MapboxCluster` (and `MapboxMap`) to live within
  * its own subtree; it resolves them with `$query`, retries a few ticks for
@@ -77,7 +77,7 @@ export class StoreLocator<T extends BaseProps = BaseProps> extends Base<T & Stor
    */
   static config: BaseConfig = {
     name: 'StoreLocator',
-    emits: ['select', 'deselect', 'filter'],
+    emits: ['map-select', 'map-deselect', 'map-filter'],
     options: {
       itemZoomLevel: {
         type: Number,
@@ -184,7 +184,7 @@ export class StoreLocator<T extends BaseProps = BaseProps> extends Base<T & Stor
   __clusterWired = false;
 
   /**
-   * Whether the `MapboxGeocoder` `result` listener is already attached.
+   * Whether the `MapboxGeocoder` `map-result` listener is already attached.
    * @private
    */
   __geocoderWired = false;
@@ -232,7 +232,7 @@ export class StoreLocator<T extends BaseProps = BaseProps> extends Base<T & Stor
 
   /**
    * Select an item: deactivate the previous one, fly to the item, open its
-   * popup, mark it active and emit a `select` event.
+   * popup, mark it active and emit a `map-select` event.
    * @param {MapboxClusterItem} item
    */
   selectItem(item: MapboxClusterItem) {
@@ -249,11 +249,11 @@ export class StoreLocator<T extends BaseProps = BaseProps> extends Base<T & Stor
     });
 
     this.__openPopup(item);
-    this.$emit('select', item);
+    this.$emit('map-select', item);
   }
 
   /**
-   * Clear the current selection, close the popup and emit a `deselect` event.
+   * Clear the current selection, close the popup and emit a `map-deselect` event.
    */
   deselect() {
     if (this.__selected) {
@@ -262,7 +262,7 @@ export class StoreLocator<T extends BaseProps = BaseProps> extends Base<T & Stor
     }
 
     this.__popup?.remove();
-    this.$emit('deselect');
+    this.$emit('map-deselect');
   }
 
   /**
@@ -299,7 +299,7 @@ export class StoreLocator<T extends BaseProps = BaseProps> extends Base<T & Stor
 
   /**
    * Fit the map to the whole item set (when `fitOnUpdate`) then recompute the
-   * in-view list. Runs on an item-set change (the cluster's `update` event) and
+   * in-view list. Runs on an item-set change (the cluster's `map-update` event) and
    * when the cluster is first wired.
    * @private
    */
@@ -341,7 +341,7 @@ export class StoreLocator<T extends BaseProps = BaseProps> extends Base<T & Stor
    * Recompute the visible/sorted list = registered ∩ in-bounds, distance-sorted.
    *
    * Reflects the in-bounds state on every item, reorders the in-view items in
-   * their shared parent list (so DOM order matches distance) and emits `filter`
+   * their shared parent list (so DOM order matches distance) and emits `map-filter`
    * with the in-view items. Never touches the map data.
    * @private
    */
@@ -374,7 +374,7 @@ export class StoreLocator<T extends BaseProps = BaseProps> extends Base<T & Stor
     }
 
     this.__reorderList(inView);
-    this.$emit('filter', inView);
+    this.$emit('map-filter', inView);
   }
 
   /**
@@ -394,7 +394,7 @@ export class StoreLocator<T extends BaseProps = BaseProps> extends Base<T & Stor
   }
 
   /**
-   * Handle the cluster's `item-click`: select the item behind the clicked
+   * Handle the cluster's `map-item-click`: select the item behind the clicked
    * unclustered point, if one was resolved.
    * @private
    */
@@ -428,14 +428,14 @@ export class StoreLocator<T extends BaseProps = BaseProps> extends Base<T & Stor
   };
 
   /**
-   * Handle the cluster's `update` (the item set changed): re-fit and re-filter.
+   * Handle the cluster's `map-update` (the item set changed): re-fit and re-filter.
    * Drops a stale selection whose item is no longer registered.
    * @private
    */
   __handleClusterUpdate = () => {
     // The selected store may have been removed by the swap. Run the full
     // deselect cleanup — not just clearing `__selected` — so its popup is
-    // removed from the map and `deselect` is emitted, instead of leaving the
+    // removed from the map and `map-deselect` is emitted, instead of leaving the
     // removed store's popup stranded while the locator claims nothing is
     // selected.
     if (this.__selected && !this.items.includes(this.__selected)) {
@@ -446,7 +446,7 @@ export class StoreLocator<T extends BaseProps = BaseProps> extends Base<T & Stor
   };
 
   /**
-   * Handle a `MapboxGeocoder` `result`: frame the map on the geocoded location.
+   * Handle a `MapboxGeocoder` `map-result`: frame the map on the geocoded location.
    * @private
    */
   __handleGeocoderResult = (event: Event) => {
@@ -654,17 +654,17 @@ export class StoreLocator<T extends BaseProps = BaseProps> extends Base<T & Stor
     if (cluster && cluster.$isMounted && !this.__clusterWired) {
       this.__clusterWired = true;
       this.__cluster = cluster;
-      this.__offCluster.push(cluster.$on('item-click', this.__handleItemClick));
-      this.__offCluster.push(cluster.$on('update', this.__handleClusterUpdate));
+      this.__offCluster.push(cluster.$on('map-item-click', this.__handleItemClick));
+      this.__offCluster.push(cluster.$on('map-update', this.__handleClusterUpdate));
       // Catch up on the cluster's current item set: it may have emitted its
-      // seeded `update` before we subscribed.
+      // seeded `map-update` before we subscribed.
       this.__refresh();
     }
 
     if (geocoder && !this.__geocoderWired) {
       this.__geocoderWired = true;
       this.__geocoder = geocoder;
-      this.__offGeocoder.push(geocoder.$on('result', this.__handleGeocoderResult));
+      this.__offGeocoder.push(geocoder.$on('map-result', this.__handleGeocoderResult));
     }
 
     if ((!this.__clusterWired || !this.__geocoderWired) && attempt < WIRE_CHILDREN_MAX_ATTEMPTS) {


### PR DESCRIPTION
## Summary

- prefix every public `@studiometa/ui-mapbox` component event with `map-` to prevent native event conflicts
- update internal StoreLocator subscriptions and add regression coverage for the event naming convention
- update Mapbox and StoreLocator API docs, examples, stories, and migration guidance

## Tests

- `npm run test -- -- tests/MapboxMap`
- `npm run lint`
- `npm run docs:build`