### PR TITLE
Migrate the CDN build to tsdown and serve TypeScript declarations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23285,9 +23285,9 @@
         "@mapbox/mapbox-gl-geocoder": "5.1.2",
         "@playwright/test": "1.61.1",
         "@studiometa/js-toolkit": "3.8.0",
-        "esbuild": "0.27.4",
         "happy-dom": "^20.8.8",
         "mapbox-gl": "3.27.0",
+        "tsdown": "0.21.5",
         "vitest": "4.1.1"
       }
     },
@@ -23404,10 +23404,37 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "packages/cdn/node_modules/ansis": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/ansis/-/ansis-4.3.1.tgz",
+      "integrity": "sha512-BJ8/l4R5LRE7hW9WdSuGYrLSHi2ynxeFpDFbH0K/CgNeY/tyhk+vO6TYxXC5r5CpUhNVX310xzPsN/H9lCdfOA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "packages/cdn/node_modules/cac": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-7.0.0.tgz",
+      "integrity": "sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
     "packages/cdn/node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "packages/cdn/node_modules/hookable": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/hookable/-/hookable-6.1.1.tgz",
+      "integrity": "sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -23430,6 +23457,72 @@
       "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
       "dev": true,
       "license": "MIT"
+    },
+    "packages/cdn/node_modules/tsdown": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/tsdown/-/tsdown-0.21.5.tgz",
+      "integrity": "sha512-TlgNhfPioAD6ECCUnZsxcUsXXuPPR4Rrxz3az741kL/M3oGIET4a9GajSNRNRx+jIva73TYUKQybrEPkDYN+fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansis": "^4.2.0",
+        "cac": "^7.0.0",
+        "defu": "^6.1.4",
+        "empathic": "^2.0.0",
+        "hookable": "^6.1.0",
+        "import-without-cache": "^0.2.5",
+        "obug": "^2.1.1",
+        "picomatch": "^4.0.4",
+        "rolldown": "1.0.0-rc.11",
+        "rolldown-plugin-dts": "^0.22.5",
+        "semver": "^7.7.4",
+        "tinyexec": "^1.0.4",
+        "tinyglobby": "^0.2.15",
+        "tree-kill": "^1.2.2",
+        "unconfig-core": "^7.5.0",
+        "unrun": "^0.2.33"
+      },
+      "bin": {
+        "tsdown": "dist/run.mjs"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sxzz"
+      },
+      "peerDependencies": {
+        "@arethetypeswrong/core": "^0.18.1",
+        "@tsdown/css": "0.21.5",
+        "@tsdown/exe": "0.21.5",
+        "@vitejs/devtools": "*",
+        "publint": "^0.3.0",
+        "typescript": "^5.0.0 || ^6.0.0",
+        "unplugin-unused": "^0.5.0"
+      },
+      "peerDependenciesMeta": {
+        "@arethetypeswrong/core": {
+          "optional": true
+        },
+        "@tsdown/css": {
+          "optional": true
+        },
+        "@tsdown/exe": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "publint": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        },
+        "unplugin-unused": {
+          "optional": true
+        }
+      }
     },
     "packages/cdn/node_modules/vitest": {
       "version": "4.1.1",

--- a/packages/cdn/package.json
+++ b/packages/cdn/package.json
@@ -29,9 +29,9 @@
     "@mapbox/mapbox-gl-geocoder": "5.1.2",
     "@playwright/test": "1.61.1",
     "@studiometa/js-toolkit": "3.8.0",
-    "esbuild": "0.27.4",
     "happy-dom": "^20.8.8",
     "mapbox-gl": "3.27.0",
+    "tsdown": "0.21.5",
     "vitest": "4.1.1"
   }
 }

