### PR TITLE
CDN: per-component subpath imports + bare-root latest redirects

### DIFF
--- a/packages/cdn/scripts/build.ts
+++ b/packages/cdn/scripts/build.ts
@@ -619,9 +619,31 @@ const jsToolkitResult = await esbuild.build({
   outdir: jsToolkitOutputDirectory,
 });
 
+// Every @studiometa/ui and @studiometa/ui-mapbox component is emitted as a stable, non-hashed ESM
+// entry named `<subpath>.js` at the ui tree root, so a consumer can import a single component by a
+// path that mirrors the npm subpath export (e.g. `/ui@<ref>/Action.js`). Pointing an entry straight
+// at the component source module re-exports its public exports. js-toolkit gets no per-symbol files
+// (pass A keeps only index.js + utils/index.js). Subpaths must not collide with the reserved ui
+// entries (autoload/loader/manifest/index) and no two components may share a subpath — both trees
+// share this one ui release tree.
+const reservedUiEntryNames = new Set(['autoload', 'loader', 'manifest', 'index']);
+const componentEntryPoints: Record<string, string> = {};
+for (const definition of definitions) {
+  const entryName = definition.subpath;
+  if (reservedUiEntryNames.has(entryName)) {
+    throw new Error(`Component subpath "${entryName}" collides with a reserved ui entry name.`);
+  }
+  const source = toPosix(relative(repositoryDirectory, definition.sourcePath));
+  const existing = componentEntryPoints[entryName];
+  if (existing && existing !== source) {
+    throw new Error(`Two components share the CDN subpath "${entryName}".`);
+  }
+  componentEntryPoints[entryName] = source;
+}
+
 // Pass B — the @studiometa/ui tree. js-toolkit is rewritten to its external, versioned URL and the
-// ui barrel is emitted as index.js. Autoload, loader, manifest, every component chunk and the
-// barrel now import the single external js-toolkit URL and carry no js-toolkit source.
+// ui barrel is emitted as index.js. Autoload, loader, manifest, every stable component entry and
+// the barrel now import the single external js-toolkit URL and carry no js-toolkit source.
 const uiResult = await esbuild.build({
   ...sharedEsbuildOptions(),
   entryPoints: {
@@ -629,6 +651,7 @@ const uiResult = await esbuild.build({
     loader: 'packages/cdn/src/loader.ts',
     manifest: 'packages/cdn/src/manifest.ts',
     index: 'packages/cdn/src/barrel-ui.ts',
+    ...componentEntryPoints,
   },
   outdir: uiOutputDirectory,
   external: [...mapboxExternalSpecifiers],

--- a/packages/cdn/size-budgets.json
+++ b/packages/cdn/size-budgets.json
@@ -15,8 +15,8 @@
     "js-toolkit:entry:utils": 6000,
     "js-toolkit:initial:index": 90000,
     "js-toolkit:initial:utils": 42000,
-    "total:esm": 360000,
-    "total:source-maps": 1600000,
-    "total:release": 2200000
+    "total:esm": 475000,
+    "total:source-maps": 2000000,
+    "total:release": 2700000
   }
 }

--- a/packages/cdn/size-budgets.json
+++ b/packages/cdn/size-budgets.json
@@ -15,8 +15,8 @@
     "js-toolkit:entry:utils": 6000,
     "js-toolkit:initial:index": 90000,
     "js-toolkit:initial:utils": 42000,
-    "total:esm": 475000,
-    "total:source-maps": 2000000,
-    "total:release": 2700000
+    "total:esm": 360000,
+    "total:source-maps": 1600000,
+    "total:release": 2200000
   }
 }

--- a/packages/cdn/tests/build.test.ts
+++ b/packages/cdn/tests/build.test.ts
@@ -326,10 +326,21 @@ describe('browser CDN build', () => {
       ['Action', 'Action'],
       ['MapboxMap', 'MapboxMap'],
     ] as const) {
+      const component = Object.values(build.components).find((entry) => entry.subpath === subpath);
+      expect(component).toBeDefined();
       expect(uiFiles).toContain(`${subpath}.js`);
       const source = await readFile(resolve(uiTree, `${subpath}.js`), 'utf8');
       expect(source).toMatch(new RegExp(`\\bas ${exportName}\\b`));
-      expect(source).toContain(`/js-toolkit@${jsToolkitVersion}/index.js`);
+      // js-toolkit is resolved through the single external URL somewhere in the entry's static
+      // graph (the entry or a shared chunk it imports, depending on code-splitting), never by
+      // bundling js-toolkit source.
+      const graph = [`${subpath}.js`, ...component!.preload];
+      const graphSources = await Promise.all(
+        graph.map((file) => readFile(resolve(uiTree, file), 'utf8')),
+      );
+      expect(
+        graphSources.some((text) => text.includes(`/js-toolkit@${jsToolkitVersion}/index.js`)),
+      ).toBe(true);
     }
   });
 

