### PR TITLE
Pin the playground's ui CDN imports to the exact version (fix editor types)

### DIFF
--- a/packages/playground/meta.config.js
+++ b/packages/playground/meta.config.js
@@ -2,6 +2,12 @@ import { resolve } from 'node:path';
 import { playgroundPreset as playground, defineWebpackConfig } from '@studiometa/playground/preset';
 
 const CDN_BASE_URL = 'https://cdn.studiometa.dev';
+// The exact published version of this repo (e.g. `1.10.0-beta.1`). ui/ui-mapbox are pinned to it
+// on the CDN rather than the mutable `@main` alias: `@main` 307-redirects to the immutable
+// `main-<sha>` channel, and modern-monaco's TypeScript LSP cannot resolve `.d.ts` through a
+// redirect (its `resolveModuleNameLiterals` skips the `x-typescript-types` header on a redirected
+// response), so an exact, non-redirecting URL is required for editor autocomplete to work.
+const UI_VERSION = process.env.npm_package_version;
 
 export default defineWebpackConfig({
   presets: [
@@ -41,11 +47,11 @@ export default defineWebpackConfig({
       importMap: {
         '@studiometa/js-toolkit': `${CDN_BASE_URL}/js-toolkit@3.8.0/index.js`,
         '@studiometa/js-toolkit/utils': `${CDN_BASE_URL}/js-toolkit@3.8.0/utils/index.js`,
-        // `@main` 307-redirects to the current immutable `main-<sha>` channel.
-        // Switch to `@latest` (or a pinned version) once a stable release tag is
-        // cut — `@latest` currently 404s because no stable CDN release exists yet.
-        '@studiometa/ui': `${CDN_BASE_URL}/ui@main/index.js`,
-        '@studiometa/ui-mapbox': `${CDN_BASE_URL}/ui-mapbox@main/index.js`,
+        // Pinned to the exact repo version (non-redirecting) so modern-monaco's LSP resolves
+        // their `.d.ts`; it tracks releases as the version bumps land, and that version must be
+        // published to the CDN (it is, via the release `cdn_release` job).
+        '@studiometa/ui': `${CDN_BASE_URL}/ui@${UI_VERSION}/index.js`,
+        '@studiometa/ui-mapbox': `${CDN_BASE_URL}/ui-mapbox@${UI_VERSION}/index.js`,
       },
       defaults: {
         html: `{% html_element 'span' with { class: 'dark:text-white font-bold border-b-2 border-current' } %}


### PR DESCRIPTION
## Summary

Fixes TypeScript autocomplete in the playground for `@studiometa/ui` / `@studiometa/ui-mapbox`, which regressed when they moved to the CDN under the mutable `@main` alias.

## Root cause
`modern-monaco`'s TS LSP **cannot resolve a `.d.ts` through an HTTP redirect**. In `resolveModuleNameLiterals`, a redirect-following `fetch` sets `res.redirected === true`, and the worker takes an early branch that only records the redirect URL — it never reads the `x-typescript-types` header or fetches the `.d.ts`. `@main` 307-redirects to the immutable `main-<sha>` channel, so the editor reported **TS 7016** ("`https://cdn.studiometa.dev/ui@main/index.js` implicitly has an 'any' type"). js-toolkit was unaffected because it's pinned to exact `@3.8.0` (no redirect). Confirmed with a browser repro + the exact upstream code (identical in `modern-monaco@0.4.2`).

## Fix
Pin `@studiometa/ui` and `@studiometa/ui-mapbox` to the **exact repo version** (`process.env.npm_package_version`, currently `1.10.0-beta.1`) — an immutable, **non-redirecting** URL that carries the types header on the direct `200`. It tracks releases as version bumps land, and that version is always published to the CDN by the release `cdn_release` job. js-toolkit stays pinned to `@3.8.0` (must match the URL the ui build bakes in).

Verified: `npm run play:build` emits the import map with `cdn.studiometa.dev/ui@1.10.0-beta.1/index.js` and `…/ui-mapbox@1.10.0-beta.1/index.js`, both direct `200`s with `X-TypeScript-Types`.

## Note
The underlying redirect-vs-types bug is upstream in `modern-monaco`; worth an issue/PR there. If fixed upstream, the playground could move back to rolling `@main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)