### PR TITLE
Resolve versionless and extensionless subpath imports for all CDN packages

### DIFF
--- a/packages/cdn/tests/worker/fixtures.ts
+++ b/packages/cdn/tests/worker/fixtures.ts
@@ -132,6 +132,9 @@ export async function createWorkerFixture(): Promise<WorkerFixture> {
     'index.js',
     'index.js.map',
     'index.d.ts',
+    // The per-component `Action.js` entry backs the extensionless subpath tests (`/ui/Action` and
+    // `/ui@<version>/Action` both map to `Action.js`).
+    'Action.js',
     moduleWithoutDeclaration,
     'build.json',
     'integrity.json',

--- a/packages/cdn/tests/worker/index.test.ts
+++ b/packages/cdn/tests/worker/index.test.ts
@@ -133,13 +133,24 @@ describe('CDN Worker js-toolkit package routing', () => {
     expect(utils.headers.get('Content-Type')).toBe('text/javascript; charset=utf-8');
   });
 
-  it('resolves js-toolkit by exact semver only, never by alias or the versionless default', async () => {
+  it('resolves js-toolkit by exact semver only, never by an explicit alias, channel, or tag', async () => {
     const major = fixture.jsToolkitVersion.split('.')[0];
-    expect((await request('/js-toolkit/index.js')).status).toBe(404);
     expect((await request('/js-toolkit@latest/index.js')).status).toBe(404);
     expect((await request(`/js-toolkit@${major}/index.js`)).status).toBe(404);
     expect((await request('/js-toolkit@main-abcdef1/index.js')).status).toBe(404);
     expect((await request('/js-toolkit@9.9.9/index.js')).status).toBe(404);
+  });
+
+  it('resolves a versionless js-toolkit request to its highest release, not a latest tag', async () => {
+    // js-toolkit has no `latest` tag, so a versionless request must resolve via the bare-root ladder
+    // (highest published release) rather than the `latest` an explicit `/js-toolkit@latest/` uses.
+    const response = await request('/js-toolkit/index.js');
+    expect(response.status).toBe(307);
+    expect(response.headers.get('Location')).toBe(
+      `${origin}/js-toolkit@${fixture.jsToolkitVersion}/index.js`,
+    );
+    expect(response.headers.get('Cache-Control')).toBe(MUTABLE_CACHE_CONTROL);
+    expectCrossOriginHeaders(response);
   });
 });
 
@@ -187,6 +198,81 @@ describe('CDN Worker ui-mapbox package routing', () => {
       `${origin}/ui-mapbox@1.2.0/MapboxMap.d.ts`,
     );
     expect(module.headers.get('Access-Control-Expose-Headers')).toContain('X-TypeScript-Types');
+  });
+});
+
+describe('CDN Worker extensionless subpath resolution', () => {
+  it('maps a versionless extensionless ui component to its .js output in one hop', async () => {
+    const response = await request('/ui/Action');
+    expect(response.status).toBe(307);
+    expect(response.headers.get('Location')).toBe(`${origin}/ui@2.0.0/Action.js`);
+    expect(response.headers.get('Cache-Control')).toBe(MUTABLE_CACHE_CONTROL);
+    expectCrossOriginHeaders(response);
+
+    const served = await fetch(new Request(response.headers.get('Location') as string), {
+      ASSETS: fixture.bucket,
+    });
+    expect(served.status).toBe(200);
+    expect(served.headers.get('Content-Type')).toBe('text/javascript; charset=utf-8');
+    expect(await served.text()).toBe(fixture.files['Action.js']);
+  });
+
+  it('maps a versionless extensionless ui-mapbox component to its .js output', async () => {
+    const response = await request('/ui-mapbox/MapboxMap');
+    expect(response.status).toBe(307);
+    expect(response.headers.get('Location')).toBe(`${origin}/ui-mapbox@2.0.0/MapboxMap.js`);
+
+    const served = await fetch(new Request(response.headers.get('Location') as string), {
+      ASSETS: fixture.bucket,
+    });
+    expect(served.status).toBe(200);
+    expect(await served.text()).toBe(fixture.uiMapboxFiles['MapboxMap.js']);
+  });
+
+  it('maps a versionless extensionless js-toolkit subpath to its /index.js output', async () => {
+    const response = await request('/js-toolkit/utils');
+    expect(response.status).toBe(307);
+    expect(response.headers.get('Location')).toBe(
+      `${origin}/js-toolkit@${fixture.jsToolkitVersion}/utils/index.js`,
+    );
+
+    const served = await fetch(new Request(response.headers.get('Location') as string), {
+      ASSETS: fixture.bucket,
+    });
+    expect(served.status).toBe(200);
+    expect(served.headers.get('Content-Type')).toBe('text/javascript; charset=utf-8');
+  });
+
+  it('maps an exact-versioned extensionless request to its .js output', async () => {
+    const response = await request('/ui@1.2.0/Action');
+    expect(response.status).toBe(307);
+    expect(response.headers.get('Location')).toBe(`${origin}/ui@1.2.0/Action.js`);
+
+    const served = await fetch(new Request(response.headers.get('Location') as string), {
+      ASSETS: fixture.bucket,
+    });
+    expect(served.status).toBe(200);
+    expect(served.headers.get('Content-Type')).toBe('text/javascript; charset=utf-8');
+  });
+
+  it('maps an exact-versioned extensionless js-toolkit subpath to /index.js', async () => {
+    const response = await request(`/js-toolkit@${fixture.jsToolkitVersion}/utils`);
+    expect(response.status).toBe(307);
+    expect(response.headers.get('Location')).toBe(
+      `${origin}/js-toolkit@${fixture.jsToolkitVersion}/utils/index.js`,
+    );
+  });
+
+  it('serves an exact request that already names a concrete output without an extra hop', async () => {
+    const response = await request('/ui@1.2.0/Action.js');
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Content-Type')).toBe('text/javascript; charset=utf-8');
+  });
+
+  it('404s an extensionless subpath that maps to no served output', async () => {
+    expect((await request('/ui/DoesNotExist')).status).toBe(404);
+    expect((await request('/ui@1.2.0/DoesNotExist')).status).toBe(404);
+    expect((await request(`/js-toolkit@${fixture.jsToolkitVersion}/missing`)).status).toBe(404);
   });
 });
 

