### PR TITLE
Use cloudflare/wrangler-action@v4 for the CDN Worker deploy

### DIFF
--- a/.github/workflows/cdn-main.yml
+++ b/.github/workflows/cdn-main.yml
@@ -48,7 +48,7 @@ jobs:
       # immutable R2 prefixes and versions.json hold), so redeploying it after each main publish
       # simply keeps the live Worker in step with the worker/ sources on main.
       - name: Deploy the CDN Worker
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CDN_CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CDN_CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/cdn-preview.yml
+++ b/.github/workflows/cdn-preview.yml
@@ -105,7 +105,7 @@ jobs:
       # Worker exists, this uploads a preview version and comments its URL on every PR.
       - name: Upload a preview version of the CDN Worker
         continue-on-error: true
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CDN_CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CDN_CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
Fixes the CDN Worker deploy, which failed on the first `cdn-main` run.

`cloudflare/wrangler-action@v3` installs an old default wrangler (`3.90.0`) that predates `wrangler.jsonc` support (added in 3.91), so `wrangler deploy` never read the config's `main` and failed with **"Missing entry-point"**. (The publish step already succeeds — the non-fatal-purge fix from #576 worked.)

Move the deploy (`cdn-main`) and versions-upload (`cdn-preview`) steps to `cloudflare/wrangler-action@v4`, which ships a current wrangler that honours the jsonc config and `preview_urls`. Merging this produces a fresh `main` commit whose `cdn-main` will deploy the Worker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)