### PR TITLE
Serve extensionless subpaths directly at immutable refs

### DIFF
--- a/packages/cdn/tests/worker/index.test.ts
+++ b/packages/cdn/tests/worker/index.test.ts
@@ -243,23 +243,38 @@ describe('CDN Worker extensionless subpath resolution', () => {
     expect(served.headers.get('Content-Type')).toBe('text/javascript; charset=utf-8');
   });
 
-  it('maps an exact-versioned extensionless request to its .js output', async () => {
+  it('serves an exact-versioned extensionless request directly as its .js output', async () => {
     const response = await request('/ui@1.2.0/Action');
-    expect(response.status).toBe(307);
-    expect(response.headers.get('Location')).toBe(`${origin}/ui@1.2.0/Action.js`);
-
-    const served = await fetch(new Request(response.headers.get('Location') as string), {
-      ASSETS: fixture.bucket,
-    });
-    expect(served.status).toBe(200);
-    expect(served.headers.get('Content-Type')).toBe('text/javascript; charset=utf-8');
+    // An immutable ref (exact semver) resolves its extensionless subpath to `Action.js` and serves it
+    // directly — no redirect — so a cross-origin TS language server reads the types header inline.
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Content-Type')).toBe('text/javascript; charset=utf-8');
+    expect(response.headers.get('Cache-Control')).toBe(IMMUTABLE_CACHE_CONTROL);
+    expect(await response.text()).toBe(fixture.files['Action.js']);
+    expect(response.headers.get('X-TypeScript-Types')).toBe(`${origin}/ui@1.2.0/Action.d.ts`);
+    expect(response.headers.get('Access-Control-Expose-Headers')).toContain('X-TypeScript-Types');
+    expectCrossOriginHeaders(response);
   });
 
-  it('maps an exact-versioned extensionless js-toolkit subpath to /index.js', async () => {
+  it('serves an exact-versioned extensionless js-toolkit subpath directly as /index.js', async () => {
     const response = await request(`/js-toolkit@${fixture.jsToolkitVersion}/utils`);
-    expect(response.status).toBe(307);
-    expect(response.headers.get('Location')).toBe(
-      `${origin}/js-toolkit@${fixture.jsToolkitVersion}/utils/index.js`,
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Content-Type')).toBe('text/javascript; charset=utf-8');
+    expect(response.headers.get('Cache-Control')).toBe(IMMUTABLE_CACHE_CONTROL);
+    expect(response.headers.get('X-TypeScript-Types')).toBe(
+      `${origin}/js-toolkit@${fixture.jsToolkitVersion}/utils/index.d.ts`,
+    );
+    expect(response.headers.get('Access-Control-Expose-Headers')).toContain('X-TypeScript-Types');
+  });
+
+  it('serves an immutable channel extensionless subpath directly as its .js output', async () => {
+    const response = await request('/ui@main-abcdef1/Action');
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Content-Type')).toBe('text/javascript; charset=utf-8');
+    expect(response.headers.get('Cache-Control')).toBe(IMMUTABLE_CACHE_CONTROL);
+    expect(await response.text()).toBe(fixture.files['Action.js']);
+    expect(response.headers.get('X-TypeScript-Types')).toBe(
+      `${origin}/ui@main-abcdef1/Action.d.ts`,
     );
   });
 

--- a/packages/cdn/worker/index.ts
+++ b/packages/cdn/worker/index.ts
@@ -376,14 +376,20 @@ async function handleRequest(
 
   const query = canonicalizeQuery(url, assetPath, new Set(Object.keys(metadata.build.components)));
   recorder.componentCount(query.components.length);
-  // Redirect to the canonical location when the version is mutable (versionless or a moving tag), the
-  // extensionless path was mapped to a concrete output, or the query is not yet canonical. A single
-  // hop covers all three at once (e.g. `/ui/Action` -> `/ui@<latest>/Action.js`).
-  if (
-    isMutableVersion(route.requestedVersion, exact) ||
-    assetPath !== route.assetPath ||
-    !query.canonical
-  ) {
+  // Redirect to canonicalize a request; otherwise serve it directly. A mutable ref (versionless, or a
+  // moving tag like `latest`/`next`/`main`) always redirects to its resolved exact location, and a
+  // non-canonical query always redirects to canonicalize it — a single hop covers both at once (e.g.
+  // `/ui/Action` -> `/ui@<latest>/Action.js`). An immutable ref (an exact semver, or an immutable
+  // `main-<sha>`/`next-<sha>` channel — anything `isMutableVersion` rules out) is served directly:
+  // its extensionless subpath (`Action`, `utils`) streams the resolved `.js`/`index.js` output as an
+  // accepted alias of the canonical `.js` URL, without a redirect. This is safe because such a ref has
+  // `requested === resolved.version`, so its bytes are immutable by construction (the store marks
+  // `releases/*` and `channels/*` `immutable` and never overwrites them); a new version or ref publish
+  // only ever mints new immutable paths and re-points the mutable tags, which still redirect. Serving
+  // the extensionless alias directly also lets a cross-origin TypeScript language server read the
+  // `X-TypeScript-Types` header off the response without following a 307 (modern-monaco's LSP stops at
+  // redirects). `.js` (canonical) URLs are unchanged.
+  if (isMutableVersion(route.requestedVersion, exact) || !query.canonical) {
     return redirectResponse(
       canonicalLocation(url, route.packageName, exact.version, assetPath, query.search),
     );


### PR DESCRIPTION
## What

Removes the redirect gate term that forced an extensionless subpath (`Action`, `utils`) to 307-redirect to its canonical `.js`/`index.js` output. At an **immutable** ref, the extensionless subpath is now served **directly** (HTTP 200) as the resolved output; it becomes an accepted alias of the canonical `.js` URL serving the same immutable bytes.

The gate now redirects only for:
- a **mutable** ref — a versionless root or a moving dist-tag (`@latest`/`@next`/`@main`) — which still redirects to its resolved exact location, or
- a **non-canonical query**, which still redirects to canonicalize it.

An immutable ref is an exact semver version or an immutable `main-<sha>`/`next-<sha>` channel — anything `isMutableVersion` rules out (`requested === resolved.version`). Canonical `.js` URLs are unchanged.

## Why

Two benefits:

- **One fewer round trip** for extensionless imports pinned to an exact ref.
- **Types resolve without a redirect hop.** The served response already carries `X-TypeScript-Types` (a same-origin `.d.ts` URL) plus `Access-Control-Expose-Headers`. Cross-origin TypeScript language servers — notably modern-monaco's LSP, which stops at 307s — can now read the types header directly off the extensionless subpath response. This upgrades the #596 subpath glob from runtime-only to **fully typed** for exact-pinned specifiers.

## Why there is no cache risk

The direct-serve path is reached only when `requested === resolved.version`, so the URL names its own immutable identity. Immutability is structural: the object store gives both `releases/*` and `channels/*` `public, max-age=31536000, immutable`, and publication never overwrites an already-populated immutable prefix. A new version/commit/ref publish only ever mints **new** immutable paths and re-points the mutable tags — and those tags still redirect with their short TTL. A URL that direct-serves can never change bytes, so caching it for a year is correct.

## Tests

- Rewrote the two exact-version extensionless worker tests (`/ui@1.2.0/Action`, `/js-toolkit@<v>/utils`) to expect a direct 200 with a JavaScript `Content-Type`, immutable `Cache-Control`, the module body, and `X-TypeScript-Types` + `Access-Control-Expose-Headers` pointing at the sibling `.d.ts`.
- Added a coverage test that an immutable `main-<sha>` channel extensionless subpath is served directly too.
- Mutable-ref assertions (versionless roots, `@latest`/`@next`/`@main`, aliases, package roots) still expect 307 — untouched. The observability dist-tag redirect test is unaffected (its ref stays mutable).

Worker unit tests (112), full CDN vitest suite (165), and the CDN Playwright browser suite (10) all pass; root `npm run lint` (ESLint + type check + prettier) is clean for the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014FQxYGj2RqgcP8BkubpiNu