### PR TITLE
Add per-package side-effect autoload entries to ui-autoload

### DIFF
--- a/packages/tests/autoload/runtime.spec.ts
+++ b/packages/tests/autoload/runtime.spec.ts
@@ -1,0 +1,273 @@
+import { Base, getInstances } from '@studiometa/js-toolkit';
+import {
+  readEagerTokens,
+  registerManifest,
+  type AutoloadRuntime,
+  type ComponentManifest,
+  type ComponentManifestEntry,
+  type LoaderDependencies,
+} from '@studiometa/ui-autoload';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const RUNTIME_KEY = Symbol.for('@studiometa/ui-autoload/runtime');
+
+class First extends Base {
+  static config = { name: 'First' };
+}
+class Second extends Base {
+  static config = { name: 'Second' };
+}
+
+function entry(
+  token: string,
+  overrides: Partial<ComponentManifestEntry> = {},
+): ComponentManifestEntry {
+  return {
+    token,
+    packageName: '@studiometa/ui',
+    subpath: token,
+    exportName: token,
+    strategy: 'eager',
+    group: 'test',
+    load: vi.fn(async () => First),
+    ...overrides,
+  };
+}
+
+/** A MutationObserver mock that counts constructions so we can assert how many loaders started. */
+class CountingMutationObserver {
+  static instances: CountingMutationObserver[] = [];
+
+  constructor(_callback: MutationCallback) {
+    CountingMutationObserver.instances.push(this);
+  }
+
+  observe(): void {}
+  disconnect(): void {}
+  takeRecords(): MutationRecord[] {
+    return [];
+  }
+}
+
+function dependencies(overrides: Partial<LoaderDependencies> = {}): Partial<LoaderDependencies> {
+  return {
+    registerComponent: vi.fn(async () => []),
+    console: { warn: vi.fn(), error: vi.fn() },
+    MutationObserver: CountingMutationObserver as unknown as typeof MutationObserver,
+    IntersectionObserver: undefined,
+    ...overrides,
+  };
+}
+
+/** Build a fresh, isolated HTML document with the given body markup and eager `<meta>` contents. */
+function createDocument(bodyHtml = '', eagerContents: string[] = []): Document {
+  const documentObject = document.implementation.createHTMLDocument('runtime test');
+  for (const content of eagerContents) {
+    const meta = documentObject.createElement('meta');
+    meta.name = 'studiometa-ui:eager';
+    meta.content = content;
+    documentObject.head.append(meta);
+  }
+  documentObject.body.innerHTML = bodyHtml;
+  return documentObject;
+}
+
+async function settle(): Promise<void> {
+  for (let index = 0; index < 8; index += 1) {
+    await Promise.resolve();
+  }
+}
+
+/** Flush js-toolkit's macrotask mount queue on top of the microtask queue. */
+async function settleToolkit(): Promise<void> {
+  for (let index = 0; index < 8; index += 1) {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+  await settle();
+}
+
+afterEach(() => {
+  const host = globalThis as unknown as Record<PropertyKey, unknown>;
+  const runtime = host[RUNTIME_KEY] as AutoloadRuntime | undefined;
+  runtime?.handle?.stop();
+  delete host[RUNTIME_KEY];
+  // Reset js-toolkit's global instance registry so real `registerComponent` tests stay isolated
+  // from each other and from retries (the storage lazily re-creates on next access).
+  delete host.__JS_TOOLKIT_INSTANCES__;
+  delete host.__JS_TOOLKIT_ELEMENTS__;
+  document.body.innerHTML = '';
+  document.head.innerHTML = '';
+  CountingMutationObserver.instances = [];
+  vi.restoreAllMocks();
+});
+
+describe('readEagerTokens', () => {
+  it('returns an empty list when no eager meta is present', () => {
+    expect(readEagerTokens(createDocument())).toEqual([]);
+  });
+
+  it('splits, trims, dedupes and drops empty tokens from a single meta', () => {
+    const documentObject = createDocument('', ['  Accordion , Action ,, Accordion ,Modal ']);
+    expect(readEagerTokens(documentObject)).toEqual(['Accordion', 'Action', 'Modal']);
+  });
+
+  it('concatenates the content of several eager metas in document order', () => {
+    const documentObject = createDocument('', ['Accordion, Action', 'Action, Modal']);
+    expect(readEagerTokens(documentObject)).toEqual(['Accordion', 'Action', 'Modal']);
+  });
+});
+
+describe('registerManifest', () => {
+  it('coalesces manifests registered synchronously into a single loader over the composed set', async () => {
+    const firstLoad = vi.fn(async () => First);
+    const secondLoad = vi.fn(async () => Second);
+    const register = vi.fn(async () => []);
+    const globalObject = {};
+    const documentObject = createDocument(`
+      <div data-component="First"></div>
+      <div data-component="Second"></div>
+    `);
+    const deps = dependencies({ registerComponent: register });
+
+    // Mirror `import './ui'; import './ui-mapbox'` at the top of a module: both manifests register
+    // synchronously, before any microtask flushes.
+    const runtimeA = registerManifest(
+      { First: entry('First', { load: firstLoad }) },
+      { document: documentObject, globalObject, version: 'test', dependencies: deps },
+    );
+    const runtimeB = registerManifest(
+      { Second: entry('Second', { load: secondLoad }) },
+      { document: documentObject, globalObject, version: 'test', dependencies: deps },
+    );
+    await settle();
+
+    // A single shared runtime, a single loader (one MutationObserver), both tokens discovered.
+    expect(runtimeB).toBe(runtimeA);
+    expect(CountingMutationObserver.instances).toHaveLength(1);
+    expect(firstLoad).toHaveBeenCalledOnce();
+    expect(secondLoad).toHaveBeenCalledOnce();
+    expect(register).toHaveBeenCalledWith(First, 'First');
+    expect(register).toHaveBeenCalledWith(Second, 'Second');
+  });
+
+  it('passes the eager <meta> tokens through to the loader as forced-eager components', async () => {
+    const load = vi.fn(async () => First);
+    const globalObject = {};
+    const documentObject = createDocument('<div data-component="Deferred"></div>', ['Deferred']);
+
+    registerManifest(
+      { Deferred: entry('Deferred', { strategy: 'visible', load }) },
+      { document: documentObject, globalObject, version: 'test', dependencies: dependencies() },
+    );
+    await settle();
+
+    // The `visible` component loaded immediately because the eager meta forced it, with no
+    // IntersectionObserver ever created.
+    expect(load).toHaveBeenCalledOnce();
+  });
+
+  it('starts a fresh loader for a manifest registered after the first flush', async () => {
+    const firstLoad = vi.fn(async () => First);
+    const secondLoad = vi.fn(async () => Second);
+    const globalObject = {};
+    const documentObject = createDocument(`
+      <div data-component="First"></div>
+      <div data-component="Second"></div>
+    `);
+    const deps = dependencies();
+
+    registerManifest(
+      { First: entry('First', { load: firstLoad }) },
+      { document: documentObject, globalObject, version: 'test', dependencies: deps },
+    );
+    await settle();
+    expect(CountingMutationObserver.instances).toHaveLength(1);
+    expect(firstLoad).toHaveBeenCalledOnce();
+    expect(secondLoad).not.toHaveBeenCalled();
+
+    // Late registration (a separate tick): not dropped, it triggers a fresh start.
+    registerManifest(
+      { Second: entry('Second', { load: secondLoad }) },
+      { document: documentObject, globalObject, version: 'test', dependencies: deps },
+    );
+    await settle();
+    expect(CountingMutationObserver.instances).toHaveLength(2);
+    expect(secondLoad).toHaveBeenCalledOnce();
+  });
+
+  it('does not double-mount already-mounted components when it restarts (real registerComponent)', async () => {
+    document.body.innerHTML = `
+      <div data-component="First"></div>
+      <div data-component="Second"></div>
+    `;
+    const globalObject = {};
+    const manifest: ComponentManifest = {
+      First: entry('First', { load: async () => First }),
+      Second: entry('Second', { load: async () => Second }),
+    };
+
+    registerManifest(manifest, { globalObject, version: 'test' });
+    await settleToolkit();
+    expect([...getInstances(First)]).toHaveLength(1);
+    expect([...getInstances(Second)]).toHaveLength(1);
+
+    // Re-registering forces a fresh start over the accumulated set. The previous loader is stopped
+    // and a new one re-scans the DOM; the already-mounted instances must be reused, not duplicated.
+    registerManifest(manifest, { globalObject, version: 'test' });
+    await settleToolkit();
+
+    expect([...getInstances(First)]).toHaveLength(1);
+    expect([...getInstances(Second)]).toHaveLength(1);
+  });
+
+  it('reuses the runtime for a matching version and warns + no-ops on a conflicting one', async () => {
+    const globalObject = {};
+    const logger = { warn: vi.fn() };
+    const documentObject = createDocument('<div data-component="First"></div>');
+    const baseOptions = {
+      document: documentObject,
+      globalObject,
+      console: logger,
+      dependencies: dependencies(),
+    };
+
+    const first = registerManifest({ First: entry('First') }, { ...baseOptions, version: '1.0.0' });
+    const repeated = registerManifest(
+      { First: entry('First') },
+      { ...baseOptions, version: '1.0.0' },
+    );
+    const conflicting = registerManifest(
+      { First: entry('First') },
+      { ...baseOptions, version: '2.0.0' },
+    );
+    await settle();
+
+    expect(repeated).toBe(first);
+    expect(conflicting).toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledWith(
+      '[@studiometa/ui-autoload] A conflicting runtime (version 1.0.0) is already active; version 2.0.0 was ignored.',
+    );
+    // Only one loader was ever created despite the three calls.
+    expect(CountingMutationObserver.instances).toHaveLength(1);
+  });
+
+  it('is inert until called: importing the package registers nothing on its own', async () => {
+    const register = vi.fn(async () => []);
+    const documentObject = createDocument('<div data-component="First"></div>');
+    const manifest: ComponentManifest = { First: entry('First') };
+
+    // Simply having a manifest in hand does nothing.
+    await settle();
+    expect(register).not.toHaveBeenCalled();
+
+    // Only calling registerManifest activates discovery.
+    registerManifest(manifest, {
+      document: documentObject,
+      globalObject: {},
+      version: 'test',
+      dependencies: dependencies({ registerComponent: register }),
+    });
+    await settle();
+    expect(register).toHaveBeenCalledWith(First, 'First');
+  });
+});

--- a/packages/ui-autoload/index.ts
+++ b/packages/ui-autoload/index.ts
@@ -20,3 +20,9 @@ export {
   type AutoloadOptions,
   type AutoloadHandle,
 } from './autoload.js';
+export {
+  registerManifest,
+  readEagerTokens,
+  type AutoloadRuntime,
+  type RegisterManifestOptions,
+} from './runtime.js';

--- a/packages/ui-autoload/package.json
+++ b/packages/ui-autoload/package.json
@@ -6,12 +6,21 @@
     "access": "public"
   },
   "type": "module",
