### PR TITLE
Make CDN cache purge non-fatal; enrich PR preview comment

### DIFF
--- a/.github/workflows/cdn-preview.yml
+++ b/.github/workflows/cdn-preview.yml
@@ -57,17 +57,31 @@ jobs:
           CDN_PUBLIC_BASE_URL: ${{ vars.CDN_PUBLIC_BASE_URL }}
         with:
           script: |
+            const fs = require('fs');
             const base = (process.env.CDN_PUBLIC_BASE_URL || '').replace(/\/$/, '');
             const channel = `pr-${process.env.PR_NUMBER}-${process.env.HEAD_SHA.slice(0, 12)}`;
+            // Read the js-toolkit version this build pins from the emitted build.json so the manual
+            // import example points at the exact URL the ui tree resolves internally.
+            const uiRoot = 'packages/cdn/dist/releases/ui';
+            const uiVersion = fs.readdirSync(uiRoot)[0];
+            const build = JSON.parse(fs.readFileSync(`${uiRoot}/${uiVersion}/build.json`, 'utf8'));
+            const jsToolkit = build.dependencies['@studiometa/js-toolkit'];
             const marker = '<!-- cdn-asset-preview -->';
             const body = [
               marker,
               '### CDN asset preview',
               '',
-              `This pull request's build is published as the immutable channel \`${channel}\`:`,
+              `This pull request's build is published as the immutable channel \`${channel}\`.`,
               '',
+              '**Declarative autoloader** — one script; components mount from their `data-component`:',
               '```html',
               `<script type="module" src="${base}/ui@${channel}/autoload.js" data-studiometa-ui></script>`,
+              '```',
+              '',
+              '**Manual ESM imports** — the full package surfaces at their pinned URLs:',
+              '```js',
+              `import { Base, createApp } from "${base}/js-toolkit@${jsToolkit}/index.js";`,
+              `import { Action } from "${base}/ui@${channel}/index.js";`,
               '```',
               '',
               'It is pruned from the index automatically when the PR closes.',

--- a/packages/cdn/scripts/publish.ts
+++ b/packages/cdn/scripts/publish.ts
@@ -141,10 +141,20 @@ async function main(): Promise<void> {
   const result = await publish(store, uiArtifact, uiTarget, { log });
   process.stdout.write(`Published ${result.identity} to ${result.finalPrefix}.\n`);
 
+  // The cache purge is a best-effort optimization that only shortens how long the mutable alias
+  // redirects may serve a stale target (their TTL is minutes). The immutable assets and versions.json
+  // are already published, so a purge failure — a missing permission, a transient error — must never
+  // fail an otherwise-successful publication.
   const purge = loadCloudflarePurgeConfig(process.env);
   if (purge && mutableAliases.length > 0) {
-    await purgeMutableAliases(purge, mutableAliases);
-    process.stdout.write('Purged the mutable alias cache.\n');
+    try {
+      await purgeMutableAliases(purge, mutableAliases);
+      process.stdout.write('Purged the mutable alias cache.\n');
+    } catch (error) {
+      process.stderr.write(
+        `Warning: mutable alias cache purge failed (non-fatal): ${error instanceof Error ? error.message : error}\n`,
+      );
+    }
   }
 }
 

--- a/packages/cdn/scripts/rollback.ts
+++ b/packages/cdn/scripts/rollback.ts
@@ -69,10 +69,18 @@ async function main(): Promise<void> {
   const store = createS3ObjectStore(loadObjectStoreConfig(process.env));
   await rollback(store, target, { log: (message) => process.stdout.write(`${message}\n`) });
 
+  // Best-effort: a failed cache purge must not fail an otherwise-successful rollback (the index is
+  // already updated; the purge only shortens how long a mutable alias redirect may be stale).
   const purge = loadCloudflarePurgeConfig(process.env);
   if (purge) {
-    await purgeMutableAliases(purge, mutableAliases);
-    process.stdout.write('Purged the mutable alias cache.\n');
+    try {
+      await purgeMutableAliases(purge, mutableAliases);
+      process.stdout.write('Purged the mutable alias cache.\n');
+    } catch (error) {
+      process.stderr.write(
+        `Warning: mutable alias cache purge failed (non-fatal): ${error instanceof Error ? error.message : error}\n`,
+      );
+    }
   }
 }
 


### PR DESCRIPTION
Follow-up to the browser CDN (#573) fixing the first-deploy failure and improving the PR preview comment.

## Non-fatal cache purge (fixes the first Worker deploy)
`cdn-main`'s first run published the `main-<sha>` channel successfully (409 files in ~11s) but then **failed on the optional Cloudflare cache purge with HTTP 401** — the Workers-scoped API token has no zone cache-purge permission. That aborted the publish step *before* the Worker deploy step, so the Worker never deployed.

A successful publish must never fail on a best-effort cache purge (the immutable assets + `versions.json` are already live; the purge only shortens how long a mutable-alias `307` may be stale, and their TTL is minutes). `publish.ts` and `rollback.ts` now wrap the purge in `try/catch` and log a warning. Merging this produces a fresh `main` commit whose `cdn-main` will deploy the Worker cleanly.

## Richer PR preview comment
The `cdn-preview` asset comment now includes copy-pasteable **manual ESM import** snippets for `@studiometa/ui` and `@studiometa/js-toolkit` (the js-toolkit version is read from the emitted `build.json`), alongside the declarative autoloader snippet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)