--- a/packages/cdn/worker/index.ts
+++ b/packages/cdn/worker/index.ts
@@ -165,6 +165,21 @@ async function loadRelease(
   return parseReleaseMetadata(build, integrity, exact, expectedPackageName);
 }
 
+// Maps a requested asset path to the served output it names, driven purely by the release's
+// `build.json` outputs (carried in `metadata.files`). An exact output is served as-is; otherwise an
+// extensionless request is resolved to `<path>.js` (e.g. `Action` -> `Action.js`) or, failing that,
+// `<path>/index.js` (e.g. `utils` -> `utils/index.js`). This is generic: it works for `ui`,
+// `ui-mapbox`, `js-toolkit`, and any future package without code change. Returns `undefined` (a 404)
+// when none of the three candidates is a served output.
+function resolveAsset(assetPath: string, files: ReadonlySet<string>): string | undefined {
+  if (files.has(assetPath)) return assetPath;
+  const withJs = `${assetPath}.js`;
+  if (files.has(withJs)) return withJs;
+  const withIndex = `${assetPath}/index.js`;
+  if (files.has(withIndex)) return withIndex;
+  return undefined;
+}
+
 function canonicalLocation(
   url: URL,
   packageName: PackageName,
@@ -322,7 +337,12 @@ async function handleRequest(
     return redirectResponse(`${url.origin}/${bareRoot}@${resolved.version}/index.js`);
   }
 
-  const exact = resolveVersion(versions, route.packageName, route.requestedVersion);
+  // A versionless request resolves its version the same way a bare package root does, so every
+  // package — including the tagless `js-toolkit`, which has no `latest` tag — lands on a usable exact
+  // version. An explicit `@latest`/`@<version>`/`@<channel>` keeps the full resolution semantics.
+  const exact = route.versionless
+    ? resolveBareRoot(versions, route.packageName)
+    : resolveVersion(versions, route.packageName, route.requestedVersion);
   recorder.versionKind(classifyVersion(route.requestedVersion, exact));
   if (!exact) return errorResponse(404);
 
@@ -332,21 +352,28 @@ async function handleRequest(
     PUBLIC_PACKAGE_NAMES[route.packageName],
   );
   recorder.r2('release-metadata', metadata ? 'hit' : 'miss');
-  if (!metadata || !metadata.files.has(route.assetPath)) return errorResponse(404);
+  if (!metadata) return errorResponse(404);
+  // Map the requested path to a served output, resolving an extensionless subpath (`Action`,
+  // `utils`) to its `.js` or `/index.js` output. A path that names no output is a 404.
+  const assetPath = resolveAsset(route.assetPath, metadata.files);
+  if (!assetPath) return errorResponse(404);
 
-  const query = canonicalizeQuery(
-    url,
-    route.assetPath,
-    new Set(Object.keys(metadata.build.components)),
-  );
+  const query = canonicalizeQuery(url, assetPath, new Set(Object.keys(metadata.build.components)));
   recorder.componentCount(query.components.length);
-  if (isMutableVersion(route.requestedVersion, exact) || !query.canonical) {
+  // Redirect to the canonical location when the version is mutable (versionless or a moving tag), the
+  // extensionless path was mapped to a concrete output, or the query is not yet canonical. A single
+  // hop covers all three at once (e.g. `/ui/Action` -> `/ui@<latest>/Action.js`).
+  if (
+    isMutableVersion(route.requestedVersion, exact) ||
+    assetPath !== route.assetPath ||
+    !query.canonical
+  ) {
     return redirectResponse(
-      canonicalLocation(url, route.packageName, exact.version, route.assetPath, query.search),
+      canonicalLocation(url, route.packageName, exact.version, assetPath, query.search),
     );
   }
 
-  const object = await environment.ASSETS.get(`${exact.objectPrefix}/${route.assetPath}`);
+  const object = await environment.ASSETS.get(`${exact.objectPrefix}/${assetPath}`);
   if (!object) {
     recorder.r2('asset', 'miss');
     return errorResponse(404);
@@ -356,7 +383,7 @@ async function handleRequest(
   const link = preloadHeader(route.packageName, exact.version, query.components, metadata);
   const headers = responseHeaders({
     'Cache-Control': IMMUTABLE_CACHE_CONTROL,
-    'Content-Type': contentType(route.assetPath),
+    'Content-Type': contentType(assetPath),
   });
   if (etag) headers.set('ETag', etag);
   if (link) headers.set('Link', link);
@@ -365,8 +392,8 @@ async function handleRequest(
   // `X-TypeScript-Types` header esm.sh uses, as a same-origin absolute URL, and expose the header to
   // cross-origin TypeScript language servers. Set before the 304 branch so a not-modified response
   // stays consistent with the full response, and it is preserved for HEAD.
-  if (route.assetPath.endsWith('.js')) {
-    const declarationPath = `${route.assetPath.slice(0, -'.js'.length)}.d.ts`;
+  if (assetPath.endsWith('.js')) {
+    const declarationPath = `${assetPath.slice(0, -'.js'.length)}.d.ts`;
     if (metadata.files.has(declarationPath)) {
       headers.set(
         'X-TypeScript-Types',

--- a/packages/cdn/worker/queries.ts
+++ b/packages/cdn/worker/queries.ts
@@ -40,10 +40,13 @@ export function parseRoute(pathname: string): ParsedRoute {
     throw new RequestValidationError('Unknown CDN package.', 404);
   }
 
-  // A versionless package segment (e.g. /ui/autoload.js) resolves to `latest`, which redirects to
-  // the exact version like the /ui@latest/ alias. For js-toolkit `latest` never resolves, so a
-  // versionless js-toolkit request is a 404 — js-toolkit is exact-version only.
-  const requestedVersion = separator === -1 ? 'latest' : packageSegment.slice(separator + 1);
+  // A versionless package segment (e.g. `/ui/Action`, `/js-toolkit/utils`) has no `@version`; the
+  // caller resolves it the same way a bare package root does (via `resolveBareRoot`) so it works for
+  // every package — `ui`/`ui-mapbox` follow their `latest` tag and the tagless `js-toolkit` its
+  // highest release — then redirects to the resolved exact version. `requestedVersion` stays `latest`
+  // so the request always classifies as mutable and canonicalizes to that redirect.
+  const versionless = separator === -1;
+  const requestedVersion = versionless ? 'latest' : packageSegment.slice(separator + 1);
   if (!requestedVersion || !VERSION_TOKEN_PATTERN.test(requestedVersion)) {
     throw new RequestValidationError('The CDN version is malformed.');
   }
@@ -58,6 +61,7 @@ export function parseRoute(pathname: string): ParsedRoute {
   return {
     packageName: packageName as PackageName,
     requestedVersion,
+    versionless,
     assetPath: assetSegments.join('/'),
   };
 }

--- a/packages/cdn/worker/types.ts
+++ b/packages/cdn/worker/types.ts
@@ -89,6 +89,11 @@ export type ExactVersion =
 export interface ParsedRoute {
   packageName: PackageName;
   requestedVersion: string;
+  // True when the package segment carried no `@version` (e.g. `/ui/Action`). A versionless request
+  // resolves its version the same way a bare package root does — via `resolveBareRoot` — so it works
+  // for every package including the tagless `js-toolkit`, then redirects to the resolved exact
+  // version. `requestedVersion` stays `latest` so the request always canonicalizes to a redirect.
+  versionless: boolean;
   assetPath: string;
 }
 

--- a/packages/docs/guide/browser-cdn/index.md
+++ b/packages/docs/guide/browser-cdn/index.md
@@ -101,6 +101,18 @@ Individual components are importable by a subpath that mirrors the npm subpath e
 import { Action } from 'https://cdn.studiometa.dev/ui@1.9.0/Action.js';
 ```
 
+Both the `.js` extension and the version are optional on a subpath, and the two shortenings combine. A request that omits the extension is resolved against the release's own output inventory and redirected (307) to the canonical asset — `/ui@1.9.0/Action` to `/ui@1.9.0/Action.js`, and a directory-style subpath such as `/js-toolkit@3.8.0/utils` to its `/utils/index.js` barrel. A request that omits the version resolves it the same way a [bare root](#bare-root-redirects) does — `ui`/`ui-mapbox` follow their `latest` tag, `js-toolkit` its highest release — so `/ui/Action` lands on `/ui@<latest>/Action.js` in a single hop. Pin an exact, extensioned URL in production to skip the redirect; the shortened forms are conveniences for authoring and quick experiments:
+
+```js
+// Extensionless: redirects to /ui@1.9.0/Action.js
+import { Action } from 'https://cdn.studiometa.dev/ui@1.9.0/Action';
+
+// Versionless + extensionless: redirects to /ui@<latest>/Action.js
+import { Action } from 'https://cdn.studiometa.dev/ui/Action';
+```
+
+This resolution is generic and driven by each release's published output map, so it works identically for every package — `ui`, `ui-mapbox`, `js-toolkit`, and any future one — with no per-package special-casing. A subpath that matches no output (directly, as `<path>.js`, or as `<path>/index.js`) is a `404`.
+
 The `@studiometa/ui-mapbox` components live in their own first-class tree at `/ui-mapbox@<version>/`, versioned in lockstep with `@studiometa/ui` (the two trees always share the same version). They follow the same subpath convention as `@studiometa/ui`, and the whole surface is importable from the ui-mapbox barrel (provide `mapbox-gl` yourself, see [Mapbox integration](#mapbox-integration)):
 
 ```js
@@ -113,10 +125,17 @@ import { MapboxMap, StoreLocator } from 'https://cdn.studiometa.dev/ui-mapbox@1.
 
 The ui-mapbox tree resolves versions, aliases (`ui-mapbox@1`, `ui-mapbox@latest`), and preview channels (`ui-mapbox@next`/`ui-mapbox@main`) exactly like the ui tree. Because both trees share the single externalized js-toolkit runtime, autoloaded and manually-imported Mapbox components interoperate with the rest of `@studiometa/ui` on one page.
 
-The `@studiometa/js-toolkit` runtime the components build on ships as its own exact-versioned barrel:
+The `@studiometa/js-toolkit` runtime the components build on ships as its own barrel, and its subpaths follow the same versionless and extensionless shortenings (a versionless js-toolkit request resolves to its highest published release, since js-toolkit carries no `latest` tag):
 
 ```js
+// Exact-versioned barrel.
 import { Base, createApp } from 'https://cdn.studiometa.dev/js-toolkit@3.8.0/index.js';
+
+// Directory-style subpath: redirects to /js-toolkit@3.8.0/utils/index.js
+import { isObject } from 'https://cdn.studiometa.dev/js-toolkit@3.8.0/utils';
+
+// Versionless: redirects to /js-toolkit@<highest>/utils/index.js
+import { isObject } from 'https://cdn.studiometa.dev/js-toolkit/utils';
 ```
 
 These entry points are the immutable, versioned assets described under [URL structure and caching](#url-structure-and-caching), so pin an exact version (aliases redirect the same way as `autoload.js`). Use the [Registry](#registry) to discover which components, subpath URLs, and versions a deployment serves. Manual imports do not conflict with the autoloader — a page can either import modules itself or rely on the marked script, but the two runtimes still cannot be mixed on one page (see [Limitations](#limitations)).
@@ -217,6 +236,20 @@ A bare package root — the package name with no version and no file — redirec
 | `/js-toolkit` | `/js-toolkit@<highest>/index.js` | Shortest js-toolkit barrel URL |
 
 `/ui` and `/ui-mapbox` follow their `latest` stable tag to the `index.js` barrel — the natural landing now that the autoloader is just another export of the ui tree (reach it explicitly at `/ui@<latest>/autoload.js`). `/js-toolkit` follows its highest published release to `index.js` (js-toolkit is exact-version only, so this bare root is its only moving pointer). All resolve to the immutable target the [Registry](#registry) reports under `current`.
+
+#### Versionless and extensionless subpaths
+
+A subpath may drop the version, the `.js` extension, or both — the Worker resolves each independently and redirects (307, same short cache) to the canonical immutable asset:
+
+| Request                   | Redirects to                           | Resolution                                      |
+| ------------------------- | -------------------------------------- | ----------------------------------------------- |
+| `/ui@1.9.0/Action`        | `/ui@1.9.0/Action.js`                  | Extensionless output lookup (`<path>.js`)       |
+| `/js-toolkit@3.8.0/utils` | `/js-toolkit@3.8.0/utils/index.js`     | Extensionless output lookup (`<path>/index.js`) |
+| `/ui/Action`              | `/ui@<latest>/Action.js`               | Versionless (bare-root ladder) + extensionless  |
+| `/ui-mapbox/MapboxMap`    | `/ui-mapbox@<latest>/MapboxMap.js`     | Versionless + extensionless                     |
+| `/js-toolkit/utils`       | `/js-toolkit@<highest>/utils/index.js` | Versionless + extensionless                     |
+
+A versionless subpath resolves its version exactly like the bare root of the same package (`ui`/`ui-mapbox` by `latest`, `js-toolkit` by highest release). The extensionless step is driven by the release's own published output map: the requested path is served as-is when it names an output, otherwise `<path>.js` is tried, then `<path>/index.js`, otherwise the request is a `404`. Both steps are generic across every package and any future one — there is no per-package or per-component list. Pin an exact, extensioned URL in production to avoid the redirect hop; the exact-version, extensioned `.js` and `.map` assets are unaffected and served directly.
 
 ### Asset types
 


### PR DESCRIPTION
## Summary

Adds generic versionless + extensionless subpath resolution to the studiometa browser CDN Worker, so a short URL like `/ui/Action` lands on the canonical immutable asset in a single hop. Two additive capabilities, both driven by data the Worker already loads — no changes to `versions.json` shape, dist-tag semantics, or any existing parse invariant. Exact-version and `.js`/`.map` serving stays byte-identical.

### 1. Versionless requests resolve per-package

`parseRoute` now flags a package segment with no `@version` (`/ui/Action`, `/js-toolkit/utils`) as versionless, and the Worker resolves its version the same way a bare package root does — via `resolveBareRoot`:

- `ui` / `ui-mapbox` follow their `latest` tag
- the tagless `js-toolkit` follows its highest published release (it has no `latest` tag, so the old hardcoded `latest` was a guaranteed 404)

Explicit `@latest` / `@<version>` / `@<channel>` resolution is untouched — an explicit `/js-toolkit@latest/…` still 404s.

### 2. Extensionless subpath → asset, from the release `build.json` outputs

When the requested path is not itself a served output, it is mapped against the release's authoritative `build.json` `outputs` set:

- `<assetPath>` is an output → use it
- else `<assetPath>.js` is an output → use it (`Action` → `Action.js`, `autoload` → `autoload.js`)
- else `<assetPath>/index.js` is an output → use it (`utils` → `utils/index.js`)
- else `404`

This is generic: it works for `ui`, `ui-mapbox`, `js-toolkit`, and any future package with **no code change**, because it reads the release's own output inventory rather than any hardcoded list. Mapping applies to both versionless and exact/versioned requests. A single 307 combines version + asset canonicalization.

### Example redirects

| Request | Redirects to |
| --- | --- |
| `/ui/Action` | `/ui@<latest>/Action.js` |
| `/ui-mapbox/MapboxMap` | `/ui-mapbox@<latest>/MapboxMap.js` |
| `/js-toolkit/utils` | `/js-toolkit@<highest>/utils/index.js` |
| `/ui@1.10.0-beta.1/Action` | `/ui@1.10.0-beta.1/Action.js` |

Preserved: exact `/ui@1.10.0-beta.1/Action.js` → 200; bare `/ui` → `/ui@latest/index.js`; `/js-toolkit` → `/js-toolkit@<highest>/index.js`; `/ui/Action.js` (versionless with extension) still redirects to `/ui@<resolved>/Action.js`. Path-safety validation, the `autoload.js?components=` canonicalization, and `.d.ts` / `X-TypeScript-Types` behavior are all unchanged.

## Tests

Extended `packages/cdn/tests/worker/index.test.ts` + `fixtures.ts`:

- versionless extensionless for ui (`/ui/Action` → `/ui@<latest>/Action.js`), ui-mapbox, and js-toolkit (`/js-toolkit/utils` → `/js-toolkit@<highest>/utils/index.js`, resolving to the highest release, not `latest`)
- versioned extensionless (`/ui@1.2.0/Action` → `…/Action.js`, `/js-toolkit@<v>/utils` → `…/utils/index.js`)
- each redirect followed to its 200
- a subpath matching no output 404s (versionless and versioned)
- updated the js-toolkit exact-only test: an explicit `@latest`/alias/channel still 404s, while the versionless default now resolves to the highest release
- existing exact / `.js` / bare-root / `.d.ts` cases unchanged

## Docs

Updated `packages/docs/guide/browser-cdn/index.md` (Manual imports + version-resolution sections) to document optional versions and optional `.js` extensions on subpaths across all packages, the build.json-driven output lookup, and a redirect table.

## Quality gates

- `npx vitest run --root packages/cdn` — 151 passed
- `npm run test` — 827 passed
- `npm run lint` — 0 errors
- `npm run cdn:build` — clean
- `npx prettier --check` on changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)