### PR TITLE
Align the CDN next dist-tag with the latest prerelease (phase 2)

### DIFF
--- a/packages/cdn/docs/infrastructure.md
+++ b/packages/cdn/docs/infrastructure.md
@@ -100,6 +100,7 @@ The Worker enforces several invariants when parsing the index. For `ui` (and, wh
 
 - **Immutable objects**: Each exact version or channel is written to a new prefix and never overwritten.
 - **Version index**: `versions.json` maps semantic aliases and distribution tags to exact prefixes.
+- **Distribution tags (npm parity)**: `latest` names the latest stable release, `next` names the latest prerelease release (advanced only forward, to the highest prerelease), and `main` names the rolling `main-<commit>` main channel. The three are advanced independently — a stable release moves `latest`, a prerelease moves `next`, and a main-branch publish moves `main` — so `next` and `main` are decoupled. The tolerant Worker still also accepts the legacy coupled shape where `next` names the main channel.
 - **Append-only**: Old versions remain available; releasing only adds prefixes and updates the index.
 - **Reproducible identity**: The build identifier embeds the source-tree digest for reproducibility (see `build.json`).
 

--- a/packages/cdn/docs/release.md
+++ b/packages/cdn/docs/release.md
@@ -13,6 +13,16 @@ A release is two things published in order:
 
 The index is the source of truth the Worker reads first. A prefix that exists in the bucket but is absent from `versions.json` is invisible to the Worker; a tag in `versions.json` that names a missing prefix would fail validation. The two must stay consistent, and the index must be updated last.
 
+### Distribution tags
+
+The three ui distribution tags mirror npm and are advanced independently:
+
+- **`latest` = latest stable release.** A stable (non-prerelease) release publish advances it.
+- **`next` = latest prerelease release (npm parity).** A prerelease publish advances it, tracking the _highest_ published prerelease — it only ever moves forward, never back to an older prerelease. It is decoupled from `main`.
+- **`main` = rolling main channel.** A main-branch channel publish advances it to the new `main-<commit>` channel and touches nothing else; it never moves `next`.
+
+Each ui tag is advanced identically on the lockstep `ui-mapbox` package. Re-running a release publish for an already-published version is idempotent: the immutable tree is left untouched and only these tags (and `versions.json`) are advanced.
+
 ## Preconditions
 
 Before publishing:
@@ -40,8 +50,8 @@ The publish step must preserve the append-only, index-last contract:
 
 1. **Upload to a temporary location.** Stage the built files under a non-served temporary key so a partially uploaded release is never reachable through the index.
 2. **Verify the upload.** Re-check every file against `integrity.json` (SHA-384) after upload. Confirm the file inventory matches `build.json` outputs. The upload is only considered good if every digest matches.
-3. **Copy into the final immutable prefixes.** Move the verified files to `releases/ui/<version>/` (or `channels/main-<commit>/`) and, when the exact js-toolkit version is not yet present, to `releases/js-toolkit/<jtVersion>/`. These prefixes are immutable: each is written once and never overwritten. If a prefix for that exact version already exists, stop — re-publishing an existing version is not allowed (js-toolkit simply keeps its existing artifact). Publish js-toolkit before the ui tree that imports it becomes visible.
-4. **Update `versions.json` atomically.** Write a new `schemaVersion: 2` index that adds the ui version to `packages.ui.releases` (or `packages.ui.channels`), the lockstep ui-mapbox version to `packages["ui-mapbox"].releases` (or `.channels`), and the js-toolkit version to `packages["js-toolkit"].releases`, and, if this ui release should become current, sets the relevant distribution tag on both ui and ui-mapbox. `versions.json` is the only mutable object touched by a release, and it is written as a single object so the Worker never observes a half-updated index. Preserve the schema invariants: `latest` must name a published stable release with no pre-release identifier, and `next` must equal `main` and name a published channel.
+3. **Copy into the final immutable prefixes.** Move the verified files to `releases/ui/<version>/` (or `channels/main-<commit>/`) and, when the exact js-toolkit version is not yet present, to `releases/js-toolkit/<jtVersion>/`. These prefixes are immutable: each is written once and never overwritten. A channel or preview whose prefix already exists is an error — stop. A **release** whose prefix already exists is instead idempotent: skip the copy, leave the immutable tree untouched, and continue to the index update so a re-run only re-advances the distribution tags (js-toolkit likewise keeps its existing artifact). Publish js-toolkit before the ui tree that imports it becomes visible.
+4. **Update `versions.json` atomically.** Write a new `schemaVersion: 2` index that adds the ui version to `packages.ui.releases` (or `packages.ui.channels`), the lockstep ui-mapbox version to `packages["ui-mapbox"].releases` (or `.channels`), and the js-toolkit version to `packages["js-toolkit"].releases`, and advances the appropriate distribution tag on both ui and ui-mapbox: a stable release moves `latest`, a prerelease moves `next` (to the highest prerelease), and a main channel moves `main`. `versions.json` is the only mutable object touched by a release, and it is written as a single object so the Worker never observes a half-updated index. Preserve the schema invariants: `latest` must name a published stable release with no pre-release identifier; `main` must name a published channel; and `next` must name either a published prerelease release (npm parity) or, in the legacy shape, a published channel.
 
 Uploading the immutable prefix before touching the index guarantees that every version the index references is already fully present and verified.
 

--- a/packages/cdn/scripts/lib/publication.ts
+++ b/packages/cdn/scripts/lib/publication.ts
@@ -213,7 +213,9 @@ function targetIdentity(target: PublishTarget): { identity: string; finalPrefix:
  *    releases/channels and advancing distribution tags per policy;
  * 4. temporary objects are deleted on success and deliberately left in place on failure.
  *
- * An already-populated final prefix is never overwritten.
+ * An already-populated immutable prefix is never overwritten: for a channel or preview that is a
+ * hard error, but a release re-publish is idempotent — the existing tree is left in place and only
+ * the `versions.json` dist-tags are advanced, so re-running a release publish moves its tag.
  */
 /**
  * Stages every file of an artifact to a temporary prefix (verifying each read-back), then
@@ -315,13 +317,23 @@ export async function publish(
     }
   }
 
-  if ((await store.head(`${finalPrefix}/build.json`)) !== undefined) {
-    throw new Error(`${identity} is already published and immutable; refusing to overwrite it.`);
-  }
-  if (lockstepPrefix && (await store.head(`${lockstepPrefix}/build.json`)) !== undefined) {
-    throw new Error(
-      `${identity} (ui-mapbox) is already published and immutable; refusing to overwrite it.`,
-    );
+  // Immutable prefixes are written once. A release re-publish is idempotent for the dist-tags: the
+  // immutable tree is left untouched (re-uploading it is skipped) but the index is still rewritten
+  // below so re-running a publish for an already-published release moves its distribution tag. A
+  // channel or preview is commit-addressed and re-publishing one is a mistake, so it still hard-fails.
+  const finalAlreadyPublished = (await store.head(`${finalPrefix}/build.json`)) !== undefined;
+  const lockstepAlreadyPublished =
+    lockstepPrefix !== undefined &&
+    (await store.head(`${lockstepPrefix}/build.json`)) !== undefined;
+  if (target.kind !== 'release') {
+    if (finalAlreadyPublished) {
+      throw new Error(`${identity} is already published and immutable; refusing to overwrite it.`);
+    }
+    if (lockstepAlreadyPublished) {
+      throw new Error(
+        `${identity} (ui-mapbox) is already published and immutable; refusing to overwrite it.`,
+      );
+    }
   }
 
   const now = options.now ?? Date.now();
@@ -329,16 +341,24 @@ export async function publish(
   const temporaryPrefix = `tmp/${publicationId}`;
   const lockstepTemporaryPrefix = `tmp/${publicationId}-ui-mapbox`;
 
-  await stageAndCopyArtifact(store, artifact, finalPrefix, temporaryPrefix, identity, log);
+  if (finalAlreadyPublished) {
+    log(`${identity} is already published; skipping its upload and only advancing dist-tags.`);
+  } else {
+    await stageAndCopyArtifact(store, artifact, finalPrefix, temporaryPrefix, identity, log);
+  }
   if (lockstep && lockstepPrefix) {
-    await stageAndCopyArtifact(
-      store,
-      lockstep,
-      lockstepPrefix,
-      lockstepTemporaryPrefix,
-      `${identity} (ui-mapbox)`,
-      log,
-    );
+    if (lockstepAlreadyPublished) {
+      log(`${identity} (ui-mapbox) is already published; skipping its upload.`);
+    } else {
+      await stageAndCopyArtifact(
+        store,
+        lockstep,
+        lockstepPrefix,
+        lockstepTemporaryPrefix,
+        `${identity} (ui-mapbox)`,
+        log,
+      );
+    }
   }
 
   log('Updating versions.json.');
@@ -364,10 +384,12 @@ export async function publish(
   });
 
   log('Cleaning up temporary objects.');
-  await forEachWithConcurrency(artifact.files, (file) =>
-    store.delete(`${temporaryPrefix}/${file.path}`),
-  );
-  if (lockstep) {
+  if (!finalAlreadyPublished) {
+    await forEachWithConcurrency(artifact.files, (file) =>
+      store.delete(`${temporaryPrefix}/${file.path}`),
+    );
+  }
+  if (lockstep && !lockstepAlreadyPublished) {
     await forEachWithConcurrency(lockstep.files, (file) =>
       store.delete(`${lockstepTemporaryPrefix}/${file.path}`),
     );

--- a/packages/cdn/scripts/lib/versions.ts
+++ b/packages/cdn/scripts/lib/versions.ts
@@ -7,6 +7,17 @@ const MAIN_CHANNEL_PATTERN = /^main-[0-9a-f]{7,40}$/;
 const PREVIEW_CHANNEL_PATTERN = /^pr-[1-9]\d*-[0-9a-f]{7,40}$/;
 const CHANNEL_PATTERN = /^(?:main|pr-[1-9]\d*)-[0-9a-f]{7,40}$/;
 
+/**
+ * The mutable distribution tags for a ui-like package, mirroring npm's model:
+ * - `latest` — the latest stable (non-prerelease) release.
+ * - `next` — the latest prerelease release (npm parity), decoupled from `main`. It tracks the
+ *   highest published prerelease and never moves backward to an older one. Managed by releases.
+ * - `main` — the rolling `main-<sha>` main channel, advanced on every main-branch publish.
+ *
+ * `next` and `main` are independent: `next` names a prerelease release once one is published, while
+ * `main` always names the newest main channel. Before any prerelease exists, a legacy `next` may
+ * still name the main channel (the tolerant Worker keeps accepting that shape).
+ */
 export interface DistributionTags {
   latest?: string;
   next?: string;
@@ -213,8 +224,15 @@ function withUiLikePackage(
 }
 
 /**
- * Records a stable release for a ui-like package. The `latest` distribution tag is advanced only for
- * non-prerelease versions; prereleases are indexed but never become `latest`.
+ * Records a release for a ui-like package and advances the release-managed distribution tags:
+ * - a stable (non-prerelease) version advances `latest` (npm's latest stable);
+ * - a prerelease version advances `next` (npm's latest prerelease), but only forward: `next` moves
+ *   to it when there is no current `next`, when the current `next` is a channel id rather than a
+ *   published release, or when the version sorts at/after the current `next` target. This keeps
+ *   `next` tracking the highest published prerelease and never regresses it to an older one.
+ *
+ * `main` (the rolling main channel) is never touched here — releases and the main channel are
+ * decoupled.
  */
 export function addRelease(
   index: WorkingVersionsIndex,
@@ -229,14 +247,24 @@ export function addRelease(
       ? [...pkg.releases]
       : [...pkg.releases, version];
     const distTags = { ...pkg.distTags };
-    if (isStableVersion(version)) distTags.latest = version;
+    if (isStableVersion(version)) {
+      distTags.latest = version;
+    } else if (
+      distTags.next === undefined ||
+      isChannelId(distTags.next) ||
+      compareStableVersions(version, distTags.next) >= 0
+    ) {
+      distTags.next = version;
+    }
     return { ...pkg, releases: releases.sort(compareStableVersions), distTags };
   });
 }
 
 /**
- * Records an immutable main channel for a ui-like package and advances its `next` and `main`
- * distribution tags together, as the Worker requires them to always name the same channel.
+ * Records an immutable main channel for a ui-like package and advances only its `main` distribution
+ * tag to the channel. `next` is no longer advanced here — it tracks the latest published prerelease
+ * release (managed by {@link addRelease}) and is left untouched so a channel publish never clobbers
+ * a prerelease `next`.
  */
 export function addChannel(
   index: WorkingVersionsIndex,
@@ -253,7 +281,7 @@ export function addChannel(
     return {
       ...pkg,
       channels: channels.sort(),
-      distTags: { ...pkg.distTags, next: channelId, main: channelId },
+      distTags: { ...pkg.distTags, main: channelId },
     };
   });
 }
@@ -281,8 +309,9 @@ export function addPreviewChannel(
 
 /**
  * Removes a channel from a ui-like package's index (used to prune a pull request's preview channel
- * once the PR is closed). If the channel happened to be the `next`/`main` target, both tags are
- * cleared together so the Worker's "next and main name the same published channel" invariant holds.
+ * once the PR is closed). Only `main` is a channel tag now, so if the pruned channel happened to be
+ * the `main` target it is cleared; `next` is left alone because it names a prerelease release rather
+ * than a channel. (Preview-channel pruning never set `main`, so this branch is mostly defensive.)
  */
 export function removeChannel(
   index: WorkingVersionsIndex,
@@ -292,8 +321,7 @@ export function removeChannel(
   return withUiLikePackage(index, packageName, (pkg) => {
     const channels = pkg.channels.filter((channel) => channel !== channelId);
     const distTags = { ...pkg.distTags };
-    if (distTags.next === channelId || distTags.main === channelId) {
-      delete distTags.next;
+    if (distTags.main === channelId) {
       delete distTags.main;
     }
     return { ...pkg, channels, distTags };
@@ -305,7 +333,7 @@ export function addUiRelease(index: WorkingVersionsIndex, version: string): Work
   return addRelease(index, 'ui', version);
 }
 
-/** Records an immutable `ui` main channel, advancing its `next`/`main` tags together. */
+/** Records an immutable `ui` main channel, advancing only its `main` tag. */
 export function addUiChannel(index: WorkingVersionsIndex, channelId: string): WorkingVersionsIndex {
   return addChannel(index, 'ui', channelId);
 }
@@ -318,7 +346,7 @@ export function addUiPreviewChannel(
   return addPreviewChannel(index, 'ui', channelId);
 }
 
-/** Removes a `ui` channel from the index, clearing `next`/`main` together if they named it. */
+/** Removes a `ui` channel from the index, clearing `main` if it named the pruned channel. */
 export function removeUiChannel(
   index: WorkingVersionsIndex,
   channelId: string,

--- a/packages/cdn/tests/publication.test.ts
+++ b/packages/cdn/tests/publication.test.ts
@@ -149,7 +149,7 @@ describe('CDN publication', () => {
     expect(() => parseVersionsIndex(result.index)).not.toThrow();
   });
 
-  it('advances latest for a stable tag but never for a prerelease', async () => {
+  it('advances latest for a stable tag, and next (not latest) for a prerelease', async () => {
     const stable = await publish(seededStore(), makeArtifact(), releaseTarget, {
       publicationId: 'p',
     });
@@ -161,7 +161,10 @@ describe('CDN publication', () => {
       { kind: 'release', packageName: 'ui', version: '2.2.0-beta.1' },
       { publicationId: 'p' },
     );
+    // A prerelease never moves latest, but does advance next (npm parity). The seed's next named a
+    // channel, so the prerelease takes it over.
     expect(prerelease.index.packages.ui.distTags.latest).toBe('2.0.0');
+    expect(prerelease.index.packages.ui.distTags.next).toBe('2.2.0-beta.1');
     expect(prerelease.index.packages.ui.releases).toContain('2.2.0-beta.1');
   });
 
@@ -181,7 +184,7 @@ describe('CDN publication', () => {
     expect(() => parseVersionsIndex(result.index)).not.toThrow();
   });
 
-  it('publishes a main channel and moves next and main together', async () => {
+  it('publishes a main channel and advances only main, leaving next untouched', async () => {
     const store = seededStore();
     const result = await publish(
       store,
@@ -190,10 +193,37 @@ describe('CDN publication', () => {
       { publicationId: 'chan' },
     );
     expect(result.identity).toBe('main-bbbbbbbbbbbb');
-    expect(result.index.packages.ui.distTags.next).toBe('main-bbbbbbbbbbbb');
     expect(result.index.packages.ui.distTags.main).toBe('main-bbbbbbbbbbbb');
+    // next is release-managed now: a channel publish never advances it. It stays on the seed's next.
+    expect(result.index.packages.ui.distTags.next).toBe('main-000000000002');
     expect(store.objects.has('channels/main-bbbbbbbbbbbb/build.json')).toBe(true);
     expect(() => parseVersionsIndex(result.index)).not.toThrow();
+  });
+
+  it('keeps main (channel) and next (prerelease) decoupled across a channel then a prerelease publish', async () => {
+    const store = seededStore();
+    const channel = await publish(
+      store,
+      makeArtifact({ commit: 'b'.repeat(40) }),
+      { kind: 'channel', commit: 'b'.repeat(40) },
+      { publicationId: 'chan', lockstepUiMapbox: makeArtifact({ commit: 'b'.repeat(40) }) },
+    );
+    // The channel advances main only; next is left on whatever the seed pointed it at.
+    expect(channel.index.packages.ui.distTags.main).toBe('main-bbbbbbbbbbbb');
+    expect(channel.index.packages.ui.distTags.next).toBe('main-000000000002');
+
+    const prerelease = await publish(
+      store,
+      makeArtifact({ version: '2.2.0-beta.1' }),
+      { kind: 'release', packageName: 'ui', version: '2.2.0-beta.1' },
+      { publicationId: 'pre', lockstepUiMapbox: makeArtifact({ version: '2.2.0-beta.1' }) },
+    );
+    // The prerelease advances next but never main; the two stay decoupled for both lockstep packages.
+    expect(prerelease.index.packages.ui.distTags.main).toBe('main-bbbbbbbbbbbb');
+    expect(prerelease.index.packages.ui.distTags.next).toBe('2.2.0-beta.1');
+    expect(prerelease.index.packages['ui-mapbox'].distTags.main).toBe('main-bbbbbbbbbbbb');
+    expect(prerelease.index.packages['ui-mapbox'].distTags.next).toBe('2.2.0-beta.1');
+    expect(() => parseVersionsIndex(prerelease.index)).not.toThrow();
   });
 
   it('publishes a per-PR preview channel without moving the next or main tags', async () => {
@@ -250,15 +280,49 @@ describe('CDN publication', () => {
     expect(again.removed).toEqual([]);
   });
 
-  it('refuses to overwrite an already published immutable prefix', async () => {
+  it('refuses to overwrite an already published immutable channel', async () => {
+    // A channel is commit-addressed and immutable; re-publishing it is a mistake and still hard-fails.
     const store = seededStore();
-    store.objects.set('releases/ui/2.1.0/build.json', {
+    store.objects.set('channels/main-bbbbbbbbbbbb/build.json', {
       body: new Uint8Array(),
       sha384: 'sha384-existing',
     });
-    await expect(publish(store, makeArtifact(), releaseTarget)).rejects.toThrow(
-      /already published/,
+    await expect(
+      publish(store, makeArtifact({ commit: 'b'.repeat(40) }), {
+        kind: 'channel',
+        commit: 'b'.repeat(40),
+      }),
+    ).rejects.toThrow(/already published/);
+  });
+
+  it('re-publishing an existing release skips the upload but still advances its dist-tag', async () => {
+    // The idempotent re-tag path: after 2.2.0-beta.0 was published, re-running its publish (e.g. to
+    // fix up next semantics after this deploy) must not re-upload the immutable tree, but must still
+    // rewrite versions.json so next moves to the prerelease.
+    const store = seededStore();
+    for (const key of [
+      'releases/ui/2.2.0-beta.0/build.json',
+      'releases/ui-mapbox/2.2.0-beta.0/build.json',
+    ]) {
+      store.objects.set(key, { body: new Uint8Array(), sha384: 'x' });
+    }
+    const opsBefore = store.operations.length;
+    const result = await publish(
+      store,
+      makeArtifact({ version: '2.2.0-beta.0' }),
+      { kind: 'release', packageName: 'ui', version: '2.2.0-beta.0' },
+      { publicationId: 'retag', lockstepUiMapbox: makeArtifact({ version: '2.2.0-beta.0' }) },
     );
+    // No immutable object was re-uploaded: neither tree was staged or copied.
+    const newOps = store.operations.slice(opsBefore);
+    expect(newOps.some((entry) => entry.op === 'copy')).toBe(false);
+    expect(newOps.some((entry) => entry.op === 'put' && entry.key.startsWith('tmp/'))).toBe(false);
+    // versions.json was still rewritten and next advanced to the prerelease for both packages.
+    expect(newOps.some((entry) => entry.op === 'put' && entry.key === 'versions.json')).toBe(true);
+    expect(result.index.packages.ui.distTags.next).toBe('2.2.0-beta.0');
+    expect(result.index.packages['ui-mapbox'].distTags.next).toBe('2.2.0-beta.0');
+    expect(result.index.packages.ui.releases).toContain('2.2.0-beta.0');
+    expect(() => parseVersionsIndex(result.index)).not.toThrow();
   });
 
   it('fails an interrupted upload and leaves temporary objects for diagnosis', async () => {

--- a/packages/cdn/tests/worker/versions.test.ts
+++ b/packages/cdn/tests/worker/versions.test.ts
@@ -2,6 +2,7 @@
 
 import { describe, expect, it } from 'vitest';
 import { parseVersionsIndex, resolveBareRoot, resolveVersion } from '../../worker/versions.ts';
+import { addChannel, addRelease, type WorkingVersionsIndex } from '../../scripts/lib/versions.ts';
 
 function uiIndex(ui: { releases: string[]; channels: string[]; distTags: Record<string, string> }) {
   // ui-mapbox is validated identically to ui and versioned in lockstep, so it mirrors ui here.
@@ -301,5 +302,89 @@ describe('bare package root resolution', () => {
     const empty = parseVersionsIndex(uiIndex({ releases: [], channels: [], distTags: {} }));
     expect(resolveBareRoot(empty, 'ui')).toBeUndefined();
     expect(resolveBareRoot(empty, 'js-toolkit')).toBeUndefined();
+  });
+});
+
+describe('distribution tag mutators (scripts/lib/versions)', () => {
+  // Builds a working index whose ui and ui-mapbox packages share the given shape (they are versioned
+  // in lockstep). Only `ui` is inspected in these unit tests.
+  function workingIndex(ui: {
+    releases: string[];
+    channels: string[];
+    distTags: Record<string, string>;
+  }): WorkingVersionsIndex {
+    return {
+      schemaVersion: 2,
+      packages: {
+        ui: structuredClone(ui),
+        'ui-mapbox': structuredClone(ui),
+        'js-toolkit': { releases: [] },
+      },
+    };
+  }
+
+  it('addChannel advances only main and never touches next', () => {
+    // next names a published prerelease release; a channel publish must leave it untouched.
+    const before = workingIndex({
+      releases: ['1.0.0', '2.0.0-beta.1'],
+      channels: [],
+      distTags: { latest: '1.0.0', next: '2.0.0-beta.1' },
+    });
+    const after = addChannel(before, 'ui', 'main-abcdef1234ab');
+    expect(after.packages.ui.distTags.main).toBe('main-abcdef1234ab');
+    expect(after.packages.ui.distTags.next).toBe('2.0.0-beta.1');
+    expect(after.packages.ui.channels).toContain('main-abcdef1234ab');
+  });
+
+  it('addRelease advances latest for a stable version and leaves next alone', () => {
+    const after = addRelease(
+      workingIndex({
+        releases: ['1.0.0'],
+        channels: ['main-abcdef1234ab'],
+        distTags: { latest: '1.0.0', next: 'main-abcdef1234ab' },
+      }),
+      'ui',
+      '2.0.0',
+    );
+    expect(after.packages.ui.distTags.latest).toBe('2.0.0');
+    expect(after.packages.ui.distTags.next).toBe('main-abcdef1234ab');
+  });
+
+  it('addRelease advances next to a prerelease when next is unset or names a channel', () => {
+    // Unset next.
+    const fresh = addRelease(
+      workingIndex({ releases: ['1.0.0'], channels: [], distTags: { latest: '1.0.0' } }),
+      'ui',
+      '2.0.0-beta.0',
+    );
+    expect(fresh.packages.ui.distTags.next).toBe('2.0.0-beta.0');
+
+    // next currently names a channel (the legacy coupled shape): the prerelease takes it over, and
+    // latest is untouched by a prerelease.
+    const fromChannel = addRelease(
+      workingIndex({
+        releases: ['1.0.0'],
+        channels: ['main-abcdef1234ab'],
+        distTags: { latest: '1.0.0', next: 'main-abcdef1234ab' },
+      }),
+      'ui',
+      '2.0.0-beta.0',
+    );
+    expect(fromChannel.packages.ui.distTags.next).toBe('2.0.0-beta.0');
+    expect(fromChannel.packages.ui.distTags.latest).toBe('1.0.0');
+  });
+
+  it('addRelease only moves next forward to a higher prerelease, never backward', () => {
+    const start = workingIndex({
+      releases: ['1.0.0', '2.0.0-beta.1'],
+      channels: [],
+      distTags: { latest: '1.0.0', next: '2.0.0-beta.1' },
+    });
+    // A newer prerelease advances next.
+    expect(addRelease(start, 'ui', '2.0.0-beta.2').packages.ui.distTags.next).toBe('2.0.0-beta.2');
+    // An older prerelease does not move next backward, but is still indexed.
+    const backward = addRelease(start, 'ui', '2.0.0-beta.0');
+    expect(backward.packages.ui.distTags.next).toBe('2.0.0-beta.1');
+    expect(backward.packages.ui.releases).toContain('2.0.0-beta.0');
   });
 });


### PR DESCRIPTION
## Summary

**Phase 2 of 2** — with the tolerant Worker already live (#588), this flips the publish logic so the CDN dist-tags mirror npm:

- **`latest`** = latest **stable** release (unchanged)
- **`next`** = latest **prerelease** (npm parity) — new
- **`main`** = rolling **main channel** (`main-<sha>`) — no longer also claims `next`

### `packages/cdn/scripts/lib/versions.ts`
- `addChannel` sets only `main` (drops `next`).
- `addRelease` advances `next` to a **prerelease**, forward-only (moves when `next` is unset or a channel, or when the version sorts at/after the current `next` via `compareStableVersions`; never regresses to an older prerelease). Stable still advances `latest`.
- `removeChannel` clears only `main`.
- Applied identically to the lockstep `ui-mapbox` package.

### `packages/cdn/scripts/lib/publication.ts` — idempotent release re-tag
A **release** re-publish (`--git-tag`) whose immutable tree already exists now skips re-uploading but still advances the dist-tags and rewrites `versions.json` (channels/previews still hard-fail on re-publish). This lets a re-run of `cdn_release` for an already-published version move `next` onto it — which I'll use to point `next` at the existing `1.10.0-beta.0`.

Worker and registry `current` resolution are untouched (Phase 1 handles reading the decoupled shape; `current` never uses `next`). Docs updated (`release.md`, `infrastructure.md`).

## Test plan
- `npx vitest run --root packages/cdn` — 143 passed (incl. new dist-tag mutator unit tests, channel↔prerelease decoupling, and the idempotent release re-tag path).
- Full repo suite — 827 passed. Lint 0 errors, `cdn:build` clean, prettier clean.

## Rollout
Merge → `cdn-main` deploys → re-run `cdn_release` for `1.10.0-beta.0` so `/ui@next/` and `/ui-mapbox@next/` resolve to `1.10.0-beta.0`, matching npm's `next`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)