--- a/packages/cdn/scripts/build.ts
+++ b/packages/cdn/scripts/build.ts
@@ -3,7 +3,8 @@ import { execFileSync } from 'node:child_process';
 import { mkdir, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises';
 import { dirname, isAbsolute, relative, resolve, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import esbuild, { type Metafile, type Plugin } from 'esbuild';
+import { build as tsdownBuild } from 'tsdown';
+import type { Plugin } from 'rolldown';
 import { catalog as uiCatalog } from '@studiometa/ui/catalog';
 import { catalog as mapboxCatalog } from '@studiometa/ui-mapbox/catalog';
 
@@ -15,6 +16,14 @@ const scriptsDirectory = dirname(fileURLToPath(import.meta.url));
 const packageDirectory = resolve(scriptsDirectory, '..');
 const repositoryDirectory = resolve(packageDirectory, '../..');
 const defaultOutputDirectory = resolve(packageDirectory, 'dist');
+
+// tsdown resolves both its `tsconfig` and its package.json-based dependency externalization from the
+// process working directory. Pin it to the repository root so the build behaves identically whether
+// it is launched from the repo root (as the tests do) or from `packages/cdn` (as `npm run build`
+// does); every path in this script is absolute, so the working directory only steers tsdown. Left
+// unpinned, a run from `packages/cdn` would externalize the workspace `@studiometa/ui*` packages
+// (they are that manifest's dependencies) and resolve the narrower package tsconfig.
+process.chdir(repositoryDirectory);
 const packageMetadata = JSON.parse(
   await readFile(resolve(packageDirectory, 'package.json'), 'utf8'),
 );
@@ -24,6 +33,13 @@ const jsToolkitMetadata = JSON.parse(
     'utf8',
   ),
 );
+const tsdownMetadata = JSON.parse(
+  await readFile(resolve(packageDirectory, 'node_modules/tsdown/package.json'), 'utf8'),
+);
+const rolldownMetadata = JSON.parse(
+  await readFile(resolve(repositoryDirectory, 'node_modules/rolldown/package.json'), 'utf8'),
+);
+const bundlerLabel = `tsdown@${tsdownMetadata.version} (rolldown@${rolldownMetadata.version})`;
 const sizeBudgets = JSON.parse(
   await readFile(resolve(packageDirectory, 'size-budgets.json'), 'utf8'),
 ) as SizeBudgets;
@@ -39,6 +55,15 @@ const jsToolkitUtilsUrl = `/js-toolkit@${jsToolkitVersion}/utils/index.js`;
 // (or an injected instance via `provideMapboxGl`). This sidesteps redistributing the proprietary
 // Mapbox GL build and lets strict-CSP consumers self-host the same-origin GL worker.
 const mapboxExternalSpecifiers = ['mapbox-gl', '@mapbox/mapbox-gl-geocoder'] as const;
+
+// The declarations import js-toolkit types by their bare specifier so the ui `.d.ts` files resolve
+// against the separately built js-toolkit declarations (served from its own versioned tree) instead
+// of inlining them. Only the JavaScript rewrites js-toolkit to its absolute, origin-relative URL.
+const declarationExternals = [
+  '@studiometa/js-toolkit',
+  '@studiometa/js-toolkit/utils',
+  ...mapboxExternalSpecifiers,
+] as const;
 
 const packageDirectories = {
   '@studiometa/ui': resolve(repositoryDirectory, 'packages/ui'),
@@ -72,6 +97,40 @@ interface ComponentDefinition {
   styles: readonly string[];
   integrations: readonly string[];
   sourcePath: string;
+}
+
+// esbuild derived the release graph from its metafile. tsdown/rolldown expose the same information
+// on each Rollup-style output chunk (`imports`/`dynamicImports`/`moduleIds`/`facadeModuleId`), so
+// the build re-projects the chunk output into this minimal metafile shape and keeps every downstream
+// graph helper (preload derivation, isolation assertions, third-party notices) unchanged. Output
+// keys are tree-relative POSIX paths (e.g. `Action.js`, `chunks/Action-<hash>.js`) and input keys
+// are repository-relative POSIX paths, matching what esbuild's metafile exposed to these helpers.
+interface MetafileImport {
+  path: string;
+  kind: 'import-statement' | 'dynamic-import';
+  external: boolean;
+}
+interface MetafileOutput {
+  imports: MetafileImport[];
+  inputs: Record<string, unknown>;
+  entryPoint?: string;
+  bytes: number;
+}
+interface Metafile {
+  outputs: Record<string, MetafileOutput>;
+  inputs: Record<string, unknown>;
+}
+
+// A minimal view of the rolldown output chunk this build relies on.
+interface OutputChunkLike {
+  type: 'chunk' | 'asset';
+  fileName: string;
+  isEntry: boolean;
+  facadeModuleId: string | null;
+  moduleIds: string[];
+  imports: string[];
+  dynamicImports: string[];
+  code?: string;
 }
 
 function toPosix(path: string): string {
@@ -206,20 +265,17 @@ function shopifyFallbackPlugin(): Plugin {
   const sourcePath = resolve(repositoryDirectory, 'packages/ui/Fetch/FetchShopifyPartial.ts');
   return {
     name: 'cdn-shopify-partial-rendering-policy',
-    setup(build) {
-      build.onLoad({ filter: /FetchShopifyPartial\.ts$/ }, async (args) => {
-        if (resolve(args.path) !== sourcePath) return undefined;
-        const source = await readFile(args.path, 'utf8');
-        const original = '    return import(this.__PARTIALS_MODULE);';
-        if (!source.includes(original)) {
-          throw new Error('The CDN Shopify fallback transform is stale.');
-        }
-        const replacement = [
-          "    console.warn('[@studiometa/ui-cdn] Shopify partial rendering is unavailable in this CDN build; falling back to Fetch.');",
-          "    throw new Error('The optional @shopify/partial-rendering adapter is excluded from this CDN build.');",
-        ].join('\n');
-        return { contents: source.replace(original, replacement), loader: 'ts' };
-      });
+    transform(source: string, id: string) {
+      if (resolve(id.split('?')[0]) !== sourcePath) return undefined;
+      const original = '    return import(this.__PARTIALS_MODULE);';
+      if (!source.includes(original)) {
+        throw new Error('The CDN Shopify fallback transform is stale.');
+      }
+      const replacement = [
+        "    console.warn('[@studiometa/ui-cdn] Shopify partial rendering is unavailable in this CDN build; falling back to Fetch.');",
+        "    throw new Error('The optional @shopify/partial-rendering adapter is excluded from this CDN build.');",
+      ].join('\n');
+      return { code: source.replace(original, replacement) };
     },
   };
 }
@@ -238,33 +294,70 @@ function externalizeToolkitPlugin(): Plugin {
   };
   return {
     name: 'cdn-externalize-js-toolkit',
-    setup(build) {
-      build.onResolve({ filter: /^@studiometa\/js-toolkit(?:\/utils)?$/ }, (args) => {
-        const path = mapping[args.path];
-        if (!path) return undefined;
-        return { path, external: true };
-      });
+    resolveId(id: string) {
+      const path = mapping[id];
+      if (!path) return undefined;
+      return { id: path, external: true };
     },
   };
 }
 
-function outputKeyForPath(metafile: Metafile, absolutePath: string): string {
-  const normalized = resolve(absolutePath);
-  const output = Object.keys(metafile.outputs).find(
-    (key) => resolve(repositoryDirectory, key) === normalized,
-  );
-  if (!output) throw new Error(`Missing metafile output for ${absolutePath}`);
-  return output;
+// Rolldown reports every module id it bundles as an absolute path; keep only real, in-repository
+// source files (dropping rolldown's virtual/runtime modules) and normalise them to the same
+// repository-relative POSIX keys esbuild's metafile inputs used.
+function toRepositoryInput(id: string | null | undefined): string | undefined {
+  if (!id) return undefined;
+  const clean = id.split('?')[0];
+  if (clean.includes('\0') || !isAbsolute(clean)) return undefined;
+  const rel = toPosix(relative(repositoryDirectory, clean));
+  return rel.startsWith('..') ? undefined : rel;
 }
 
+// Projects the rolldown output chunks into the minimal metafile the graph helpers consume. Static
+// imports and dynamic imports keep their kind, and any import whose path is not itself an output
+// chunk is an external browser import (a js-toolkit URL or a bare Mapbox specifier).
+function metafileFromChunks(chunks: readonly OutputChunkLike[]): Metafile {
+  const jsChunks = chunks.filter(
+    (chunk) => chunk.type === 'chunk' && chunk.fileName.endsWith('.js'),
+  );
+  const outputKeys = new Set(jsChunks.map((chunk) => chunk.fileName));
+  const outputs: Record<string, MetafileOutput> = {};
+  const inputs: Record<string, unknown> = {};
+  for (const chunk of jsChunks) {
+    const chunkInputs: Record<string, unknown> = {};
+    for (const moduleId of chunk.moduleIds) {
+      const input = toRepositoryInput(moduleId);
+      if (!input) continue;
+      chunkInputs[input] = {};
+      inputs[input] = {};
+    }
+    const imports: MetafileImport[] = [
+      ...chunk.imports.map((path) => ({
+        path,
+        kind: 'import-statement' as const,
+        external: !outputKeys.has(path),
+      })),
+      ...chunk.dynamicImports.map((path) => ({
+        path,
+        kind: 'dynamic-import' as const,
+        external: !outputKeys.has(path),
+      })),
+    ];
+    outputs[chunk.fileName] = {
+      imports,
+      inputs: chunkInputs,
+      entryPoint: chunk.isEntry ? toRepositoryInput(chunk.facadeModuleId) : undefined,
+      bytes: chunk.code?.length ?? 0,
+    };
+  }
+  return { outputs, inputs };
+}
+
+// A rolldown import path already is the tree-relative output key, so no importer-relative resolution
+// is needed; assert the referenced chunk actually exists.
 function importedOutputKey(metafile: Metafile, importer: string, imported: string): string {
   if (metafile.outputs[imported]) return imported;
-  const resolved = toPosix(resolve(dirname(resolve(repositoryDirectory, importer)), imported));
-  const output = Object.keys(metafile.outputs).find(
-    (key) => toPosix(resolve(repositoryDirectory, key)) === resolved,
-  );
-  if (!output) throw new Error(`Missing imported output ${imported} from ${importer}`);
-  return output;
+  throw new Error(`Missing imported output ${imported} from ${importer}`);
 }
 
 function staticOutputGraph(metafile: Metafile, root: string): string[] {
@@ -299,8 +392,9 @@ function dynamicOutputEntries(metafile: Metafile, root: string): string[] {
     .sort();
 }
 
-function publicPath(outputDirectory: string, outputKey: string): string {
-  return toPosix(relative(outputDirectory, resolve(repositoryDirectory, outputKey)));
+// Output keys are already tree-relative POSIX paths, so the public path is the key itself.
+function publicPath(_outputDirectory: string, outputKey: string): string {
+  return outputKey;
 }
 
 function assertDoesNotContain(
@@ -327,19 +421,19 @@ function collectExternalImports(metafile: Metafile): string[] {
 }
 
 /**
- * Asserts the ui tree's externalization invariants and returns the external specifiers, split into
- * the js-toolkit URLs and the Mapbox specifiers:
+ * Asserts the ui tree's externalization invariants and returns the js-toolkit external URLs:
  *
  * - js-toolkit is imported only through its single absolute URL(s), and the main index URL — the
  *   module that owns the shared component registry — is present, with no js-toolkit source bundled.
- * - Mapbox GL and the optional geocoder are imported only as their bare specifiers (resolved by the
- *   consumer's import map) and neither library's source is bundled anywhere in the tree.
+ * - Mapbox GL and the optional geocoder source is bundled nowhere in the tree.
  * - No other external import is allowed.
+ *
+ * Rolldown surfaces static externals (the js-toolkit URLs) on the chunk graph but does not list a
+ * bare *dynamic* external (Mapbox is loaded through `import('mapbox-gl')`) there, so the presence of
+ * the Mapbox external specifiers is verified separately against the emitted code by
+ * `assertMapboxDynamicExternals`.
  */
-function assertUiExternals(metafile: Metafile): {
-  toolkitUrls: string[];
-  mapboxSpecifiers: string[];
-} {
+function assertUiExternals(metafile: Metafile): { toolkitUrls: string[] } {
   const external = collectExternalImports(metafile);
   const allowed = new Set<string>([
     jsToolkitIndexUrl,
@@ -352,13 +446,6 @@ function assertUiExternals(metafile: Metafile): {
   }
   if (!external.includes(jsToolkitIndexUrl)) {
     throw new Error(`The ui tree does not import the js-toolkit URL ${jsToolkitIndexUrl}.`);
-  }
-  for (const specifier of mapboxExternalSpecifiers) {
-    if (!external.includes(specifier)) {
-      throw new Error(
-        `The ui tree does not import Mapbox through the external specifier ${specifier}.`,
-      );
-    }
   }
   const bundled = Object.keys(metafile.inputs).filter((input) =>
     [
@@ -374,10 +461,32 @@ function assertUiExternals(metafile: Metafile): {
   }
   return {
     toolkitUrls: external.filter((url) => url === jsToolkitIndexUrl || url === jsToolkitUtilsUrl),
-    mapboxSpecifiers: external.filter((url) =>
-      (mapboxExternalSpecifiers as readonly string[]).includes(url),
-    ),
   };
+}
+
+// Rolldown keeps a bare *dynamic* external as a runtime `import('<specifier>')` in the emitted code
+// without recording it on the chunk graph, so the Mapbox externalization is asserted directly
+// against the built modules: every Mapbox specifier must appear as a bare dynamic import, resolved
+// by the consumer's import map. Returns the specifiers actually found, in sorted order.
+async function assertMapboxDynamicExternals(
+  outputDirectory: string,
+  files: readonly string[],
+): Promise<string[]> {
+  const pattern = /\bimport\(\s*[`'"]([^`'"]+)[`'"]\s*\)/g;
+  const found = new Set<string>();
+  for (const file of files.filter((path) => path.endsWith('.js'))) {
+    const source = await readFile(resolve(outputDirectory, file), 'utf8');
+    for (const match of source.matchAll(pattern)) {
+      if ((mapboxExternalSpecifiers as readonly string[]).includes(match[1])) found.add(match[1]);
+    }
+  }
+  const missing = mapboxExternalSpecifiers.filter((specifier) => !found.has(specifier));
+  if (missing.length > 0) {
+    throw new Error(
+      `The ui tree does not import Mapbox through the external specifier ${missing.join(', ')}.`,
+    );
+  }
+  return [...found].sort();
 }
 
 async function listFiles(directory: string, root = directory): Promise<string[]> {
@@ -396,6 +505,34 @@ async function fileSizes(outputDirectory: string, files: readonly string[]) {
       files.map(async (file) => [file, (await stat(resolve(outputDirectory, file))).size] as const),
     ),
   );
+}
+
+// Rolldown emits no source map for a pure re-export facade entry (`export { X as Action } …`), the
+// same shape esbuild emitted with an empty (`sources: []`) map. Synthesize that empty, source-free
+// map for every such `.js` so the public "one source map per module" invariant still holds and the
+// facade stays sourcemap-linked.
+async function synthesizeFacadeSourceMaps(treeDirectory: string): Promise<void> {
+  const files = await listFiles(treeDirectory);
+  const present = new Set(files);
+  for (const file of files) {
+    if (!file.endsWith('.js') || present.has(`${file}.map`)) continue;
+    const absolute = resolve(treeDirectory, file);
+    const base = file.split('/').pop() as string;
+    const map = {
+      version: 3,
+      file: base,
+      sources: [],
+      sourcesContent: [],
+      names: [],
+      mappings: '',
+    };
+    await writeFile(`${absolute}.map`, `${JSON.stringify(map)}\n`);
+    let source = await readFile(absolute, 'utf8');
+    if (!source.includes('# sourceMappingURL=')) {
+      source = `${source.replace(/\s+$/, '')}\n//# sourceMappingURL=${base}.map\n`;
+      await writeFile(absolute, source);
+    }
+  }
 }
 
 async function writeThirdPartyNotices(metafile: Metafile, outputDirectory: string): Promise<void> {
@@ -454,7 +591,7 @@ async function assertBrowserImports(
     throw new Error(`Unresolved external browser imports: ${externalImports.join(', ')}`);
   }
 
-  const dynamicLiteralPattern = /\bimport\(\s*['"]([^'"]+)['"]\s*\)/g;
+  const dynamicLiteralPattern = /\bimport\(\s*[`'"]([^`'"]+)[`'"]\s*\)/g;
   for (const file of files.filter((path) => path.endsWith('.js'))) {
     const source = await readFile(resolve(outputDirectory, file), 'utf8');
     for (const match of source.matchAll(dynamicLiteralPattern)) {
@@ -571,25 +708,69 @@ async function sha384(path: string): Promise<string> {
     .digest('base64')}`;
 }
 
-function sharedEsbuildOptions() {
+// Shared tsdown/rolldown options for a bundled JavaScript tree. Splitting is automatic with several
+// entry points; entries stay at stable, non-hashed `<name>.js` paths and shared code is content
+// hashed under `chunks/`. Source maps embed `sourcesContent`, and the build is reproducible.
+function sharedBundleOptions(outputDirectory: string) {
   return {
-    absWorkingDir: repositoryDirectory,
-    bundle: true,
-    splitting: true,
-    format: 'esm',
-    platform: 'browser',
+    format: 'esm' as const,
+    platform: 'browser' as const,
     target: 'es2020',
-    entryNames: '[dir]/[name]',
-    chunkNames: 'chunks/[name]-[hash]',
-    assetNames: 'assets/[name]-[hash]',
+    outDir: outputDirectory,
+    clean: false,
+    write: true,
     sourcemap: true,
-    metafile: true,
     minify: true,
-    legalComments: 'eof',
-    charset: 'utf8',
+    treeshake: true,
+    dts: false as const,
+    config: false,
+    logLevel: 'silent' as const,
     define: { __DEV__: 'false' },
-    logLevel: 'info',
-  } as const;
+    outputOptions: {
+      entryFileNames: '[name].js',
+      chunkFileNames: 'chunks/[name]-[hash].js',
+      sourcemapExcludeSources: false,
+    },
+  };
+}
+
+// Shared tsdown options for a declarations-only pass. `eager` resolves the barrel's transitive
+// re-exports so `index.d.ts` re-exports every component, and `emitDtsOnly` leaves the JavaScript
+// pass to own the `.js`/`.map` outputs. Declaration entries stay at `<name>.d.ts` and shared
+// declaration chunks are hashed under `chunks/`.
+//
+// The `tsconfig` is pinned to the repository root config by absolute path so the eager tsc program
+// compiles the same bounded set of files regardless of the process working directory. Left to
+// discovery, a run from `packages/cdn` would pick up that package's narrower `tsconfig.json` (which
+// does not include the ui/ui-mapbox sources) and pull in an unbounded file set, exhausting memory.
+const declarationTsconfig = resolve(repositoryDirectory, 'tsconfig.json');
+function sharedDeclarationOptions(outputDirectory: string, external: readonly string[]) {
+  return {
+    format: 'esm' as const,
+    platform: 'browser' as const,
+    target: 'es2020',
+    outDir: outputDirectory,
+    clean: false,
+    write: true,
+    sourcemap: false,
+    tsconfig: declarationTsconfig,
+    dts: { eager: true, emitDtsOnly: true, tsconfig: declarationTsconfig },
+    config: false,
+    logLevel: 'silent' as const,
+    external: [...external],
+    outputOptions: {
+      entryFileNames: '[name].js',
+      chunkFileNames: 'chunks/[name]-[hash].js',
+    },
+  };
+}
+
+function chunksOf(results: Awaited<ReturnType<typeof tsdownBuild>>): OutputChunkLike[] {
+  const chunks: OutputChunkLike[] = [];
+  for (const result of results as unknown as Array<{ chunks?: OutputChunkLike[] }>) {
+    for (const chunk of result.chunks ?? []) chunks.push(chunk);
+  }
+  return chunks;
 }
 
 const { outputDirectory, allowDirty } = parseBuildOptions();
@@ -616,16 +797,23 @@ const buildIdentifier = currentSourceState.clean
   ? cleanBuildIdentifier
   : `${cleanBuildIdentifier}.dirty.${currentSourceState.digest}`;
 
+const jsToolkitEntryPoints = {
+  index: resolve(repositoryDirectory, 'packages/cdn/src/barrel-js-toolkit.ts'),
+  'utils/index': resolve(repositoryDirectory, 'packages/cdn/src/barrel-js-toolkit-utils.ts'),
+};
+
 // Pass A — the versioned js-toolkit artifact. It is bundled fully (no externals) so its own
-// internal chunks resolve relatively within its tree, and the ui tree can import it by URL.
-const jsToolkitResult = await esbuild.build({
-  ...sharedEsbuildOptions(),
-  entryPoints: {
-    index: 'packages/cdn/src/barrel-js-toolkit.ts',
-    'utils/index': 'packages/cdn/src/barrel-js-toolkit-utils.ts',
-  },
-  outdir: jsToolkitOutputDirectory,
+// internal chunks resolve relatively within its tree, and the ui tree can import it by URL. Its
+// declarations bundle js-toolkit's own types into `index.d.ts` and `utils/index.d.ts`.
+const jsToolkitResults = await tsdownBuild({
+  ...sharedBundleOptions(jsToolkitOutputDirectory),
+  entry: jsToolkitEntryPoints,
 });
+await tsdownBuild({
+  ...sharedDeclarationOptions(jsToolkitOutputDirectory, []),
+  entry: jsToolkitEntryPoints,
+});
+const jsToolkitMetafile = metafileFromChunks(chunksOf(jsToolkitResults));
 
 // Every @studiometa/ui and @studiometa/ui-mapbox component is emitted as a stable, non-hashed ESM
 // entry named `<subpath>.js` at the ui tree root, so a consumer can import a single component by a
@@ -646,41 +834,55 @@ for (const definition of definitions) {
   if (existing && existing !== source) {
     throw new Error(`Two components share the CDN subpath "${entryName}".`);
   }
-  componentEntryPoints[entryName] = source;
+  componentEntryPoints[entryName] = definition.sourcePath;
 }
+
+const uiEntryPoints = {
+  autoload: resolve(repositoryDirectory, 'packages/cdn/src/autoload.ts'),
+  loader: resolve(repositoryDirectory, 'packages/cdn/src/loader.ts'),
+  manifest: resolve(repositoryDirectory, 'packages/cdn/src/manifest.ts'),
+  index: resolve(repositoryDirectory, 'packages/cdn/src/barrel-ui.ts'),
+  ...componentEntryPoints,
+};
 
 // Pass B — the @studiometa/ui tree. js-toolkit is rewritten to its external, versioned URL and the
 // ui barrel is emitted as index.js. Autoload, loader, manifest, every stable component entry and
-// the barrel now import the single external js-toolkit URL and carry no js-toolkit source.
-const uiResult = await esbuild.build({
-  ...sharedEsbuildOptions(),
-  entryPoints: {
-    autoload: 'packages/cdn/src/autoload.ts',
-    loader: 'packages/cdn/src/loader.ts',
-    manifest: 'packages/cdn/src/manifest.ts',
-    index: 'packages/cdn/src/barrel-ui.ts',
-    ...componentEntryPoints,
-  },
-  outdir: uiOutputDirectory,
+// the barrel now import the single external js-toolkit URL and carry no js-toolkit source. The
+// declarations pass keeps js-toolkit external as a bare specifier so the ui `.d.ts` files resolve
+// against the js-toolkit declarations tree rather than inlining its types.
+const uiResults = await tsdownBuild({
+  ...sharedBundleOptions(uiOutputDirectory),
+  entry: uiEntryPoints,
   external: [...mapboxExternalSpecifiers],
   plugins: [shopifyFallbackPlugin(), externalizeToolkitPlugin()],
 });
+await tsdownBuild({
+  ...sharedDeclarationOptions(uiOutputDirectory, declarationExternals),
+  entry: uiEntryPoints,
+});
+const uiMetafile = metafileFromChunks(chunksOf(uiResults));
+
+// Re-export facade entries carry no source map from rolldown; synthesize the empty maps so the
+// public source-map invariant holds across both trees.
+await synthesizeFacadeSourceMaps(jsToolkitOutputDirectory);
+await synthesizeFacadeSourceMaps(uiOutputDirectory);
 
 // Mapbox GL and the geocoder are external (import-map resolved) and no longer bundled, so the CDN
 // serves neither their JavaScript, their stylesheets nor their license notices — consumers load
 // those from the same source they point their import map at.
-await writeThirdPartyNotices(uiResult.metafile, uiOutputDirectory);
-await writeThirdPartyNotices(jsToolkitResult.metafile, jsToolkitOutputDirectory);
+await writeThirdPartyNotices(uiMetafile, uiOutputDirectory);
+await writeThirdPartyNotices(jsToolkitMetafile, jsToolkitOutputDirectory);
 
 const uiEntryNames = ['autoload', 'loader', 'manifest', 'index'];
 const entryOutputs = Object.fromEntries(
-  uiEntryNames.map((name) => [
-    name,
-    outputKeyForPath(uiResult.metafile, resolve(uiOutputDirectory, `${name}.js`)),
-  ]),
+  uiEntryNames.map((name) => {
+    const key = `${name}.js`;
+    if (!uiMetafile.outputs[key]) throw new Error(`Missing ui entry output ${key}.`);
+    return [name, key];
+  }),
 );
 const componentOutputBySource = new Map<string, string>();
-for (const [output, metadata] of Object.entries(uiResult.metafile.outputs)) {
+for (const [output, metadata] of Object.entries(uiMetafile.outputs)) {
   if (!metadata.entryPoint) continue;
   componentOutputBySource.set(resolve(repositoryDirectory, metadata.entryPoint), output);
 }
@@ -699,7 +901,7 @@ const mapboxLibPatterns = [
 ];
 const mapboxIsolationPatterns = [uiMapboxSourcePattern, ...mapboxLibPatterns];
 for (const name of uiEntryNames) {
-  const inputs = graphInputs(uiResult.metafile, entryOutputs[name]);
+  const inputs = graphInputs(uiMetafile, entryOutputs[name]);
   assertDoesNotContain(inputs, mapboxIsolationPatterns, `${name} startup graph`);
 }
 const uiDefinitions = definitions.filter(({ packageName }) => packageName === '@studiometa/ui');
@@ -707,7 +909,7 @@ for (const definition of uiDefinitions) {
   const output = componentOutputBySource.get(definition.sourcePath);
   if (!output) throw new Error(`Missing component output for ${definition.token}.`);
   assertDoesNotContain(
-    graphInputs(uiResult.metafile, output),
+    graphInputs(uiMetafile, output),
     mapboxIsolationPatterns,
     `${definition.token} graph`,
   );
@@ -716,20 +918,23 @@ const actionDefinition = definitions.find(({ token }) => token === 'Action');
 const actionOutput = actionDefinition && componentOutputBySource.get(actionDefinition.sourcePath);
 if (!actionOutput) throw new Error('Missing Action output for unrelated-family isolation.');
 assertDoesNotContain(
-  graphInputs(uiResult.metafile, actionOutput),
+  graphInputs(uiMetafile, actionOutput),
   [/(?:^|\/)packages\/ui\/Accordion\//],
   'Action graph',
 );
 
-const { toolkitUrls: toolkitExternalUrls, mapboxSpecifiers: mapboxExternalSpecifiersFound } =
-  assertUiExternals(uiResult.metafile);
+const { toolkitUrls: toolkitExternalUrls } = assertUiExternals(uiMetafile);
 const toolkitIdentity = `@studiometa/js-toolkit@${jsToolkitVersion}`;
 
 const uiInitialFiles = (await listFiles(uiOutputDirectory)).filter(
   (file) => !file.endsWith('.json'),
 );
+const mapboxExternalSpecifiersFound = await assertMapboxDynamicExternals(
+  uiOutputDirectory,
+  uiInitialFiles,
+);
 await assertBrowserImports(
-  uiResult.metafile,
+  uiMetafile,
   uiOutputDirectory,
   uiInitialFiles,
   new Set([...toolkitExternalUrls, ...mapboxExternalSpecifiersFound]),
@@ -746,14 +951,15 @@ const jsToolkitEntryOutputs = Object.fromEntries(
       ['index', 'index.js'],
       ['utils', 'utils/index.js'],
     ] as const
-  ).map(([name, file]) => [
-    name,
-    outputKeyForPath(jsToolkitResult.metafile, resolve(jsToolkitOutputDirectory, file)),
-  ]),
+  ).map(([name, file]) => {
+    if (!jsToolkitMetafile.outputs[file])
+      throw new Error(`Missing js-toolkit entry output ${file}.`);
+    return [name, file];
+  }),
 );
 for (const name of Object.keys(jsToolkitEntryOutputs)) {
   assertDoesNotContain(
-    graphInputs(jsToolkitResult.metafile, jsToolkitEntryOutputs[name]),
+    graphInputs(jsToolkitMetafile, jsToolkitEntryOutputs[name]),
     mapboxIsolationPatterns,
     `js-toolkit ${name} graph`,
   );
@@ -762,7 +968,7 @@ const jsToolkitInitialFiles = (await listFiles(jsToolkitOutputDirectory)).filter
   (file) => !file.endsWith('.json'),
 );
 await assertBrowserImports(
-  jsToolkitResult.metafile,
+  jsToolkitMetafile,
   jsToolkitOutputDirectory,
   jsToolkitInitialFiles,
   new Set(),
@@ -773,9 +979,15 @@ for (const file of jsToolkitInitialFiles.filter((path) => path.endsWith('.js')))
 }
 const jsToolkitSizes = await fileSizes(jsToolkitOutputDirectory, jsToolkitInitialFiles);
 
+function declarationBytes(sizes: Record<string, number>): number {
+  return Object.entries(sizes)
+    .filter(([file]) => file.endsWith('.d.ts'))
+    .reduce((total, [, bytes]) => total + bytes, 0);
+}
+
 const observedBudgets: Record<string, number> = {
   ...measureUiSizeBudgets(
-    uiResult.metafile,
+    uiMetafile,
     uiOutputDirectory,
     entryOutputs,
     componentOutputBySource,
@@ -783,12 +995,18 @@ const observedBudgets: Record<string, number> = {
     uiSizes,
   ),
   ...measureJsToolkitSizeBudgets(
-    jsToolkitResult.metafile,
+    jsToolkitMetafile,
     jsToolkitOutputDirectory,
     jsToolkitEntryOutputs,
     jsToolkitSizes,
   ),
 };
+// The declaration budgets mirror the JavaScript per-entry style: a per-barrel ceiling for each of
+// the three importable roots (the ui barrel and the two js-toolkit entries) plus a total across
+// every emitted `.d.ts` (entries and shared declaration chunks) in both trees.
+observedBudgets['dts:entry:index'] = uiSizes['index.d.ts'];
+observedBudgets['dts:js-toolkit:entry:index'] = jsToolkitSizes['index.d.ts'];
+observedBudgets['dts:js-toolkit:entry:utils'] = jsToolkitSizes['utils/index.d.ts'];
 // Totals span both trees, so they are measured over the whole dist listing (dist-relative paths
 // are unique, unlike the tree-relative keys of uiSizes/jsToolkitSizes which both contain index.js).
 const distFilesBeforeMetadata = await listFiles(outputDirectory);
@@ -798,6 +1016,9 @@ observedBudgets['total:esm'] = Object.entries(distSizesBeforeMetadata)
   .reduce((total, [, bytes]) => total + bytes, 0);
 observedBudgets['total:source-maps'] = Object.entries(distSizesBeforeMetadata)
   .filter(([file]) => file.endsWith('.map'))
+  .reduce((total, [, bytes]) => total + bytes, 0);
+observedBudgets['total:declarations'] = Object.entries(distSizesBeforeMetadata)
+  .filter(([file]) => file.endsWith('.d.ts'))
   .reduce((total, [, bytes]) => total + bytes, 0);
 observedBudgets['total:release'] = 0;
 
@@ -815,13 +1036,15 @@ function outputMetadataFor(
       file,
       {
         bytes: sizes[file],
-        type: file.endsWith('.map')
-          ? 'source-map'
-          : file.endsWith('.css')
-            ? 'style'
-            : file.endsWith('.js')
-              ? 'module'
-              : 'notice',
+        type: file.endsWith('.d.ts')
+          ? 'declaration'
+          : file.endsWith('.map')
+            ? 'source-map'
+            : file.endsWith('.css')
+              ? 'style'
+              : file.endsWith('.js')
+                ? 'module'
+                : 'notice',
       },
     ]),
   );
@@ -854,15 +1077,15 @@ const componentInventory = Object.fromEntries(
   definitions.map((definition) => {
     const output = componentOutputBySource.get(definition.sourcePath);
     if (!output) throw new Error(`Missing component entry chunk for ${definition.token}.`);
-    const graph = staticOutputGraph(uiResult.metafile, output).map((dependency) =>
+    const graph = staticOutputGraph(uiMetafile, output).map((dependency) =>
       publicPath(uiOutputDirectory, dependency),
     );
     const entry = publicPath(uiOutputDirectory, output);
-    const dynamicImports = dynamicOutputEntries(uiResult.metafile, output).map((dynamicOutput) => {
+    const dynamicImports = dynamicOutputEntries(uiMetafile, output).map((dynamicOutput) => {
       const dynamicEntry = publicPath(uiOutputDirectory, dynamicOutput);
       return {
         entry: dynamicEntry,
-        preload: staticOutputGraph(uiResult.metafile, dynamicOutput)
+        preload: staticOutputGraph(uiMetafile, dynamicOutput)
           .map((dependency) => publicPath(uiOutputDirectory, dependency))
           .filter((dependency) => dependency !== dynamicEntry)
           .sort(),
@@ -900,7 +1123,8 @@ const uiBuildMetadata = {
     target: 'es2020',
     splitting: true,
     sourcemaps: true,
-    bundler: `esbuild@${esbuild.version}`,
+    declarations: true,
+    bundler: bundlerLabel,
   },
   package: { name: packageMetadata.name, version: uiVersion },
   dependencies: { '@studiometa/js-toolkit': jsToolkitVersion },
@@ -939,7 +1163,7 @@ const uiBuildMetadata = {
       mutable: true,
     },
   },
-  entries: entryMetadataFor(uiResult.metafile, uiOutputDirectory, entryOutputs),
+  entries: entryMetadataFor(uiMetafile, uiOutputDirectory, entryOutputs),
   components: componentInventory,
   outputs: outputMetadataFor(uiInitialFiles, uiSizes),
   // The CDN serves no stylesheets: Mapbox GL and the geocoder — the only components that needed
@@ -947,7 +1171,7 @@ const uiBuildMetadata = {
   styles: {},
   licenses: {
     thirdPartyNotices: 'licenses/THIRD_PARTY_LICENSES.txt',
-    esbuildLegalComments: 'eof',
+    legalComments: 'none',
   },
   // The public Mapbox-redistribution review gate is gone: this CDN no longer serves Mapbox GL or
   // the geocoder (their JavaScript, stylesheets and license notices), so there is nothing to review.
@@ -984,6 +1208,10 @@ const uiBuildMetadata = {
     semantics:
       'Each preload list contains sorted transitive static ESM dependencies; order is not significant, and dynamic component and optional-integration edges are excluded.',
   },
+  declarations: {
+    semantics:
+      'Every importable entry emits a bundled `.d.ts` alongside its `.js`, sharing hashed declaration chunks under `chunks/`. The ui declarations import `@studiometa/js-toolkit` externally so they resolve against the js-toolkit declarations tree instead of inlining its types.',
+  },
   assertions: {
     jsToolkitIdentities: [toolkitIdentity],
     jsToolkitExternalUrls: toolkitExternalUrls,
@@ -1011,7 +1239,8 @@ const jsToolkitBuildMetadata = {
     target: 'es2020',
     splitting: true,
     sourcemaps: true,
-    bundler: `esbuild@${esbuild.version}`,
+    declarations: true,
+    bundler: bundlerLabel,
   },
   package: { name: JS_TOOLKIT_BUILD_NAME, version: jsToolkitVersion },
   build: {
@@ -1023,16 +1252,12 @@ const jsToolkitBuildMetadata = {
     sourceDateEpoch: buildTime.epoch,
     timeSource: buildTime.source,
   },
-  entries: entryMetadataFor(
-    jsToolkitResult.metafile,
-    jsToolkitOutputDirectory,
-    jsToolkitEntryOutputs,
-  ),
+  entries: entryMetadataFor(jsToolkitMetafile, jsToolkitOutputDirectory, jsToolkitEntryOutputs),
   components: {},
   outputs: outputMetadataFor(jsToolkitInitialFiles, jsToolkitSizes),
   licenses: {
     thirdPartyNotices: 'licenses/THIRD_PARTY_LICENSES.txt',
-    esbuildLegalComments: 'eof',
+    legalComments: 'none',
   },
 };
 

--- a/packages/cdn/size-budgets.json
+++ b/packages/cdn/size-budgets.json
@@ -12,11 +12,15 @@
     "graph:component:Action": 8000,
     "graph:family:Accordion": 10000,
     "js-toolkit:entry:index": 55000,
-    "js-toolkit:entry:utils": 6000,
+    "js-toolkit:entry:utils": 30000,
     "js-toolkit:initial:index": 90000,
     "js-toolkit:initial:utils": 42000,
+    "dts:entry:index": 13000,
+    "dts:js-toolkit:entry:index": 150000,
+    "dts:js-toolkit:entry:utils": 65000,
     "total:esm": 360000,
     "total:source-maps": 1600000,
+    "total:declarations": 520000,
     "total:release": 2200000
   }
 }

--- a/packages/cdn/tests/browser/fixtures.ts
+++ b/packages/cdn/tests/browser/fixtures.ts
@@ -69,7 +69,8 @@ export default {
   FullscreenControl: noop,
 };
 `;
-const MAPBOX_GEOCODER_STUB = 'export default class StubGeocoder { addTo() {} onRemove() {} on() {} };';
+const MAPBOX_GEOCODER_STUB =
+  'export default class StubGeocoder { addTo() {} onRemove() {} on() {} };';
 const MAPBOX_GL_STUB_PATH = '/stub/mapbox-gl.js';
 const MAPBOX_GEOCODER_STUB_PATH = '/stub/mapbox-gl-geocoder.js';
 
@@ -182,7 +183,11 @@ async function createServers(): Promise<{ fixture: CdnServers; close: () => Prom
     await readFile(resolve(uiOutputDirectory, 'build.json'), 'utf8'),
   ) as BuildMetadata;
   const jsToolkitVersion = build.dependencies['@studiometa/js-toolkit'];
-  const jsToolkitOutputDirectory = resolve(outputDirectory, 'releases/js-toolkit', jsToolkitVersion);
+  const jsToolkitOutputDirectory = resolve(
+    outputDirectory,
+    'releases/js-toolkit',
+    jsToolkitVersion,
+  );
   const realUiDirectory = await realpath(uiOutputDirectory);
   const realJsToolkitDirectory = await realpath(jsToolkitOutputDirectory);
   const requests: RequestLog[] = [];
@@ -255,14 +260,22 @@ async function createServers(): Promise<{ fixture: CdnServers; close: () => Prom
     let contents = await readFile(realPath);
     if (relativePath === build.entries.autoload.path && identifier !== build.build.identifier) {
       const source = contents.toString('utf8');
-      const versionMarker = `version:"${build.package.version}"`;
-      if (!source.includes(versionMarker)) {
+      // Serve a genuinely conflicting runtime version for a mismatched identifier by rewriting the
+      // package version the autoload module embeds. The bundler inlines it as a single quoted
+      // literal — esbuild placed it inline in the runtime object (version:"x") while tsdown/rolldown
+      // hoists it into a `x`-quoted variable referenced as version:<id> — so target the standalone
+      // version literal itself, preserving whichever quote (", ' or `) the bundler chose. The single
+      // match is asserted so an unexpected output shape fails loudly instead of silently no-op'ing.
+      const escaped = build.package.version.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      const versionLiteral = new RegExp(`(["'\`])${escaped}\\1`, 'g');
+      const matches = source.match(versionLiteral);
+      if (!matches || matches.length !== 1) {
         response.statusCode = 500;
         addArtifactHeaders(response, MIME_TYPES['.txt']);
         response.end('The versioned autoload fixture transform is stale.');
         return;
       }
-      contents = Buffer.from(source.replace(versionMarker, `version:"${identifier}"`));
+      contents = Buffer.from(source.replace(versionLiteral, `$1${identifier}$1`));
     }
 
     await send(response, realPath, relativePath, contents);

--- a/packages/cdn/tests/build.test.ts
+++ b/packages/cdn/tests/build.test.ts
@@ -1,7 +1,7 @@
 import { createHash } from 'node:crypto';
 import { execFileSync } from 'node:child_process';
 import { copyFile, readFile, readdir, rm, stat } from 'node:fs/promises';
-import { dirname, resolve } from 'node:path';
+import { dirname, posix, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
@@ -72,7 +72,7 @@ interface BuildMetadata {
   styles: Record<string, { path: string; autoInject: boolean }>;
   licenses: {
     thirdPartyNotices: string;
-    esbuildLegalComments: string;
+    legalComments: string;
   };
   integrations: Record<string, Record<string, unknown>>;
   releaseGates: Record<string, Record<string, unknown>>;
@@ -510,12 +510,12 @@ describe('browser CDN build', () => {
     expect(build.releaseGates).toEqual({});
     expect(build.licenses).toEqual({
       thirdPartyNotices: 'licenses/THIRD_PARTY_LICENSES.txt',
-      esbuildLegalComments: 'eof',
+      legalComments: 'none',
     });
   });
 
   it('ships third-party notices and diagnoses the excluded Shopify preview adapter', async () => {
-    expect(build.licenses.esbuildLegalComments).toBe('eof');
+    expect(build.licenses.legalComments).toBe('none');
     const notices = await readFile(resolve(uiTree, build.licenses.thirdPartyNotices), 'utf8');
     // Mapbox GL and the geocoder are external and not bundled, so they carry no third-party notice.
     expect(notices).not.toContain('mapbox-gl@');
@@ -548,5 +548,91 @@ describe('browser CDN build', () => {
     for (const source of shopifySources) {
       expect(source).not.toContain('import("@shopify/partial-rendering")');
     }
+  });
+
+  it('emits a bundled declaration for every importable entry, recorded and hashed', async () => {
+    // Each ui entry, each component, and both js-toolkit entries carry a sibling `.d.ts`.
+    for (const entry of Object.values(build.entries)) {
+      const declaration = `${entry.path.slice(0, -'.js'.length)}.d.ts`;
+      expect(uiFiles).toContain(declaration);
+      expect(build.outputs[declaration].type).toBe('declaration');
+    }
+    for (const component of Object.values(build.components)) {
+      const declaration = `${component.entry.slice(0, -'.js'.length)}.d.ts`;
+      expect(uiFiles).toContain(declaration);
+      expect(build.outputs[declaration].type).toBe('declaration');
+    }
+    expect(uiFiles).toContain('Action.d.ts');
+    expect(uiFiles).toContain('MapboxMap.d.ts');
+    expect(jsToolkitFiles).toContain('index.d.ts');
+    expect(jsToolkitFiles).toContain('utils/index.d.ts');
+
+    // Every declaration output (entries and shared declaration chunks) is a real, hashed file.
+    for (const [tree, treeFiles] of [
+      [uiTree, uiFiles],
+      [jsToolkitTree, jsToolkitFiles],
+    ] as const) {
+      const buildJson = await readJson<BuildMetadata>(tree, 'build.json');
+      const integrity = await readJson<{ files: Record<string, string> }>(tree, 'integrity.json');
+      const declarations = treeFiles.filter((file) => file.endsWith('.d.ts'));
+      expect(declarations.length).toBeGreaterThan(0);
+      for (const declaration of declarations) {
+        expect(buildJson.outputs[declaration].type).toBe('declaration');
+        expect(integrity.files[declaration]).toBe(
+          `sha384-${await digest(resolve(tree, declaration))}`,
+        );
+      }
+    }
+
+    // Declaration size budgets exist and hold.
+    const budgets = await readJson<{ bytes: Record<string, number> }>(
+      packageDirectory,
+      'size-budgets.json',
+    );
+    for (const key of [
+      'total:declarations',
+      'dts:entry:index',
+      'dts:js-toolkit:entry:index',
+      'dts:js-toolkit:entry:utils',
+    ]) {
+      expect(budgets.bytes[key]).toBeTypeOf('number');
+      expect(build.assertions.sizeBudgets[key]).toBeLessThanOrEqual(budgets.bytes[key]);
+    }
+    const declarationBytes = (
+      await Promise.all(
+        allFiles
+          .filter((file) => file.endsWith('.d.ts'))
+          .map(async (file) => (await stat(resolve(firstOutput, file))).size),
+      )
+    ).reduce((total, bytes) => total + bytes, 0);
+    expect(build.assertions.sizeBudgets['total:declarations']).toBe(declarationBytes);
+  });
+
+  it('imports js-toolkit types externally in the ui declarations instead of inlining them', async () => {
+    // Walk the declaration graph reachable from the ui barrel (index.d.ts -> ./chunks/*.js siblings)
+    // and confirm js-toolkit is referenced by its bare specifier, never inlined from node_modules.
+    const seen = new Set<string>();
+    const queue = ['index.d.ts'];
+    let importsToolkitExternally = false;
+    while (queue.length > 0) {
+      const file = queue.shift() as string;
+      if (seen.has(file) || !uiFiles.includes(file)) continue;
+      seen.add(file);
+      const source = await readFile(resolve(uiTree, file), 'utf8');
+      if (/from\s*["']@studiometa\/js-toolkit["']/.test(source)) importsToolkitExternally = true;
+      expect(source).not.toContain('node_modules/@studiometa/js-toolkit');
+      for (const match of source.matchAll(/from\s*["']([^"']+)["']/g)) {
+        const specifier = match[1];
+        if (!specifier.startsWith('.')) continue;
+        const resolved = posix.join(posix.dirname(file), specifier);
+        queue.push(
+          resolved.endsWith('.js') ? `${resolved.slice(0, -'.js'.length)}.d.ts` : resolved,
+        );
+      }
+    }
+    expect(importsToolkitExternally).toBe(true);
+    // The ui barrel re-exports the components it declares.
+    const barrel = await readFile(resolve(uiTree, 'index.d.ts'), 'utf8');
+    expect(barrel).toMatch(/\bas Action\b/);
   });
 });

--- a/packages/cdn/tests/worker/fixtures.ts
+++ b/packages/cdn/tests/worker/fixtures.ts
@@ -65,6 +65,7 @@ export interface WorkerFixture {
   files: Record<string, string>;
   versionsIndex: VersionsIndex;
   jsToolkitVersion: string;
+  moduleWithoutDeclaration: string;
   cleanup(): Promise<void>;
 }
 
@@ -114,11 +115,16 @@ export async function createWorkerFixture(): Promise<WorkerFixture> {
     `releases/js-toolkit/${jsToolkitVersion}`,
   );
 
+  // A shared JavaScript chunk has no sibling declaration (declaration chunks are hashed
+  // independently), so it exercises the "served `.js` without a sibling `.d.ts`" path.
+  const moduleWithoutDeclaration = build.components.Action.preload[0];
   const uiAssetPaths = [
     'autoload.js',
     'autoload.js.map',
     'index.js',
     'index.js.map',
+    'index.d.ts',
+    moduleWithoutDeclaration,
     'build.json',
     'integrity.json',
     'licenses/THIRD_PARTY_LICENSES.txt',
@@ -184,6 +190,7 @@ export async function createWorkerFixture(): Promise<WorkerFixture> {
     files,
     versionsIndex,
     jsToolkitVersion,
+    moduleWithoutDeclaration,
     cleanup: () => rm(outputDirectory, { recursive: true, force: true }),
   };
 }

--- a/packages/cdn/tests/worker/index.test.ts
+++ b/packages/cdn/tests/worker/index.test.ts
@@ -316,6 +316,41 @@ describe('CDN Worker asset responses', () => {
   });
 });
 
+describe('CDN Worker declarations', () => {
+  it('serves a declaration with the TypeScript MIME and cross-origin headers', async () => {
+    const response = await request('/ui@1.2.0/index.d.ts');
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Content-Type')).toBe('application/typescript; charset=utf-8');
+    expect(response.headers.get('Cache-Control')).toBe(IMMUTABLE_CACHE_CONTROL);
+    expectCrossOriginHeaders(response);
+    expect(await response.text()).toBe(fixture.files['index.d.ts']);
+  });
+
+  it('advertises the sibling declaration of a module via X-TypeScript-Types and exposes it', async () => {
+    const response = await request('/ui@1.2.0/index.js');
+    expect(response.status).toBe(200);
+    expect(response.headers.get('X-TypeScript-Types')).toBe(`${origin}/ui@1.2.0/index.d.ts`);
+    expect(response.headers.get('Access-Control-Expose-Headers')).toContain('X-TypeScript-Types');
+    expectCrossOriginHeaders(response);
+  });
+
+  it('omits X-TypeScript-Types for a module without a sibling declaration', async () => {
+    const response = await request(`/ui@1.2.0/${fixture.moduleWithoutDeclaration}`);
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Content-Type')).toBe('text/javascript; charset=utf-8');
+    expect(response.headers.get('X-TypeScript-Types')).toBeNull();
+    expect(response.headers.get('Access-Control-Expose-Headers')).toBeNull();
+  });
+
+  it('keeps the declaration hint consistent on HEAD requests', async () => {
+    const response = await request('/ui@1.2.0/index.js', { method: 'HEAD' });
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe('');
+    expect(response.headers.get('X-TypeScript-Types')).toBe(`${origin}/ui@1.2.0/index.d.ts`);
+    expect(response.headers.get('Access-Control-Expose-Headers')).toContain('X-TypeScript-Types');
+  });
+});
+
 describe('CDN Worker registry', () => {
   interface Registry {
     packages: {

--- a/packages/cdn/worker/index.ts
+++ b/packages/cdn/worker/index.ts
@@ -346,6 +346,21 @@ async function handleRequest(
   if (etag) headers.set('ETag', etag);
   if (link) headers.set('Link', link);
 
+  // When a served module has a sibling declaration in the release, advertise it with the same
+  // `X-TypeScript-Types` header esm.sh uses, as a same-origin absolute URL, and expose the header to
+  // cross-origin TypeScript language servers. Set before the 304 branch so a not-modified response
+  // stays consistent with the full response, and it is preserved for HEAD.
+  if (route.assetPath.endsWith('.js')) {
+    const declarationPath = `${route.assetPath.slice(0, -'.js'.length)}.d.ts`;
+    if (metadata.files.has(declarationPath)) {
+      headers.set(
+        'X-TypeScript-Types',
+        `${url.origin}/${route.packageName}@${exact.version}/${declarationPath}`,
+      );
+      headers.set('Access-Control-Expose-Headers', 'X-TypeScript-Types');
+    }
+  }
+
   if (etagMatches(request.headers.get('If-None-Match'), etag)) {
     headers.delete('Content-Type');
     return new Response(null, { status: 304, headers });

--- a/packages/cdn/worker/responses.ts
+++ b/packages/cdn/worker/responses.ts
@@ -45,6 +45,9 @@ export function redirectResponse(location: string): Response {
 }
 
 export function contentType(assetPath: string): string {
+  // `.d.ts` is checked before `.js` so a declaration is never misreported as JavaScript (it does not
+  // end with `.js`, but the explicit branch keeps the intent clear and order-independent).
+  if (assetPath.endsWith('.d.ts')) return 'application/typescript; charset=utf-8';
   if (assetPath.endsWith('.js')) return 'text/javascript; charset=utf-8';
   if (assetPath.endsWith('.css')) return 'text/css; charset=utf-8';
   if (assetPath.endsWith('.json') || assetPath.endsWith('.map')) {


### PR DESCRIPTION
## Summary

**PR 2 of 4** in the CDN generic-refactor arc (stacked on #580). Migrates the CDN build from **esbuild to tsdown** (rolldown + rolldown-plugin-dts) and makes the CDN **types-aware**: it now emits a `.d.ts` per importable entry and the Worker advertises them with an `X-TypeScript-Types` header, so consumers loading from `cdn.studiometa.dev` keep editor autocomplete.

### Build: esbuild → tsdown (full swap)
Rolldown's `OutputChunk` (`imports` / `dynamicImports` / `moduleIds` / `facadeModuleId` / `isEntry`) provides everything the esbuild metafile did, so a small `metafileFromChunks()` projection lets **every existing graph helper stay unchanged** — preload lists (`entries[].preload` / `components[].preload`), dynamic-import edges, js-toolkit/mapbox externalization, and the mapbox isolation assertions all keep identical semantics. Determinism holds (repeat builds and different cwds → byte-identical output).

Three behavioural gaps vs esbuild, each handled explicitly (documented in code):
1. Rolldown emits no source map for a pure re-export facade — the build synthesizes the empty map so "one source map per module" still holds.
2. Rolldown doesn't surface a bare *dynamic* external (mapbox `import(\`mapbox-gl\`)`) on the graph — mapbox externalization is asserted against the emitted code instead.
3. tsdown resolves tsconfig/externalization from `process.cwd()` — pinned via `process.chdir(repoRoot)` (all script paths are absolute) + the root tsconfig for the dts pass.

### Declarations
- A bundled `.d.ts` per entry: ui `index.d.ts`, js-toolkit `index.d.ts` + `utils/index.d.ts`, and each component `<subpath>.d.ts`. `@studiometa/js-toolkit` is kept **external** in the ui declarations (0 declaration files reference `node_modules/@studiometa/js-toolkit`), so ui's types resolve through the CDN's js-toolkit types.
- `build.json` `outputs` gains `type: 'declaration'`; declarations are integrity-hashed and size-budgeted (`total:declarations` + per-entry keys).

### Worker
- `.d.ts` → `application/typescript; charset=utf-8`.
- A `.js` with a sibling `.d.ts` carries `X-TypeScript-Types: <absolute url>` and exposes it via `Access-Control-Expose-Headers` (esm.sh convention), set before the 304 branch so 304/HEAD stay consistent.

No routing/registry/ui-mapbox-tree changes (PR 3) and no playground changes (PR 4).

## Test plan
- `npm run lint` — 0 errors.
- `npx vitest run --root packages/cdn` — 118 passed (incl. new dts-emission + header coverage).
- `npm run test` — full repo suite green (827 passed).
- `npm run cdn:build` (clean tree) — 94 components, 433 files; `.d.ts` verified on disk; `format.bundler: tsdown@0.21.5 (rolldown@1.0.0-rc.11)`.
- Playwright browser spec is CI-gated (needs browsers + built dist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)