-  "sideEffects": false,
+  "sideEffects": [
+    "./ui.ts",
+    "./ui.js",
+    "./ui-mapbox.ts",
+    "./ui-mapbox.js"
+  ],
   "main": "index.ts",
   "types": "index.d.ts",
   "exports": {
     ".": "./index.ts",
     "./package.json": "./package.json",
+    "./ui": "./ui.ts",
+    "./ui.js": "./ui.ts",
+    "./ui-mapbox": "./ui-mapbox.ts",
+    "./ui-mapbox.js": "./ui-mapbox.ts",
     "./*.js": "./*.ts",
     "./*": "./*.ts"
   },

--- a/packages/ui-autoload/runtime.ts
+++ b/packages/ui-autoload/runtime.ts
@@ -1,0 +1,194 @@
+import { autoload, type AutoloadHandle } from './autoload.js';
+import type { LoaderDependencies } from './loader.js';
+import type { ComponentManifest } from './types.js';
+import packageMetadata from './package.json' with { type: 'json' };
+
+/** The identity every copy of this package advertises on the shared global runtime. */
+const PACKAGE_NAME = '@studiometa/ui-autoload';
+/**
+ * The `globalThis` key the shared runtime is stored under. `Symbol.for` guarantees the same symbol
+ * across module graphs and bundle copies, so multiple side-effect entries — even from duplicated
+ * copies of this package — coordinate through a single runtime object.
+ */
+const RUNTIME_KEY = Symbol.for('@studiometa/ui-autoload/runtime');
+/** The prefix prepended to every diagnostic message emitted by the shared runtime. */
+const DIAGNOSTIC_PREFIX = '[@studiometa/ui-autoload]';
+/** The `<meta>` element carrying the comma-separated list of tokens to mount eagerly. */
+const EAGER_META_SELECTOR = 'meta[name="studiometa-ui:eager"]';
+
+/** Options accepted by {@link registerManifest}; every seam is optional and testability-oriented. */
+export interface RegisterManifestOptions {
+  /** The document to scan and to read the eager `<meta>` from. Defaults to the global `document`. */
+  document?: Document;
+  /** The object the shared runtime is stored on. Defaults to `globalThis`. */
+  globalObject?: object;
+  /** The identity used by the duplicate/conflict guard. Defaults to this package's version. */
+  version?: string;
+  /** The DOM scope handed to the loader. Defaults to the resolved document. */
+  root?: Document | Element;
+  /** Loader dependency-injection seams, forwarded to {@link autoload}. */
+  dependencies?: Partial<LoaderDependencies>;
+  /** The logger used by the duplicate/conflict guard. Defaults to the global `console`. */
+  console?: Pick<Console, 'warn'>;
+  /** Schedules the single coalesced start. Defaults to `queueMicrotask`. */
+  scheduleMicrotask?: (callback: () => void) => void;
+}
+
+/** The shared, cross-copy runtime object stored on `globalThis` under {@link RUNTIME_KEY}. */
+export interface AutoloadRuntime {
+  /** The owning package name, used by the conflict guard. */
+  readonly packageName: typeof PACKAGE_NAME;
+  /** The version that first claimed this runtime; conflicting versions are ignored. */
+  readonly version: string;
+  /** Every manifest registered so far, in registration order. */
+  manifests: ComponentManifest[];
+  /** The active autoload handle, present once a start has flushed. */
+  handle?: AutoloadHandle;
+  /** True while a (re)start is scheduled through a microtask but has not flushed yet. */
+  pending: boolean;
+  /**
+   * The resolved options for the next flush. The freshest registration wins so a late import can
+   * refresh the document/root before the coalesced start runs.
+   *
+   * @private
+   */
+  __pendingOptions?: ResolvedOptions;
+}
+
+interface ResolvedOptions {
+  documentObject: Document;
+  globalObject: object;
+  version: string;
+  root: Document | Element;
+  dependencies?: Partial<LoaderDependencies>;
+  logger: Pick<Console, 'warn'>;
+  scheduleMicrotask: (callback: () => void) => void;
+}
+
+function resolveOptions(options: RegisterManifestOptions): ResolvedOptions {
+  const documentObject = options.document ?? document;
+  return {
+    documentObject,
+    globalObject: options.globalObject ?? globalThis,
+    version: options.version ?? packageMetadata.version,
+    root: options.root ?? documentObject,
+    dependencies: options.dependencies,
+    logger: options.console ?? console,
+    scheduleMicrotask: options.scheduleMicrotask ?? ((callback) => queueMicrotask(callback)),
+  };
+}
+
+/**
+ * Read the eager tokens declared by `<meta name="studiometa-ui:eager" content="A, B, C">`.
+ *
+ * The `content` values of every matching meta (in document order) are concatenated, split on
+ * commas, trimmed, stripped of empties and deduplicated — the exact normalization the CDN wrapper
+ * applied to its `?components=` query. When no such meta exists the list is empty.
+ */
+export function readEagerTokens(documentObject: Document): string[] {
+  const metas = [...documentObject.querySelectorAll(EAGER_META_SELECTOR)];
+  return [
+    ...new Set(
+      metas
+        .flatMap((meta) => (meta.getAttribute('content') ?? '').split(','))
+        .map((token) => token.trim())
+        .filter(Boolean),
+    ),
+  ];
+}
+
+function ensureRuntime(resolved: ResolvedOptions): AutoloadRuntime | undefined {
+  const host = resolved.globalObject as Record<PropertyKey, unknown>;
+  const existing = host[RUNTIME_KEY] as AutoloadRuntime | undefined;
+  if (existing) {
+    if (existing.packageName === PACKAGE_NAME && existing.version === resolved.version) {
+      return existing;
+    }
+
+    resolved.logger.warn(
+      `${DIAGNOSTIC_PREFIX} A conflicting runtime (version ${existing.version}) is already active; version ${resolved.version} was ignored.`,
+    );
+    return undefined;
+  }
+
+  const runtime: AutoloadRuntime = {
+    packageName: PACKAGE_NAME,
+    version: resolved.version,
+    manifests: [],
+    pending: false,
+  };
+  host[RUNTIME_KEY] = runtime;
+  return runtime;
+}
+
+function flushStart(runtime: AutoloadRuntime): void {
+  runtime.pending = false;
+  const resolved = runtime.__pendingOptions;
+  if (!resolved) {
+    return;
+  }
+
+  const manifests = [...runtime.manifests];
+  const eager = readEagerTokens(resolved.documentObject);
+
+  // A previous flush may already have produced a loader when a manifest is registered late (after
+  // the coalescing microtask fired). Stop it and start a fresh loader over the accumulated set:
+  // js-toolkit's `$register` reuses the instance already mounted on an element, so re-scanning never
+  // double-mounts, while a single active loader keeps exactly one MutationObserver on the DOM.
+  runtime.handle?.stop();
+  runtime.handle = autoload({
+    manifests,
+    root: resolved.root,
+    eager,
+    dependencies: {
+      document: resolved.documentObject,
+      diagnosticPrefix: DIAGNOSTIC_PREFIX,
+      ...resolved.dependencies,
+    },
+  });
+}
+
+function scheduleStart(runtime: AutoloadRuntime, resolved: ResolvedOptions): void {
+  // The freshest registration wins so a late import can refresh the document/root before the flush.
+  runtime.__pendingOptions = resolved;
+  if (runtime.pending) {
+    return;
+  }
+  runtime.pending = true;
+  resolved.scheduleMicrotask(() => flushStart(runtime));
+}
+
+/**
+ * Register a component manifest with the shared runtime and ensure the autoloader starts.
+ *
+ * This is the shared engine behind the per-package side-effect entries (`@studiometa/ui-autoload/ui`
+ * and `.../ui-mapbox`). It is safe to call from several entries and several bundle copies at once:
+ *
+ * - The first registration schedules a single start through a microtask. Because every ES module
+ *   import in a graph evaluates before microtasks flush, importing both `./ui` and `./ui-mapbox` at
+ *   the top of a module registers both manifests synchronously and results in exactly ONE
+ *   {@link autoload} call over the COMPOSED set — never two loaders both scanning the DOM.
+ * - A manifest registered after the start already fired is not dropped: it triggers a fresh start
+ *   over the accumulated manifests. The previous loader is stopped first, so a single loader stays
+ *   active, and js-toolkit's idempotent `$register` prevents any double-mount.
+ * - A conflicting activation — a different {@link RegisterManifestOptions.version} claiming an
+ *   already-owned runtime — warns and no-ops, mirroring the CDN wrapper's version guard.
+ *
+ * Returns the shared runtime, or `undefined` when a conflicting version already owns it.
+ */
+export function registerManifest(
+  manifest: ComponentManifest,
+  options: RegisterManifestOptions = {},
+): AutoloadRuntime | undefined {
+  const resolved = resolveOptions(options);
+  const runtime = ensureRuntime(resolved);
+  if (!runtime) {
+    return undefined;
+  }
+
+  if (!runtime.manifests.includes(manifest)) {
+    runtime.manifests.push(manifest);
+  }
+  scheduleStart(runtime, resolved);
+  return runtime;
+}

