### PR TITLE
Publish via tokenless trusted publishing and add @studiometa/ui-autoload

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,32 +62,31 @@ jobs:
           echo "NPM_TAG=$NPM_TAG" >> $GITHUB_ENV
           echo "IS_PRERELEASE=$IS_PRERELEASE" >> $GITHUB_ENV
 
-      - uses: JS-DevTools/npm-publish@v3
-        with:
-          provenance: true
-          package: packages/ui/dist/
-          tag: ${{ env.NPM_TAG }}
-          token: ${{ secrets.NPM_TOKEN }}
+      # Tokenless trusted publishing (npm OIDC): each package is configured as a trusted publisher
+      # on npm, so `npm publish` authenticates through the `id-token: write` permission declared
+      # above — no NPM_TOKEN — and provenance is attested from the same OIDC flow. Mirrors the
+      # working setup in @weareikko/code-review; Node 24's bundled npm (>= 11.5.1) supports it.
+      - name: Publish @studiometa/ui
+        run: npm publish --provenance --access public --tag ${{ env.NPM_TAG }}
+        working-directory: packages/ui/dist
 
-      - name: Build eslint-plugin-ui
+      - name: Build @studiometa/eslint-plugin-ui
         run: npm run build -w @studiometa/eslint-plugin-ui
+      - name: Publish @studiometa/eslint-plugin-ui
+        run: npm publish --provenance --access public --tag ${{ env.NPM_TAG }}
+        working-directory: packages/eslint-plugin-ui
 
-      - uses: JS-DevTools/npm-publish@v3
-        with:
-          provenance: true
-          package: packages/eslint-plugin-ui/
-          tag: ${{ env.NPM_TAG }}
-          token: ${{ secrets.NPM_TOKEN }}
-
-      - name: Build ui-mapbox
+      - name: Build @studiometa/ui-mapbox
         run: npm run build -w @studiometa/ui-mapbox
+      - name: Publish @studiometa/ui-mapbox
+        run: npm publish --provenance --access public --tag ${{ env.NPM_TAG }}
+        working-directory: packages/ui-mapbox/dist
 
-      - uses: JS-DevTools/npm-publish@v3
-        with:
-          provenance: true
-          package: packages/ui-mapbox/dist/
-          tag: ${{ env.NPM_TAG }}
-          token: ${{ secrets.NPM_TOKEN }}
+      - name: Build @studiometa/ui-autoload
+        run: npm run build -w @studiometa/ui-autoload
+      - name: Publish @studiometa/ui-autoload
+        run: npm publish --provenance --access public --tag ${{ env.NPM_TAG }}
+        working-directory: packages/ui-autoload/dist
 
       - uses: ncipollo/release-action@v1
         with:


### PR DESCRIPTION
## Summary

Two release-workflow changes to `publish.yml`:

1. **Migrate all packages to npm tokenless trusted publishing (OIDC).** Every release step switches from token-based `JS-DevTools/npm-publish@v3` to `npm publish --provenance --access public --tag <dist-tag>`, authenticated by the already-declared `id-token: write` permission — **no `NPM_TOKEN`**. This matches the trusted-publisher config set up on npm and mirrors the working `@weareikko/code-review` release workflow. Provenance is attested from the same OIDC flow; Node 24's bundled npm (≥ 11.5.1) supports it, so no extra setup step is needed.

2. **Add `@studiometa/ui-autoload` to the release job.** The new package (introduced in the CDN refactor) had no publish step, so it would never reach npm on a tag. Added a `Build` + `Publish` step from `packages/ui-autoload/dist`, mirroring `@studiometa/ui-mapbox`.

Packages now published by a release tag: `@studiometa/ui`, `@studiometa/eslint-plugin-ui`, `@studiometa/ui-mapbox`, `@studiometa/ui-autoload`.

## Notes / verification
- `publish.yml` validated as well-formed YAML; no `NPM_TOKEN` reference remains (comment aside).
- Confirmed `npm run build -w @studiometa/ui-autoload` emits a publishable `packages/ui-autoload/dist` with correct `name`/`version`/`main`/`types`/`exports`, `publishConfig.access: public`, a `repository` field (needed for provenance), and js + `.d.ts` + sourcemaps.
- Each package publishes from its built `dist` (or package root for `eslint-plugin-ui`) via `working-directory`, as before.
- The `id-token: write` / `contents: write` permissions and the `NPM_TAG` (latest/next) prerelease logic are unchanged. The workflow only runs on `*.*.*` tags, so this is inert until the next release.
- `NPM_TOKEN` repo secret is now unused by this workflow and can be removed at your discretion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)