### PR TITLE
Redirect a package root with a ref to its barrel (/ui@next → /ui@<ref>/index.js)

### DIFF
--- a/packages/cdn/tests/worker/index.test.ts
+++ b/packages/cdn/tests/worker/index.test.ts
@@ -338,6 +338,92 @@ describe('CDN Worker bare package roots', () => {
   });
 });
 
+describe('CDN Worker package roots with a ref', () => {
+  it.each([
+    ['/ui@2.0.0', '2.0.0'],
+    ['/ui@2.0.0-beta.1', '2.0.0-beta.1'],
+    ['/ui@latest', '2.0.0'],
+    ['/ui@1', '1.10.0'],
+    ['/ui@next', 'main-fedcba9'],
+    ['/ui@main', 'main-fedcba9'],
+  ])('redirects a ref-carrying ui root %s to its barrel', async (path, exact) => {
+    const response = await request(path);
+    expect(response.status).toBe(307);
+    expect(response.headers.get('Location')).toBe(`${origin}/ui@${exact}/index.js`);
+    expect(response.headers.get('Cache-Control')).toBe(MUTABLE_CACHE_CONTROL);
+    expectCrossOriginHeaders(response);
+  });
+
+  it.each([
+    ['/ui@2.0.0/', '2.0.0'],
+    ['/ui@next/', 'main-fedcba9'],
+  ])('redirects a trailing-slash ref-carrying root %s to its barrel', async (path, exact) => {
+    const response = await request(path);
+    expect(response.status).toBe(307);
+    expect(response.headers.get('Location')).toBe(`${origin}/ui@${exact}/index.js`);
+    expect(response.headers.get('Cache-Control')).toBe(MUTABLE_CACHE_CONTROL);
+  });
+
+  it('resolves the ref-carrying redirect target to a served barrel', async () => {
+    const response = await request('/ui@next');
+    const served = await fetch(new Request(response.headers.get('Location') as string), {
+      ASSETS: fixture.bucket,
+    });
+    expect(served.status).toBe(200);
+    expect(served.headers.get('Content-Type')).toBe('text/javascript; charset=utf-8');
+    expect(await served.text()).toBe(fixture.files['index.js']);
+  });
+
+  it('resolves a ref-carrying ui-mapbox root exactly like ui', async () => {
+    const latest = await request('/ui-mapbox@latest');
+    expect(latest.status).toBe(307);
+    expect(latest.headers.get('Location')).toBe(`${origin}/ui-mapbox@2.0.0/index.js`);
+
+    const channel = await request('/ui-mapbox@main');
+    expect(channel.status).toBe(307);
+    expect(channel.headers.get('Location')).toBe(`${origin}/ui-mapbox@main-fedcba9/index.js`);
+  });
+
+  it('resolves a ref-carrying js-toolkit root by exact semver only', async () => {
+    const exact = await request(`/js-toolkit@${fixture.jsToolkitVersion}`);
+    expect(exact.status).toBe(307);
+    expect(exact.headers.get('Location')).toBe(
+      `${origin}/js-toolkit@${fixture.jsToolkitVersion}/index.js`,
+    );
+    expect(exact.headers.get('Cache-Control')).toBe(MUTABLE_CACHE_CONTROL);
+  });
+
+  it('404s a ref that resolves to nothing', async () => {
+    // js-toolkit has no channels or dist-tags, and 9.9.9 is unpublished for ui.
+    expect((await request('/js-toolkit@main')).status).toBe(404);
+    expect((await request('/js-toolkit@latest')).status).toBe(404);
+    expect((await request('/ui@9.9.9')).status).toBe(404);
+    expect((await request('/ui-mapbox@9.9.9')).status).toBe(404);
+  });
+
+  it('404s an explicit @latest root when latest is unset', async () => {
+    const original = fixture.bucket.objects.get('versions.json') as NonNullable<
+      ReturnType<typeof fixture.bucket.objects.get>
+    >;
+    fixture.bucket.put(
+      'versions.json',
+      JSON.stringify({
+        schemaVersion: 2,
+        packages: {
+          ui: { releases: ['1.0.0'], channels: [], distTags: {} },
+          'ui-mapbox': { releases: [], channels: [], distTags: {} },
+          'js-toolkit': { releases: [] },
+        },
+      }),
+    );
+    // With no `latest` tag, both the explicit `@latest` ref and the bare `/ui` root (which also
+    // follows `latest`) 404, since ui has no latest tag to resolve.
+    expect((await request('/ui@latest')).status).toBe(404);
+    expect((await request('/ui')).status).toBe(404);
+    fixture.bucket.objects.set('versions.json', original);
+  });
+});
+
 describe('CDN Worker eager component queries', () => {
   it('resolves a mutable version and canonicalizes the query in one hop', async () => {
     const response = await request(
@@ -427,7 +513,7 @@ describe('CDN Worker request validation', () => {
     '/ui@1.2.0/chunks/%252e%252e/file.js',
     '/ui@1.2.0/chunks/%ZZ/file.js',
     '/ui@/autoload.js',
-    '/ui@1.2.0/',
+    '/ui@1.2.0/chunks/',
   ])('rejects malformed or traversal path %s', async (path) => {
     expect((await request(path)).status).toBe(400);
   });

--- a/packages/cdn/worker/index.ts
+++ b/packages/cdn/worker/index.ts
@@ -1,4 +1,9 @@
-import { canonicalizeQuery, parseBareRoot, parseRoute, RequestValidationError } from './queries.ts';
+import {
+  canonicalizeQuery,
+  parsePackageRoot,
+  parseRoute,
+  RequestValidationError,
+} from './queries.ts';
 import {
   contentType,
   errorResponse,
@@ -15,6 +20,7 @@ import type {
   ExactVersion,
   IntegrityMetadata,
   PackageName,
+  PackageRoot,
   R2BucketLike,
   R2ObjectBodyLike,
   VersionsIndex,
@@ -313,10 +319,10 @@ async function handleRequest(
     return handleRegistry(request, environment, url.origin, recorder);
   }
 
-  const bareRoot = parseBareRoot(url.pathname);
+  const packageRoot = parsePackageRoot(url.pathname);
   // Validate an asset route up front so a malformed path is rejected before any storage access; a
-  // bare package root skips validation and resolves against the index below.
-  const route = bareRoot === undefined ? parseRoute(url.pathname) : undefined;
+  // package root (bare or ref-carrying) skips validation and resolves against the index below.
+  const route = packageRoot === undefined ? parseRoute(url.pathname) : undefined;
 
   const indexValue = await readJsonObject(environment.ASSETS, 'versions.json');
   if (indexValue === undefined) {
@@ -327,14 +333,24 @@ async function handleRequest(
   const versions = parseVersionsIndex(indexValue);
 
   if (route === undefined) {
-    // A bare package root redirects to its latest usable asset: the `index.js` barrel is now the
-    // natural landing for every package — `/ui` and `/ui-mapbox` to their `latest` stable barrel,
-    // and the tagless `/js-toolkit` to its highest published barrel. Each classifies as a dist-tag
-    // hop — a moving pointer resolved to an exact version.
-    const resolved = resolveBareRoot(versions, bareRoot as PackageName);
-    recorder.versionKind(classifyVersion(resolved ? 'latest' : undefined, resolved));
-    if (!resolved) return errorResponse(404);
-    return redirectResponse(`${url.origin}/${bareRoot}@${resolved.version}/index.js`);
+    // A package root redirects to its `index.js` barrel — the natural landing for every package.
+    const { packageName, ref } = packageRoot as PackageRoot;
+    if (ref === undefined) {
+      // The bare form (`/ui`, `/ui-mapbox`, `/js-toolkit`) follows the package default: `ui` and
+      // `ui-mapbox` their `latest` stable barrel, the tagless `js-toolkit` its highest published
+      // barrel. It classifies as a dist-tag hop — a moving pointer resolved to an exact version.
+      const resolved = resolveBareRoot(versions, packageName);
+      recorder.versionKind(classifyVersion(resolved ? 'latest' : undefined, resolved));
+      if (!resolved) return errorResponse(404);
+      return redirectResponse(`${url.origin}/${packageName}@${resolved.version}/index.js`);
+    }
+    // A ref-carrying root (`/ui@next`, `/ui@1.2.0`, `/ui@main`) resolves exactly like an asset
+    // request's ref — `latest`/`next`/`main`, an exact release or channel, or a major/minor alias —
+    // and 404s when the ref names nothing (e.g. `/js-toolkit@main`, which has no channels).
+    const exact = resolveVersion(versions, packageName, ref);
+    recorder.versionKind(classifyVersion(ref, exact));
+    if (!exact) return errorResponse(404);
+    return redirectResponse(`${url.origin}/${packageName}@${exact.version}/index.js`);
   }
 
   // A versionless request resolves its version the same way a bare package root does, so every

--- a/packages/cdn/worker/queries.ts
+++ b/packages/cdn/worker/queries.ts
@@ -1,4 +1,4 @@
-import type { CanonicalQuery, PackageName, ParsedRoute } from './types.ts';
+import type { CanonicalQuery, PackageName, PackageRoot, ParsedRoute } from './types.ts';
 
 const PACKAGE_NAMES: ReadonlySet<PackageName> = new Set(['ui', 'ui-mapbox', 'js-toolkit']);
 
@@ -66,14 +66,24 @@ export function parseRoute(pathname: string): ParsedRoute {
   };
 }
 
-// A bare package root is the package name alone, with no version and no asset segment: `/ui`,
-// `/ui/`, `/js-toolkit`, `/js-toolkit/`. It redirects to a usable latest asset (resolved by the
-// caller). Anything with a version (`/ui@1.2.0`) or an asset (`/ui/autoload.js`) falls through to
-// `parseRoute`, so this recognizes only the bare name.
-export function parseBareRoot(pathname: string): PackageName | undefined {
-  const name = (pathname.endsWith('/') ? pathname.slice(0, -1) : pathname).slice(1);
-  if (name === '' || name.includes('/')) return undefined;
-  return PACKAGE_NAMES.has(name as PackageName) ? (name as PackageName) : undefined;
+// A package root is a single path segment naming a package, with an optional `@<ref>` and no asset
+// segment: the bare `/ui`, `/ui/`, `/js-toolkit`, and the ref-carrying `/ui@next`, `/ui@1.2.0/`,
+// `/ui@main`. The caller redirects it to the resolved exact version's `index.js` barrel — the bare
+// form via the package default (`resolveBareRoot`), a ref via the full `/ui@<ref>/` semantics
+// (`resolveVersion`). Anything with an asset segment (`/ui/autoload.js`, `/ui@next/Action`) has more
+// than one segment and falls through to `parseRoute`. The ref, when present, is validated with the
+// same token pattern asset routes use; a malformed ref (or a `%`/`\` in it) yields `undefined` so
+// `parseRoute` rejects it consistently.
+export function parsePackageRoot(pathname: string): PackageRoot | undefined {
+  const segment = (pathname.endsWith('/') ? pathname.slice(0, -1) : pathname).slice(1);
+  if (segment === '' || segment.includes('/')) return undefined;
+  const separator = segment.indexOf('@');
+  const packageName = separator === -1 ? segment : segment.slice(0, separator);
+  if (!PACKAGE_NAMES.has(packageName as PackageName)) return undefined;
+  if (separator === -1) return { packageName: packageName as PackageName };
+  const ref = segment.slice(separator + 1);
+  if (!ref || !VERSION_TOKEN_PATTERN.test(ref)) return undefined;
+  return { packageName: packageName as PackageName, ref };
 }
 
 export function canonicalizeQuery(

--- a/packages/cdn/worker/types.ts
+++ b/packages/cdn/worker/types.ts
@@ -97,6 +97,16 @@ export interface ParsedRoute {
   assetPath: string;
 }
 
+export interface PackageRoot {
+  packageName: PackageName;
+  // The optional ref a package-root request carries: `undefined` for the bare form (`/ui`, `/ui/`),
+  // or the `@<ref>` token for `/ui@next`, `/ui@1.2.0`, `/ui@main` (with optional trailing slash and
+  // no asset segment). A bare root follows the package default (`resolveBareRoot`); a ref resolves
+  // with the full `/ui@<ref>/` semantics (`resolveVersion`). Either redirects to that exact
+  // version's `index.js` barrel.
+  ref?: string;
+}
+
 export interface CanonicalQuery {
   components: string[];
   search: string;

--- a/packages/docs/guide/browser-cdn/index.md
+++ b/packages/docs/guide/browser-cdn/index.md
@@ -237,6 +237,18 @@ A bare package root — the package name with no version and no file — redirec
 
 `/ui` and `/ui-mapbox` follow their `latest` stable tag to the `index.js` barrel — the natural landing now that the autoloader is just another export of the ui tree (reach it explicitly at `/ui@<latest>/autoload.js`). `/js-toolkit` follows its highest published release to `index.js` (js-toolkit is exact-version only, so this bare root is its only moving pointer). All resolve to the immutable target the [Registry](#registry) reports under `current`.
 
+A package root may also carry a ref but no file — `/ui@<ref>` (with an optional trailing slash) — and redirects (307, same short cache) to that ref's `index.js` barrel. The ref resolves with the full version-resolution rules above, exactly as a `/ui@<ref>/…` asset request does, so the barrel is reachable by every supported ref shape:
+
+| Package root with ref | Redirects to                 | Resolution                        |
+| --------------------- | ---------------------------- | --------------------------------- |
+| `/ui@1.9.0`           | `/ui@1.9.0/index.js`         | Exact release                     |
+| `/ui@1`               | `/ui@<latest 1.x>/index.js`  | Major alias                       |
+| `/ui@latest`          | `/ui@<latest>/index.js`      | `latest` dist-tag                 |
+| `/ui@next`            | `/ui@<next>/index.js`        | `next` preview channel or release |
+| `/ui@main`            | `/ui@main-<commit>/index.js` | `main` preview channel            |
+
+A ref that resolves to nothing is a `404` — the same outcome as the matching asset request (for example `/js-toolkit@main`, since js-toolkit has no channels, or an unpublished `/ui@9.9.9`).
+
 #### Versionless and extensionless subpaths
 
 A subpath may drop the version, the `.js` extension, or both — the Worker resolves each independently and redirects (307, same short cache) to the canonical immutable asset:


### PR DESCRIPTION
## The bug

A package-root request that carries a version/tag/channel but **no asset path** returned **400 "Invalid CDN request."** instead of redirecting to that ref's barrel:

- `/ui@next`, `/ui@main`, `/ui@1.10.0-beta.1`, `/ui@latest` — and their trailing-slash variants — all 400ed.

The bare root (`/ui`, `/ui/`) already worked via `parseBareRoot` → `resolveBareRoot`, and full asset paths (`/ui@next/Action`) via `parseRoute`. Only the "package + ref, no asset" shape fell through both: `parseBareRoot` returned `undefined` for a segment containing `@`, and `parseRoute` requires an asset segment (`segments.length < 3` → malformed).

## The fix

Make package-root handling accept an **optional ref**.

- **`queries.ts`** — rename `parseBareRoot` → `parsePackageRoot`. It now parses a single-segment path `/<pkg>` or `/<pkg>@<ref>` (optional trailing slash, no asset segment) and returns `{ packageName, ref }` (`ref` undefined for the bare form). The ref is validated with the same `VERSION_TOKEN_PATTERN` asset routes use; a malformed ref (or one containing `%`/`\`) yields `undefined` so `parseRoute` rejects it consistently.
- **`index.ts`** — in the package-root branch:
  - **No ref** (`/ui`) → unchanged `resolveBareRoot` (ui/ui-mapbox → `latest`, js-toolkit → highest).
  - **With ref** (`/ui@next`) → `resolveVersion`, i.e. the full `latest`/`next`/`main`/exact/channel/alias semantics, 404ing when the ref resolves to nothing (`/js-toolkit@main`, `/ui@9.9.9`).
  - Both redirect (307, mutable cache) to `${origin}/${packageName}@${exact.version}/index.js`.
  - Observability preserved: bare form stays a `latest` dist-tag hop; a ref classifies exactly like the matching asset request.
- **`types.ts`** — add the `PackageRoot` interface.

Purely additive routing for the previously-400 shape. Full asset routes, `autoload.js?components=`, bare-root redirects, path-safety validation, and `versions.json`/dist-tag semantics are untouched.

## Tests

Extended `packages/cdn/tests/worker/index.test.ts`: exact/prerelease/`latest`/alias/`next`/`main` roots redirect to their `index.js`; trailing-slash variants; the redirect target actually serves the barrel; ui-mapbox parity; js-toolkit exact-only; 404 for refs that resolve to nothing (`/js-toolkit@main`, `/js-toolkit@latest`, `/ui@9.9.9`) and for `@latest` when `latest` is unset. Updated the malformed-path case (`/ui@1.2.0/` now redirects; `/ui@1.2.0/chunks/` covers the trailing-empty-segment rejection). Documented the shape in the browser-CDN guide's bare-root section.

## Quality gates

- `npx vitest run --root packages/cdn` — 164 passed
- `npm run test` — full suite green (827 passed)
- `npm run lint` — 0 errors
- `npm run cdn:build` — clean
- `npx prettier --check` on changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014FQxYGj2RqgcP8BkubpiNu