--- a/packages/ui-autoload/ui-mapbox.ts
+++ b/packages/ui-autoload/ui-mapbox.ts
@@ -1,0 +1,9 @@
+import { manifest } from '@studiometa/ui-mapbox/manifest';
+import { registerManifest } from './runtime.js';
+
+// Side-effect entry: importing this module registers the `@studiometa/ui-mapbox` manifest with the
+// shared runtime and ensures the autoloader starts. There is nothing to export — `import` is the
+// contract. Importing it alongside `./ui` coalesces into a single loader over the composed set.
+if (typeof document !== 'undefined') {
+  registerManifest(manifest);
+}

--- a/packages/ui-autoload/ui.ts
+++ b/packages/ui-autoload/ui.ts
@@ -1,0 +1,8 @@
+import { manifest } from '@studiometa/ui/manifest';
+import { registerManifest } from './runtime.js';
+
+// Side-effect entry: importing this module registers the `@studiometa/ui` manifest with the shared
+// runtime and ensures the autoloader starts. There is nothing to export — `import` is the contract.
+if (typeof document !== 'undefined') {
+  registerManifest(manifest);
+}


### PR DESCRIPTION
## What

Adds **importable side-effect entry points** to `@studiometa/ui-autoload` so a consumer can autoload a package's components by merely importing a subpath, while the existing pure `autoload()` / `composeManifests()` engine stays unchanged. This ports the bootstrapping logic from the `@studiometa/ui-cdn` wrapper into the generic package (the CDN wrapper is untouched and remains the reference implementation until a later PR).

