### PR TITLE
Point the playground at the browser CDN

### DIFF
--- a/packages/playground/meta.config.js
+++ b/packages/playground/meta.config.js
@@ -1,6 +1,8 @@
 import { resolve } from 'node:path';
 import { playgroundPreset as playground, defineWebpackConfig } from '@studiometa/playground/preset';
 
+const CDN_BASE_URL = 'https://cdn.studiometa.dev';
+
 export default defineWebpackConfig({
   presets: [
     playground({
@@ -26,21 +28,25 @@ export default defineWebpackConfig({
         'compute-scroll-into-view',
         'deepmerge',
         'morphdom',
+        // Consumer-provided peers that the ui-mapbox CDN tree externalizes, so
+        // they still need to be resolved for the script editor.
         { specifier: 'mapbox-gl', esmSh: { bundle: true } },
         { specifier: '@mapbox/mapbox-gl-geocoder', esmSh: { bundle: true } },
-        { specifier: '@studiometa/js-toolkit', esmSh: { bundle: false } },
-        { specifier: '@studiometa/js-toolkit/utils', esmSh: { bundle: false } },
-        {
-          specifier: '@studiometa/ui',
-          source: '../ui/**/*.ts',
-          entry: '../ui/index.ts',
-        },
-        {
-          specifier: '@studiometa/ui-mapbox',
-          source: '../ui-mapbox/**/*.ts',
-          entry: '../ui-mapbox/index.ts',
-        },
       ],
+      // Point js-toolkit, ui and ui-mapbox at the live studiometa CDN instead of
+      // esm.sh / local tsdown source-bundles. The CDN serves `.d.ts` + an
+      // `X-TypeScript-Types` header, so the editor keeps TypeScript autocomplete.
+      // js-toolkit MUST match the exact `/js-toolkit@3.8.0/index.js` URL the ui
+      // build bakes in as an absolute CDN import, so both share a single runtime.
+      importMap: {
+        '@studiometa/js-toolkit': `${CDN_BASE_URL}/js-toolkit@3.8.0/index.js`,
+        '@studiometa/js-toolkit/utils': `${CDN_BASE_URL}/js-toolkit@3.8.0/utils/index.js`,
+        // `@main` 307-redirects to the current immutable `main-<sha>` channel.
+        // Switch to `@latest` (or a pinned version) once a stable release tag is
+        // cut — `@latest` currently 404s because no stable CDN release exists yet.
+        '@studiometa/ui': `${CDN_BASE_URL}/ui@main/index.js`,
+        '@studiometa/ui-mapbox': `${CDN_BASE_URL}/ui-mapbox@main/index.js`,
+      },
       defaults: {
         html: `{% html_element 'span' with { class: 'dark:text-white font-bold border-b-2 border-current' } %}
   Hello world


### PR DESCRIPTION
## Summary

**PR 4 (final content PR) of the CDN generic-refactor arc** (stacked on #583). Points the playground at the live `cdn.studiometa.dev` for `@studiometa/js-toolkit`, `@studiometa/ui`, and `@studiometa/ui-mapbox`, instead of esm.sh (js-toolkit) and local tsdown source-bundles (ui, ui-mapbox). The CDN now serves `.d.ts` + an `X-TypeScript-Types` header (PR 2), so the script editor keeps TypeScript autocomplete resolving these from the CDN.

### Change (`packages/playground/meta.config.js`, one file)
- Removed the js-toolkit(+utils) esm.sh entries and the ui / ui-mapbox local `source` bundles from `dependencies`.
- Added an `importMap` pointing the four specifiers at the CDN:
  ```
  @studiometa/js-toolkit       → https://cdn.studiometa.dev/js-toolkit@3.8.0/index.js
  @studiometa/js-toolkit/utils → https://cdn.studiometa.dev/js-toolkit@3.8.0/utils/index.js
  @studiometa/ui               → https://cdn.studiometa.dev/ui@main/index.js
  @studiometa/ui-mapbox        → https://cdn.studiometa.dev/ui-mapbox@main/index.js
  ```
- `mapbox-gl` + `@mapbox/mapbox-gl-geocoder` stay on esm.sh (the consumer-provided peers the ui-mapbox tree externalizes).
- js-toolkit pinned to `3.8.0` — the exact version the ui tree bakes in (build-time asserted), so a single shared runtime instance. ui/ui-mapbox use the `@main` alias (the CDN 307-redirects it to the current immutable `main-<sha>`); a comment notes switching to `@latest`/pinned once a stable release tag exists.

## Test plan
- `npm run play:build` — compiles; the emitted import map in the built HTML contains the four CDN URLs and `static/deps/` no longer bundles ui/ui-mapbox.
- `npm run lint` — 0 errors. `npm run test` — 827 passed. Prettier clean.

## Deferred to post-merge/deploy
Live CDN runtime + editor type-hint verification can't run from CI (the CDN won't serve this stack's `@main` build or the `X-TypeScript-Types` header for these specifiers until the stack merges and deploys). Config/import map confirmed correct; build succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)