--- a/packages/cdn/tests/build.test.ts
+++ b/packages/cdn/tests/build.test.ts
@@ -59,6 +59,8 @@ interface BuildMetadata {
     string,
     {
       packageName: string;
+      subpath: string;
+      exportName: string;
       entry: string;
       preload: string[];
       dynamicImports: Array<{ entry: string; preload: string[] }>;
@@ -300,6 +302,35 @@ describe('browser CDN build', () => {
     // bundled Mapbox chunk — MapboxGeocoder and MapboxMap alike have no dynamic imports.
     expect(build.components.MapboxGeocoder.dynamicImports).toEqual([]);
     expect(build.components.MapboxMap.dynamicImports).toEqual([]);
+  });
+
+  it('emits a stable, non-hashed <subpath>.js entry at the ui tree root for every component', async () => {
+    const reserved = new Set(['autoload.js', 'loader.js', 'manifest.js', 'index.js']);
+    const seen = new Set<string>();
+    for (const component of Object.values(build.components)) {
+      // The entry is the stable subpath file at the tree root, not a hashed shared chunk.
+      expect(component.entry).toBe(`${component.subpath}.js`);
+      expect(component.entry).not.toMatch(/^chunks\//);
+      expect(component.entry).not.toMatch(/-[0-9A-Z]{8}\.js$/);
+      expect(reserved.has(component.entry)).toBe(false);
+      expect(uiFiles).toContain(component.entry);
+      expect(uiFiles).toContain(`${component.entry}.map`);
+      // Subpaths mirror the npm subpath exports one-to-one, so entries never collide.
+      expect(seen.has(component.entry)).toBe(false);
+      seen.add(component.entry);
+    }
+
+    // A @studiometa/ui and a @studiometa/ui-mapbox sample are each served and re-export the
+    // component, so `import { X } from "/ui@<ref>/X.js"` mirrors the npm subpath export.
+    for (const [subpath, exportName] of [
+      ['Action', 'Action'],
+      ['MapboxMap', 'MapboxMap'],
+    ] as const) {
+      expect(uiFiles).toContain(`${subpath}.js`);
+      const source = await readFile(resolve(uiTree, `${subpath}.js`), 'utf8');
+      expect(source).toMatch(new RegExp(`\\bas ${exportName}\\b`));
+      expect(source).toContain(`/js-toolkit@${jsToolkitVersion}/index.js`);
+    }
   });
 
   it('externalizes Mapbox and the geocoder instead of bundling their source', async () => {

--- a/packages/cdn/tests/worker/index.test.ts
+++ b/packages/cdn/tests/worker/index.test.ts
@@ -111,6 +111,49 @@ describe('CDN Worker js-toolkit package routing', () => {
   });
 });
 
+describe('CDN Worker bare package roots', () => {
+  it.each(['/ui', '/ui/'])('redirects %s to the latest ui autoload entry', async (path) => {
+    const response = await request(path);
+    expect(response.status).toBe(307);
+    expect(response.headers.get('Location')).toBe(`${origin}/ui@2.0.0/autoload.js`);
+    expect(response.headers.get('Cache-Control')).toBe(MUTABLE_CACHE_CONTROL);
+    expectCrossOriginHeaders(response);
+  });
+
+  it.each(['/js-toolkit', '/js-toolkit/'])(
+    'redirects %s to the highest js-toolkit index entry',
+    async (path) => {
+      const response = await request(path);
+      expect(response.status).toBe(307);
+      expect(response.headers.get('Location')).toBe(
+        `${origin}/js-toolkit@${fixture.jsToolkitVersion}/index.js`,
+      );
+      expect(response.headers.get('Cache-Control')).toBe(MUTABLE_CACHE_CONTROL);
+      expectCrossOriginHeaders(response);
+    },
+  );
+
+  it('returns 404 for bare roots when the package has no eligible release', async () => {
+    const original = fixture.bucket.objects.get('versions.json') as NonNullable<
+      ReturnType<typeof fixture.bucket.objects.get>
+    >;
+    fixture.bucket.put(
+      'versions.json',
+      JSON.stringify({
+        schemaVersion: 2,
+        packages: {
+          ui: { releases: [], channels: [], distTags: {} },
+          'js-toolkit': { releases: [] },
+        },
+      }),
+    );
+    for (const path of ['/ui', '/ui/', '/js-toolkit', '/js-toolkit/']) {
+      expect((await request(path)).status).toBe(404);
+    }
+    fixture.bucket.objects.set('versions.json', original);
+  });
+});
+
 describe('CDN Worker eager component queries', () => {
   it('resolves a mutable version and canonicalizes the query in one hop', async () => {
     const response = await request(

--- a/packages/cdn/tests/worker/versions.test.ts
+++ b/packages/cdn/tests/worker/versions.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment node
 
 import { describe, expect, it } from 'vitest';
-import { parseVersionsIndex, resolveVersion } from '../../worker/versions.ts';
+import { parseVersionsIndex, resolveBareRoot, resolveVersion } from '../../worker/versions.ts';
 
 function uiIndex(ui: { releases: string[]; channels: string[]; distTags: Record<string, string> }) {
   return {
@@ -122,5 +122,38 @@ describe('js-toolkit version resolution', () => {
     expect(resolveVersion(index, 'js-toolkit', 'main')).toBeUndefined();
     expect(resolveVersion(index, 'js-toolkit', 'main-abcdef1')).toBeUndefined();
     expect(resolveVersion(index, 'js-toolkit', '9.9.9')).toBeUndefined();
+  });
+});
+
+describe('bare package root resolution', () => {
+  const index = parseVersionsIndex({
+    schemaVersion: 2,
+    packages: {
+      ui: { releases: ['1.9.0', '2.0.0'], channels: [], distTags: { latest: '2.0.0' } },
+      // Deliberately unordered and spanning a two-digit minor to prove numeric (not lexical) order.
+      'js-toolkit': { releases: ['3.7.0', '3.10.0', '3.8.0'] },
+    },
+  });
+
+  it('resolves the ui root to the latest stable release', () => {
+    expect(resolveBareRoot(index, 'ui')).toEqual({
+      kind: 'release',
+      version: '2.0.0',
+      objectPrefix: 'releases/ui/2.0.0',
+    });
+  });
+
+  it('resolves the js-toolkit root to the highest published release', () => {
+    expect(resolveBareRoot(index, 'js-toolkit')).toEqual({
+      kind: 'release',
+      version: '3.10.0',
+      objectPrefix: 'releases/js-toolkit/3.10.0',
+    });
+  });
+
+  it('resolves to nothing when the package has no eligible release', () => {
+    const empty = parseVersionsIndex(uiIndex({ releases: [], channels: [], distTags: {} }));
+    expect(resolveBareRoot(empty, 'ui')).toBeUndefined();
+    expect(resolveBareRoot(empty, 'js-toolkit')).toBeUndefined();
   });
 });

--- a/packages/cdn/worker/index.ts
+++ b/packages/cdn/worker/index.ts
@@ -1,4 +1,4 @@
-import { canonicalizeQuery, parseRoute, RequestValidationError } from './queries.ts';
+import { canonicalizeQuery, parseBareRoot, parseRoute, RequestValidationError } from './queries.ts';
 import {
   contentType,
   errorResponse,
@@ -17,7 +17,7 @@ import type {
   R2ObjectBodyLike,
   WorkerEnvironment,
 } from './types.ts';
-import { isMutableVersion, parseVersionsIndex, resolveVersion } from './versions.ts';
+import { isMutableVersion, parseVersionsIndex, resolveBareRoot, resolveVersion } from './versions.ts';
 import { classifyVersion, emitObservation, ObservationRecorder } from './observability.ts';
 
 const MAX_LINK_HEADER_BYTES = 7_500;
@@ -198,7 +198,11 @@ async function handleRequest(
   }
 
   const url = new URL(request.url);
-  const route = parseRoute(url.pathname);
+  const bareRoot = parseBareRoot(url.pathname);
+  // Validate an asset route up front so a malformed path is rejected before any storage access; a
+  // bare package root skips validation and resolves against the index below.
+  const route = bareRoot === undefined ? parseRoute(url.pathname) : undefined;
+
   const indexValue = await readJsonObject(environment.ASSETS, 'versions.json');
   if (indexValue === undefined) {
     recorder.r2('index', 'miss');
@@ -206,6 +210,18 @@ async function handleRequest(
   }
   recorder.r2('index', 'hit');
   const versions = parseVersionsIndex(indexValue);
+
+  if (route === undefined) {
+    // A bare package root redirects to its latest usable asset: `/ui` to the `latest` stable
+    // autoload entry, and the tagless `/js-toolkit` to the highest published bare index entry.
+    // Both classify as a dist-tag hop — a moving pointer resolved to an exact version.
+    const resolved = resolveBareRoot(versions, bareRoot as PackageName);
+    recorder.versionKind(classifyVersion(resolved ? 'latest' : undefined, resolved));
+    if (!resolved) return errorResponse(404);
+    const entry = bareRoot === 'ui' ? 'autoload.js' : 'index.js';
+    return redirectResponse(`${url.origin}/${bareRoot}@${resolved.version}/${entry}`);
+  }
+
   const exact = resolveVersion(versions, route.packageName, route.requestedVersion);
   recorder.versionKind(classifyVersion(route.requestedVersion, exact));
   if (!exact) return errorResponse(404);

--- a/packages/cdn/worker/queries.ts
+++ b/packages/cdn/worker/queries.ts
@@ -62,6 +62,16 @@ export function parseRoute(pathname: string): ParsedRoute {
   };
 }
 
+// A bare package root is the package name alone, with no version and no asset segment: `/ui`,
+// `/ui/`, `/js-toolkit`, `/js-toolkit/`. It redirects to a usable latest asset (resolved by the
+// caller). Anything with a version (`/ui@1.2.0`) or an asset (`/ui/autoload.js`) falls through to
+// `parseRoute`, so this recognizes only the bare name.
+export function parseBareRoot(pathname: string): PackageName | undefined {
+  const name = (pathname.endsWith('/') ? pathname.slice(0, -1) : pathname).slice(1);
+  if (name === '' || name.includes('/')) return undefined;
+  return PACKAGE_NAMES.has(name as PackageName) ? (name as PackageName) : undefined;
+}
+
 export function canonicalizeQuery(
   url: URL,
   assetPath: string,

--- a/packages/cdn/worker/versions.ts
+++ b/packages/cdn/worker/versions.ts
@@ -162,6 +162,21 @@ export function resolveVersion(
   return resolved ? exactRelease('ui', resolved) : undefined;
 }
 
+/**
+ * Resolves the exact version a bare package root redirects to. The `ui` root follows the `latest`
+ * distribution tag; the tagless `js-toolkit` root follows its highest published release. Either
+ * yields `undefined` when the package has no eligible release yet, which the Worker turns into a
+ * 404.
+ */
+export function resolveBareRoot(
+  index: VersionsIndex,
+  packageName: PackageName,
+): ExactVersion | undefined {
+  if (packageName === 'ui') return resolveVersion(index, 'ui', 'latest');
+  const highest = [...index.packages['js-toolkit'].releases].sort(compareStableVersions).at(-1);
+  return highest ? exactRelease('js-toolkit', highest) : undefined;
+}
+
 export function isMutableVersion(requested: string, resolved: ExactVersion): boolean {
   return requested !== resolved.version;
 }


### PR DESCRIPTION
Two browser-CDN enhancements (follow-up to #573).

## Per-component subpath imports
Every `@studiometa/ui` and `@studiometa/ui-mapbox` component is now emitted as a stable, non-hashed ESM entry named `<subpath>.js` at the ui release root, mirroring the npm subpath exports:

```js
import { Action } from "https://cdn.studiometa.dev/ui@<ref>/Action.js";
import { MapboxMap } from "https://cdn.studiometa.dev/ui@<ref>/MapboxMap.js";
```

The build adds each component as an esbuild entry point (guarded against reserved-name and subpath collisions). These entries **replace** the former hashed component chunks (the manifest lazy-load path now resolves the stable names), so the release size is essentially unchanged — no code duplication, budgets stay tight. js-toolkit is unchanged (`index.js` + `utils/index.js`; no per-symbol files).

## Bare-root latest redirects
- `GET /ui` and `/ui/` → `307` → `/ui@<latest>/autoload.js` (the `latest` dist tag; 404 until a stable release is tagged).
- `GET /js-toolkit` and `/js-toolkit/` → `307` → `/js-toolkit@<highest>/index.js` (highest released version, numeric semver order).

Existing routes are untouched: versioned, versionless `/ui/<asset>`, aliases, and channels all behave as before; malformed requests are still rejected before any storage access.

## Tests
Full runnable CDN suite green — **101 passed** (worker, build, manifest, loader, autoload), lint clean. (The `@aws-sdk`/Playwright-dependent publication + browser suites run in CI.)

Built with two parallel subagents (worker routing + build entries), combined and reconciled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)