## New entry points

- `@studiometa/ui-autoload/ui` — on import, registers `@studiometa/ui`'s manifest (imported via the bare `@studiometa/ui/manifest` specifier) and ensures the autoloader starts.
- `@studiometa/ui-autoload/ui-mapbox` — same, for `@studiometa/ui-mapbox/manifest`.

Both are guarded by `typeof document !== 'undefined'` and export nothing — *import is the contract*. They are declared in `sideEffects` so bundlers never tree-shake the activation away.

## Shared runtime (`runtime.ts`)

- A **global runtime** stored on `globalThis` under `Symbol.for('@studiometa/ui-autoload/runtime')`, so multiple entry imports and multiple bundle copies coordinate through one object.
- **Coalesced single start:** each entry calls `registerManifest(manifest)`. The first registration schedules a single start via `queueMicrotask`. Because every ES module import in a graph evaluates before microtasks flush, importing both `./ui` and `./ui-mapbox` at the top of a module registers both manifests synchronously and results in exactly **one** `autoload()` call over the **composed** set — never two loaders both scanning the DOM.
- **Late registration** (a manifest registered after the start already fired) is not dropped: it triggers a fresh start over the accumulated manifests. The previous loader is stopped first so a single loader stays active, and js-toolkit's idempotent `$register` (reuses the instance already mounted on an element) prevents any double-mount.
- **Version guard:** a conflicting activation (a different version claiming the already-owned runtime) warns and no-ops, mirroring the CDN wrapper's version/duplicate guards.

