### PR TITLE
Prepare 1.10.0-beta.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [v1.10.0-beta.0](https://github.com/studiometa/ui/compare/1.9.0..1.10.0-beta.0) (2026-08-04)
+
 ### Added
 
-- **Browser CDN:** add an official browser CDN (`cdn.studiometa.dev`) — one `<script type="module">` with declarative `data-component` autoloading, immutable versioned releases, per-component subpath imports (`/ui@<version>/Action.js`) mirroring the npm subpaths, a JSON registry at the root, and per-PR previews; `mapbox-gl` is consumer-provided via an import map ([#573](https://github.com/studiometa/ui/pull/573), [#578](https://github.com/studiometa/ui/pull/578))
+- **Browser CDN:** add an official browser CDN (`cdn.studiometa.dev`) — one `<script type="module">` with declarative `data-component` autoloading, immutable versioned releases, per-component subpath imports (`/ui@<version>/Action.js`) mirroring the npm subpaths, a JSON registry at the root, and per-PR previews; `mapbox-gl` is consumer-provided via an import map ([#573](https://github.com/studiometa/ui/pull/573), [#578](https://github.com/studiometa/ui/pull/578), [#579](https://github.com/studiometa/ui/pull/579))
+- **@studiometa/ui-autoload:** add a generic, side-effect-free declarative autoloader package; `@studiometa/ui` and `@studiometa/ui-mapbox` each expose a `./manifest` (token → lazy `import()`) that the autoloader composes, and the CDN builds on it instead of a bespoke loader ([#580](https://github.com/studiometa/ui/pull/580))
+- **Browser CDN:** ship a TypeScript declaration (`.d.ts`) for every entry with an `X-TypeScript-Types` response header, so consumers importing from the CDN keep editor autocomplete ([#581](https://github.com/studiometa/ui/pull/581))
+- **Browser CDN:** serve `@studiometa/ui-mapbox` from its own `/ui-mapbox@<version>/` tree (barrel plus per-component subpaths), mirroring `ui` and `js-toolkit` ([#583](https://github.com/studiometa/ui/pull/583))
 - **Mapbox:** provide `mapbox-gl` (and the optional geocoder) dynamically — add `provideMapboxGl` / `provideMapboxGeocoder` injection and `resolveMapboxGl` / `resolveMapboxGeocoder` resolvers so a host can supply its own instance; `mapbox-gl` is otherwise resolved with a lazy `import()` on first map build instead of a bundled static import ([#575](https://github.com/studiometa/ui/pull/575))
 - **Toaster:** add the `Toaster` and `Toast` components — a headless notifications region built on two `aria-live` regions so toasts are announced without moving focus, each toast a `Timer`-based `Toast` with a pausable auto-dismiss countdown, and stacking animated through the `viewTransition` scheduler ([#572](https://github.com/studiometa/ui/pull/572))
+
+### Changed
+
+- **Playground:** load `@studiometa/js-toolkit`, `@studiometa/ui` and `@studiometa/ui-mapbox` from the browser CDN instead of esm.sh and locally bundled sources ([#584](https://github.com/studiometa/ui/pull/584))
+- **Build:** migrate every library build from esbuild to tsdown, and build `@studiometa/ui` into `packages/ui/dist` for parity with the other packages ([#585](https://github.com/studiometa/ui/pull/585))
+- **Release:** publish the npm packages with tokenless trusted publishing (OIDC provenance, no token) and publish the new `@studiometa/ui-autoload` package ([#586](https://github.com/studiometa/ui/pull/586))
 
 ## [v1.9.0](https://github.com/studiometa/ui/compare/1.8.0..1.9.0) (2026-07-29)
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "studiometa/ui",
   "type": "composer-plugin",
-  "version": "1.9.0",
+  "version": "1.10.0-beta.0",
   "description": "Accessible and composable JavaScript behaviors and Twig templates.",
   "license": "MIT",
   "require": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@studiometa/ui-workspace",
-  "version": "1.9.0",
+  "version": "1.10.0-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@studiometa/ui-workspace",
-      "version": "1.9.0",
+      "version": "1.10.0-beta.0",
       "hasInstallScript": true,
       "workspaces": [
         "packages/*"
@@ -23374,11 +23374,11 @@
     },
     "packages/api": {
       "name": "@studiometa/ui-api",
-      "version": "1.9.0"
+      "version": "1.10.0-beta.0"
     },
     "packages/cdn": {
       "name": "@studiometa/ui-cdn",
-      "version": "1.9.0",
+      "version": "1.10.0-beta.0",
       "license": "MIT",
       "dependencies": {
         "@studiometa/ui": "file:../ui",
@@ -23621,7 +23621,7 @@
     },
     "packages/docs": {
       "name": "@studiometa/ui-docs",
-      "version": "1.9.0",
+      "version": "1.10.0-beta.0",
       "dependencies": {
         "@studiometa/js-toolkit": "3.8.0"
       },
@@ -23642,7 +23642,7 @@
     },
     "packages/eslint-plugin-ui": {
       "name": "@studiometa/eslint-plugin-ui",
-      "version": "1.9.0",
+      "version": "1.10.0-beta.0",
       "license": "MIT",
       "dependencies": {
         "@oxlint/plugins": "1.63.0"
@@ -23671,7 +23671,7 @@
     },
     "packages/playground": {
       "name": "@studiometa/ui-playground",
-      "version": "1.9.0",
+      "version": "1.10.0-beta.0",
       "dependencies": {
         "@studiometa/playground": "0.3.10"
       },
@@ -23738,7 +23738,7 @@
     },
     "packages/tests": {
       "name": "@studiometa/ui-tests",
-      "version": "1.9.0",
+      "version": "1.10.0-beta.0",
       "license": "MIT",
       "dependencies": {
         "@happy-dom/global-registrator": "^20.8.8",
@@ -23993,7 +23993,7 @@
     },
     "packages/ui": {
       "name": "@studiometa/ui",
-      "version": "1.9.0",
+      "version": "1.10.0-beta.0",
       "license": "MIT",
       "dependencies": {
         "alien-signals": "^3.2.1",
@@ -24021,7 +24021,7 @@
     },
     "packages/ui-autoload": {
       "name": "@studiometa/ui-autoload",
-      "version": "1.9.0",
+      "version": "1.10.0-beta.0",
       "license": "MIT",
       "devDependencies": {
         "@studiometa/js-toolkit": "^3.8.0",
@@ -24033,7 +24033,7 @@
     },
     "packages/ui-mapbox": {
       "name": "@studiometa/ui-mapbox",
-      "version": "1.9.0",
+      "version": "1.10.0-beta.0",
       "license": "MIT",
       "devDependencies": {
         "@mapbox/mapbox-gl-geocoder": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-workspace",
-  "version": "1.9.0",
+  "version": "1.10.0-beta.0",
   "type": "module",
   "private": true,
   "workspaces": [

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-api",
-  "version": "1.9.0",
+  "version": "1.10.0-beta.0",
   "private": true,
   "type": "commonjs"
 }

--- a/packages/cdn/package.json
+++ b/packages/cdn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-cdn",
-  "version": "1.9.0",
+  "version": "1.10.0-beta.0",
   "description": "Private browser CDN build for @studiometa/ui",
   "private": true,
   "type": "module",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-docs",
-  "version": "1.9.0",
+  "version": "1.10.0-beta.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/eslint-plugin-ui/package.json
+++ b/packages/eslint-plugin-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/eslint-plugin-ui",
-  "version": "1.9.0",
+  "version": "1.10.0-beta.0",
   "description": "ESLint plugin to help developers discover and use @studiometa/ui components",
   "publishConfig": {
     "access": "public"

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-playground",
-  "version": "1.9.0",
+  "version": "1.10.0-beta.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-tests",
-  "version": "1.9.0",
+  "version": "1.10.0-beta.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/ui-autoload/package.json
+++ b/packages/ui-autoload/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-autoload",
-  "version": "1.9.0",
+  "version": "1.10.0-beta.0",
   "description": "Generic, side-effect-free declarative autoloader for @studiometa/ui component manifests",
   "publishConfig": {
     "access": "public"

--- a/packages/ui-mapbox/package.json
+++ b/packages/ui-mapbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-mapbox",
-  "version": "1.9.0",
+  "version": "1.10.0-beta.0",
   "description": "Vanilla js-toolkit components to build Mapbox GL maps declaratively",
   "publishConfig": {
     "access": "public"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui",
-  "version": "1.9.0",
+  "version": "1.10.0-beta.0",
   "description": "Accessible and composable JavaScript behaviors and templates",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary

Prepares the **`1.10.0-beta.0`** release — the first beta of the next minor, which ships the browser-CDN generic refactor (ui-autoload package, tsdown migration, types-aware CDN, dedicated ui-mapbox tree, playground→CDN) and the switch to tokenless trusted publishing.

- Bumps every workspace (root + all `packages/*`) and `composer.json` + `package-lock.json` to `1.10.0-beta.0` (via `npm version … --workspaces --include-workspace-root`, mirroring the `postversion` sync).
- Adds the `## [v1.10.0-beta.0]` CHANGELOG section (Added/Changed) covering #572–#586, and empties `[Unreleased]`.

Merging this, then tagging the merge commit `1.10.0-beta.0`, triggers the release workflow: publishes `@studiometa/ui`, `@studiometa/eslint-plugin-ui`, `@studiometa/ui-mapbox`, and the new `@studiometa/ui-autoload` to npm under the `next` dist-tag via trusted publishing, and publishes the versioned CDN trees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)