### PR TITLE
Prepare 1.10.0-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [v1.10.0-beta.1](https://github.com/studiometa/ui/compare/1.10.0-beta.0..1.10.0-beta.1) (2026-08-05)
+
+### Changed
+
+- **Browser CDN:** align the `next` distribution tag with the latest prerelease (npm parity), decoupled from the rolling `main` channel — `latest` names the latest stable release, `next` the latest prerelease, and `main` the rolling `main-<sha>` channel ([#588](https://github.com/studiometa/ui/pull/588), [#589](https://github.com/studiometa/ui/pull/589))
+
 ## [v1.10.0-beta.0](https://github.com/studiometa/ui/compare/1.9.0..1.10.0-beta.0) (2026-08-04)
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "studiometa/ui",
   "type": "composer-plugin",
-  "version": "1.10.0-beta.0",
+  "version": "1.10.0-beta.1",
   "description": "Accessible and composable JavaScript behaviors and Twig templates.",
   "license": "MIT",
   "require": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@studiometa/ui-workspace",
-  "version": "1.10.0-beta.0",
+  "version": "1.10.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@studiometa/ui-workspace",
-      "version": "1.10.0-beta.0",
+      "version": "1.10.0-beta.1",
       "hasInstallScript": true,
       "workspaces": [
         "packages/*"
@@ -23374,11 +23374,11 @@
     },
     "packages/api": {
       "name": "@studiometa/ui-api",
-      "version": "1.10.0-beta.0"
+      "version": "1.10.0-beta.1"
     },
     "packages/cdn": {
       "name": "@studiometa/ui-cdn",
-      "version": "1.10.0-beta.0",
+      "version": "1.10.0-beta.1",
       "license": "MIT",
       "dependencies": {
         "@studiometa/ui": "file:../ui",
@@ -23621,7 +23621,7 @@
     },
     "packages/docs": {
       "name": "@studiometa/ui-docs",
-      "version": "1.10.0-beta.0",
+      "version": "1.10.0-beta.1",
       "dependencies": {
         "@studiometa/js-toolkit": "3.8.0"
       },
@@ -23642,7 +23642,7 @@
     },
     "packages/eslint-plugin-ui": {
       "name": "@studiometa/eslint-plugin-ui",
-      "version": "1.10.0-beta.0",
+      "version": "1.10.0-beta.1",
       "license": "MIT",
       "dependencies": {
         "@oxlint/plugins": "1.63.0"
@@ -23671,7 +23671,7 @@
     },
     "packages/playground": {
       "name": "@studiometa/ui-playground",
-      "version": "1.10.0-beta.0",
+      "version": "1.10.0-beta.1",
       "dependencies": {
         "@studiometa/playground": "0.3.10"
       },
@@ -23738,7 +23738,7 @@
     },
     "packages/tests": {
       "name": "@studiometa/ui-tests",
-      "version": "1.10.0-beta.0",
+      "version": "1.10.0-beta.1",
       "license": "MIT",
       "dependencies": {
         "@happy-dom/global-registrator": "^20.8.8",
@@ -23993,7 +23993,7 @@
     },
     "packages/ui": {
       "name": "@studiometa/ui",
-      "version": "1.10.0-beta.0",
+      "version": "1.10.0-beta.1",
       "license": "MIT",
       "dependencies": {
         "alien-signals": "^3.2.1",
@@ -24021,7 +24021,7 @@
     },
     "packages/ui-autoload": {
       "name": "@studiometa/ui-autoload",
-      "version": "1.10.0-beta.0",
+      "version": "1.10.0-beta.1",
       "license": "MIT",
       "devDependencies": {
         "@studiometa/js-toolkit": "^3.8.0",
@@ -24033,7 +24033,7 @@
     },
     "packages/ui-mapbox": {
       "name": "@studiometa/ui-mapbox",
-      "version": "1.10.0-beta.0",
+      "version": "1.10.0-beta.1",
       "license": "MIT",
       "devDependencies": {
         "@mapbox/mapbox-gl-geocoder": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-workspace",
-  "version": "1.10.0-beta.0",
+  "version": "1.10.0-beta.1",
   "type": "module",
   "private": true,
   "workspaces": [

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-api",
-  "version": "1.10.0-beta.0",
+  "version": "1.10.0-beta.1",
   "private": true,
   "type": "commonjs"
 }

--- a/packages/cdn/package.json
+++ b/packages/cdn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-cdn",
-  "version": "1.10.0-beta.0",
+  "version": "1.10.0-beta.1",
   "description": "Private browser CDN build for @studiometa/ui",
   "private": true,
   "type": "module",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-docs",
-  "version": "1.10.0-beta.0",
+  "version": "1.10.0-beta.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/eslint-plugin-ui/package.json
+++ b/packages/eslint-plugin-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/eslint-plugin-ui",
-  "version": "1.10.0-beta.0",
+  "version": "1.10.0-beta.1",
   "description": "ESLint plugin to help developers discover and use @studiometa/ui components",
   "publishConfig": {
     "access": "public"

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-playground",
-  "version": "1.10.0-beta.0",
+  "version": "1.10.0-beta.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-tests",
-  "version": "1.10.0-beta.0",
+  "version": "1.10.0-beta.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/ui-autoload/package.json
+++ b/packages/ui-autoload/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-autoload",
-  "version": "1.10.0-beta.0",
+  "version": "1.10.0-beta.1",
   "description": "Generic, side-effect-free declarative autoloader for @studiometa/ui component manifests",
   "publishConfig": {
     "access": "public"

--- a/packages/ui-mapbox/package.json
+++ b/packages/ui-mapbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-mapbox",
-  "version": "1.10.0-beta.0",
+  "version": "1.10.0-beta.1",
   "description": "Vanilla js-toolkit components to build Mapbox GL maps declaratively",
   "publishConfig": {
     "access": "public"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui",
-  "version": "1.10.0-beta.0",
+  "version": "1.10.0-beta.1",
   "description": "Accessible and composable JavaScript behaviors and templates",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary

Second beta of the next minor. Bumps all workspaces + `composer.json` + `package-lock.json` to `1.10.0-beta.1` and adds the CHANGELOG section.

This beta ships the **CDN `next` dist-tag alignment** (#588 tolerant worker + #589 publish semantics): `latest` = latest stable, `next` = latest prerelease (npm parity, decoupled from the rolling `main` channel), `main` = rolling `main-<sha>` channel.

Merging + tagging `1.10.0-beta.1` publishes the four packages to npm under `next` (trusted publishing) and runs `cdn_release`, which — with the new logic — sets the CDN `next` dist-tag to `1.10.0-beta.1`, so `/ui@next/` and `/ui-mapbox@next/` finally match npm's `next`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)