## `<meta>` eager mechanism

Eager tokens now come from `<meta name="studiometa-ui:eager" content="Accordion, Action, Modal">`, **replacing** the CDN's marked-script `?components=` query. Parsing rule (reusing the CDN's exact normalization): the `content` of every matching meta, in document order, is concatenated, split on commas, trimmed, stripped of empties and deduplicated. Absent meta -> empty eager list. The resulting tokens are passed as the composed `autoload({ eager })`.

## Public API

`registerManifest` and `readEagerTokens` (plus `AutoloadRuntime` / `RegisterManifestOptions` types) are exported from `index.ts`. Importing `index.ts` remains side-effect-free — only calling the functions touches the DOM.

## Exports map / build

`package.json` gains explicit `./ui`, `./ui.js`, `./ui-mapbox`, `./ui-mapbox.js` entries (consistent with how `@studiometa/ui` lists its subpaths; the pre-existing `./*` wildcards already resolved them). The package build emits `dist/ui.js`, `dist/ui-mapbox.js`, `dist/runtime.js` and their `.d.ts`.

## Tests

`packages/tests/autoload/runtime.spec.ts` (happy-dom via Vitest) covers:
- `<meta>` parsing -> exact eager token array (trim/dedupe/empty, multi-meta concatenation, absent meta).
- Importing both manifests synchronously -> a single loader (one `MutationObserver` constructed) over the composed set.
- Late registration -> a fresh loader; and with real `registerComponent`, no double-mount on restart.
- Version guard: matching version reuses the runtime, conflicting version warns + no-ops.
- Inert until called: registering nothing happens until `registerManifest` is invoked.

Full suite: **836 passing**. `npm run lint` clean (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014FQxYGj2RqgcP8BkubpiNu