### PR TITLE
Accept ui-autoload as a fourth CDN package in the worker

### DIFF
--- a/packages/cdn/tests/worker/fixtures.ts
+++ b/packages/cdn/tests/worker/fixtures.ts
@@ -62,9 +62,11 @@ export interface WorkerFixture {
   bucket: MemoryR2;
   build: BuildMetadata;
   uiMapboxBuild: BuildMetadata;
+  uiAutoloadBuild: BuildMetadata;
   integrity: IntegrityMetadata;
   files: Record<string, string>;
   uiMapboxFiles: Record<string, string>;
+  uiAutoloadFiles: Record<string, string>;
   versionsIndex: VersionsIndex;
   uiVersion: string;
   jsToolkitVersion: string;
@@ -155,6 +157,20 @@ export async function createWorkerFixture(): Promise<WorkerFixture> {
   ];
   const uiMapboxFiles = await readTreeFiles(uiMapboxTreeDirectory, uiMapboxAssetPaths);
 
+  // The `ui-autoload` tree is not produced by the build script yet (it is published in a later PR),
+  // so this fixture synthesizes one structurally identical to ui-mapbox: a ui-like tree with its own
+  // namespaced release/channel prefixes and its own CDN build identity. Cloning the ui-mapbox tree is
+  // enough to exercise the Worker's read path — routing, resolution and registry listing — for the
+  // fourth package. The clone rewrites the build name to the ui-autoload CDN build so the Worker's
+  // `PUBLIC_PACKAGE_NAMES['ui-autoload']` expectation is met on both release and channel manifests.
+  const uiAutoloadBuild = structuredClone(uiMapboxBuild);
+  uiAutoloadBuild.package.name = '@studiometa/ui-cdn-autoload';
+  const uiAutoloadAssetPaths = uiMapboxAssetPaths;
+  const uiAutoloadFiles: Record<string, string> = {
+    ...uiMapboxFiles,
+    'build.json': JSON.stringify(uiAutoloadBuild),
+  };
+
   const jsToolkitAssetPaths = [
     'index.js',
     'index.js.map',
@@ -176,6 +192,7 @@ export async function createWorkerFixture(): Promise<WorkerFixture> {
     packages: {
       ui: uiLikePackageIndex,
       'ui-mapbox': uiLikePackageIndex,
+      'ui-autoload': uiLikePackageIndex,
       'js-toolkit': { releases: [jsToolkitVersion] },
     },
   };
@@ -186,7 +203,7 @@ export async function createWorkerFixture(): Promise<WorkerFixture> {
   // Seeds a ui-like package's release and channel objects under its namespaced prefixes. ui channels
   // keep the flat `channels/<id>` layout; every other package is namespaced as `channels/<pkg>/<id>`.
   function seedUiLikePackage(
-    packageName: 'ui' | 'ui-mapbox',
+    packageName: 'ui' | 'ui-mapbox' | 'ui-autoload',
     treeBuild: BuildMetadata,
     treeFiles: Record<string, string>,
     assetPaths: readonly string[],
@@ -216,6 +233,7 @@ export async function createWorkerFixture(): Promise<WorkerFixture> {
   }
   seedUiLikePackage('ui', build, files, uiAssetPaths);
   seedUiLikePackage('ui-mapbox', uiMapboxBuild, uiMapboxFiles, uiMapboxAssetPaths);
+  seedUiLikePackage('ui-autoload', uiAutoloadBuild, uiAutoloadFiles, uiAutoloadAssetPaths);
 
   const jsToolkitPrefix = `releases/js-toolkit/${jsToolkitVersion}`;
   for (const path of jsToolkitAssetPaths) {
@@ -226,9 +244,11 @@ export async function createWorkerFixture(): Promise<WorkerFixture> {
     bucket,
     build,
     uiMapboxBuild,
+    uiAutoloadBuild,
     integrity,
     files,
     uiMapboxFiles,
+    uiAutoloadFiles,
     versionsIndex,
     uiVersion: uiPackageVersion,
     jsToolkitVersion,

--- a/packages/cdn/tests/worker/index.test.ts
+++ b/packages/cdn/tests/worker/index.test.ts
@@ -201,6 +201,150 @@ describe('CDN Worker ui-mapbox package routing', () => {
   });
 });
 
+describe('CDN Worker ui-autoload package routing', () => {
+  // ui-autoload is the fourth CDN package: a ui-like tree versioned in lockstep with ui, carrying
+  // releases, immutable channels and the latest/next/main tags. It resolves and serves exactly like
+  // ui and ui-mapbox from its own namespaced trees. (The fixture synthesizes this tree by cloning
+  // ui-mapbox; the real tree is published in a later PR.)
+  it('serves the ui-autoload barrel and per-component modules from the ui-autoload tree', async () => {
+    const barrel = await request('/ui-autoload@1.2.0/index.js');
+    const component = await request('/ui-autoload@1.2.0/MapboxMap.js');
+
+    expect(barrel.status).toBe(200);
+    expect(barrel.headers.get('Content-Type')).toBe('text/javascript; charset=utf-8');
+    expect(barrel.headers.get('Cache-Control')).toBe(IMMUTABLE_CACHE_CONTROL);
+    expect(await barrel.text()).toBe(fixture.uiAutoloadFiles['index.js']);
+    expectCrossOriginHeaders(barrel);
+
+    expect(component.status).toBe(200);
+    expect(await component.text()).toBe(fixture.uiAutoloadFiles['MapboxMap.js']);
+  });
+
+  it('resolves ui-autoload exact versions, aliases, tags and channels exactly like ui', async () => {
+    const alias = await request('/ui-autoload@1/MapboxMap.js');
+    expect(alias.status).toBe(307);
+    expect(alias.headers.get('Location')).toBe(`${origin}/ui-autoload@1.10.0/MapboxMap.js`);
+
+    const latest = await request('/ui-autoload@latest/index.js');
+    expect(latest.status).toBe(307);
+    expect(latest.headers.get('Location')).toBe(`${origin}/ui-autoload@2.0.0/index.js`);
+
+    const channel = await request('/ui-autoload@main-abcdef1/MapboxMap.js');
+    expect(channel.status).toBe(200);
+    expect(await channel.text()).toBe(fixture.uiAutoloadFiles['MapboxMap.js']);
+
+    const next = await request('/ui-autoload@next/index.js');
+    expect(next.status).toBe(307);
+    expect(next.headers.get('Location')).toBe(`${origin}/ui-autoload@main-fedcba9/index.js`);
+
+    const main = await request('/ui-autoload@main/index.js');
+    expect(main.status).toBe(307);
+    expect(main.headers.get('Location')).toBe(`${origin}/ui-autoload@main-fedcba9/index.js`);
+  });
+
+  it('resolves versionless, bare-root and ref-carrying ui-autoload requests', async () => {
+    const versionless = await request('/ui-autoload/MapboxMap');
+    expect(versionless.status).toBe(307);
+    expect(versionless.headers.get('Location')).toBe(`${origin}/ui-autoload@2.0.0/MapboxMap.js`);
+
+    for (const path of ['/ui-autoload', '/ui-autoload/']) {
+      const root = await request(path);
+      expect(root.status).toBe(307);
+      expect(root.headers.get('Location')).toBe(`${origin}/ui-autoload@2.0.0/index.js`);
+    }
+
+    const ref = await request('/ui-autoload@main');
+    expect(ref.status).toBe(307);
+    expect(ref.headers.get('Location')).toBe(`${origin}/ui-autoload@main-fedcba9/index.js`);
+  });
+
+  it('advertises the ui-autoload declaration via X-TypeScript-Types', async () => {
+    const module = await request('/ui-autoload@1.2.0/MapboxMap.js');
+    expect(module.headers.get('X-TypeScript-Types')).toBe(
+      `${origin}/ui-autoload@1.2.0/MapboxMap.d.ts`,
+    );
+    expect(module.headers.get('Access-Control-Expose-Headers')).toContain('X-TypeScript-Types');
+  });
+});
+
+describe('CDN Worker ui-autoload two-phase rollout (index without the ui-autoload key)', () => {
+  // The crucial backward-compat guarantee: the currently-live index has no `ui-autoload` key. This
+  // Worker deploys BEFORE the ui-autoload tree is published, so an index that omits the key must
+  // still parse, keep serving the other packages, resolve every `/ui-autoload` route to a clean 404
+  // (never a 400 route-parse rejection or a 502), and empty ui-autoload gracefully in the registry.
+  const legacyIndex = JSON.stringify({
+    schemaVersion: 2,
+    packages: {
+      ui: {
+        releases: ['1.2.0', '2.0.0'],
+        channels: ['main-fedcba9'],
+        distTags: { latest: '2.0.0', next: 'main-fedcba9', main: 'main-fedcba9' },
+      },
+      'ui-mapbox': {
+        releases: ['1.2.0', '2.0.0'],
+        channels: ['main-fedcba9'],
+        distTags: { latest: '2.0.0', next: 'main-fedcba9', main: 'main-fedcba9' },
+      },
+      'js-toolkit': { releases: [] },
+    },
+  });
+
+  function withLegacyIndex(): () => void {
+    const original = fixture.bucket.objects.get('versions.json') as NonNullable<
+      ReturnType<typeof fixture.bucket.objects.get>
+    >;
+    fixture.bucket.put('versions.json', legacyIndex);
+    return () => fixture.bucket.objects.set('versions.json', original);
+  }
+
+  it('keeps serving the other packages while every ui-autoload route 404s', async () => {
+    const restore = withLegacyIndex();
+    try {
+      // The missing key does not affect the other packages.
+      expect((await request('/ui@2.0.0/index.js')).status).toBe(200);
+      expect((await request('/ui-mapbox@2.0.0/index.js')).status).toBe(200);
+      // Every ui-autoload shape resolves to a clean 404 (route parsing accepts it, resolution finds
+      // nothing), rather than a 400 rejection or a 502 from a failed parse.
+      for (const path of [
+        '/ui-autoload@2.0.0/index.js',
+        '/ui-autoload@latest/index.js',
+        '/ui-autoload@next/index.js',
+        '/ui-autoload@main/index.js',
+        '/ui-autoload@1/index.js',
+        '/ui-autoload/index.js',
+        '/ui-autoload/MapboxMap',
+        '/ui-autoload',
+        '/ui-autoload/',
+      ]) {
+        expect((await request(path)).status).toBe(404);
+      }
+    } finally {
+      restore();
+    }
+  });
+
+  it('empties ui-autoload in the registry while listing the other packages', async () => {
+    const restore = withLegacyIndex();
+    try {
+      const registry = (await (await request('/')).json()) as {
+        packages: Record<string, { releases: string[]; channels: string[]; distTags: unknown }>;
+        current: Record<string, string | null>;
+      };
+      expect(registry.packages['ui-autoload']).toEqual({
+        releases: [],
+        channels: [],
+        distTags: {},
+      });
+      expect(registry.current['ui-autoload']).toBeNull();
+      // The other packages still resolve their current surface from the same index.
+      expect(registry.current.ui).toBe('2.0.0');
+      expect(registry.current['ui-mapbox']).toBe('2.0.0');
+    } finally {
+      restore();
+    }
+  });
+});
+
 describe('CDN Worker extensionless subpath resolution', () => {
   it('maps a versionless extensionless ui component to its .js output in one hop', async () => {
     const response = await request('/ui/Action');
@@ -641,9 +785,15 @@ describe('CDN Worker registry', () => {
     packages: {
       ui: { releases: string[]; channels: string[]; distTags: Record<string, string> };
       'ui-mapbox': { releases: string[]; channels: string[]; distTags: Record<string, string> };
+      'ui-autoload': { releases: string[]; channels: string[]; distTags: Record<string, string> };
       'js-toolkit': { releases: string[] };
     };
-    current: { ui: string | null; 'ui-mapbox': string | null; 'js-toolkit': string | null };
+    current: {
+      ui: string | null;
+      'ui-mapbox': string | null;
+      'ui-autoload': string | null;
+      'js-toolkit': string | null;
+    };
     entries: Record<string, string>;
     components: { token: string; package: string; url: string }[];
   }
@@ -673,10 +823,17 @@ describe('CDN Worker registry', () => {
       distTags: fixture.versionsIndex.packages['ui-mapbox'].distTags,
     });
     expect(registry.packages['js-toolkit'].releases).toEqual([fixture.jsToolkitVersion]);
+    expect(registry.packages['ui-autoload']).toEqual({
+      releases: fixture.versionsIndex.packages['ui-autoload'].releases,
+      channels: fixture.versionsIndex.packages['ui-autoload'].channels,
+      distTags: fixture.versionsIndex.packages['ui-autoload'].distTags,
+    });
 
     expect(registry.current.ui).toBe('2.0.0');
     expect(registry.current['ui-mapbox']).toBe('2.0.0');
     expect(registry.current['js-toolkit']).toBe(fixture.jsToolkitVersion);
+    // ui-autoload is versioned in lockstep with ui, so its current ref matches ui's latest.
+    expect(registry.current['ui-autoload']).toBe('2.0.0');
 
     expect(registry.entries.autoload).toBe(`${origin}/ui@2.0.0/autoload.js`);
     expect(registry.entries.index).toBe(`${origin}/ui@2.0.0/index.js`);
@@ -738,8 +895,14 @@ describe('CDN Worker registry', () => {
 
     expect(registry.packages.ui).toEqual({ releases: [], channels: [], distTags: {} });
     expect(registry.packages['ui-mapbox']).toEqual({ releases: [], channels: [], distTags: {} });
+    expect(registry.packages['ui-autoload']).toEqual({ releases: [], channels: [], distTags: {} });
     expect(registry.packages['js-toolkit']).toEqual({ releases: [] });
-    expect(registry.current).toEqual({ ui: null, 'ui-mapbox': null, 'js-toolkit': null });
+    expect(registry.current).toEqual({
+      ui: null,
+      'ui-mapbox': null,
+      'ui-autoload': null,
+      'js-toolkit': null,
+    });
     expect(registry.entries).toEqual({});
     expect(registry.components).toEqual([]);
   });
@@ -752,7 +915,12 @@ describe('CDN Worker registry', () => {
     expect(response.status).toBe(200);
     expect(response.headers.get('Content-Type')).toBe('application/json; charset=utf-8');
     const registry = (await response.json()) as Registry;
-    expect(registry.current).toEqual({ ui: null, 'ui-mapbox': null, 'js-toolkit': null });
+    expect(registry.current).toEqual({
+      ui: null,
+      'ui-mapbox': null,
+      'ui-autoload': null,
+      'js-toolkit': null,
+    });
     expect(registry.components).toEqual([]);
     expect(registry.entries).toEqual({});
   });

--- a/packages/cdn/tests/worker/versions.test.ts
+++ b/packages/cdn/tests/worker/versions.test.ts
@@ -233,6 +233,70 @@ describe('versions index parsing (schemaVersion 2)', () => {
       objectPrefix: 'channels/ui-mapbox/main-abcdef1',
     });
   });
+
+  it('parses a schema-2 index that predates the ui-autoload tree and 404s every ui-autoload route', () => {
+    // The currently-live index has no `ui-autoload` key. It must still parse, ui/ui-mapbox/js-toolkit
+    // must keep resolving, and every ui-autoload route must resolve to nothing (a clean 404) until a
+    // publish populates the tree. This is the deploy-first half of the two-phase rollout at the
+    // resolution layer: the Worker tolerates the live index verbatim.
+    const index = parseVersionsIndex({
+      schemaVersion: 2,
+      packages: {
+        ui: { releases: ['1.9.0'], channels: [], distTags: { latest: '1.9.0' } },
+        'ui-mapbox': { releases: ['1.9.0'], channels: [], distTags: { latest: '1.9.0' } },
+        'js-toolkit': { releases: ['3.8.0'] },
+      },
+    });
+    // The other packages keep resolving exactly as before.
+    expect(resolveVersion(index, 'ui', 'latest')).toMatchObject({ version: '1.9.0' });
+    expect(resolveVersion(index, 'ui-mapbox', 'latest')).toMatchObject({ version: '1.9.0' });
+    expect(resolveVersion(index, 'js-toolkit', '3.8.0')).toMatchObject({ version: '3.8.0' });
+    // ui-autoload defaults to an empty package: every route 404s.
+    expect(resolveVersion(index, 'ui-autoload', 'latest')).toBeUndefined();
+    expect(resolveVersion(index, 'ui-autoload', '1.0.0')).toBeUndefined();
+    expect(resolveVersion(index, 'ui-autoload', 'main')).toBeUndefined();
+    expect(resolveBareRoot(index, 'ui-autoload')).toBeUndefined();
+  });
+
+  it('resolves ui-autoload with the full ui semantics from its own namespaced trees', () => {
+    const index = parseVersionsIndex({
+      schemaVersion: 2,
+      packages: {
+        ui: {
+          releases: ['1.9.0'],
+          channels: ['main-abcdef1'],
+          distTags: { latest: '1.9.0', next: 'main-abcdef1', main: 'main-abcdef1' },
+        },
+        'ui-mapbox': { releases: ['1.9.0'], channels: [], distTags: { latest: '1.9.0' } },
+        'ui-autoload': {
+          releases: ['1.9.0', '2.0.0'],
+          channels: ['main-abcdef1'],
+          distTags: { latest: '2.0.0', next: 'main-abcdef1', main: 'main-abcdef1' },
+        },
+        'js-toolkit': { releases: [] },
+      },
+    });
+    expect(resolveVersion(index, 'ui-autoload', '2.0.0')).toEqual({
+      kind: 'release',
+      version: '2.0.0',
+      objectPrefix: 'releases/ui-autoload/2.0.0',
+    });
+    expect(resolveVersion(index, 'ui-autoload', 'latest')).toMatchObject({ version: '2.0.0' });
+    expect(resolveVersion(index, 'ui-autoload', '1')).toMatchObject({ version: '1.9.0' });
+    // ui-autoload channels are namespaced under channels/ui-autoload/ so they never collide with ui's.
+    expect(resolveVersion(index, 'ui-autoload', 'main-abcdef1')).toEqual({
+      kind: 'channel',
+      version: 'main-abcdef1',
+      objectPrefix: 'channels/ui-autoload/main-abcdef1',
+    });
+    expect(resolveVersion(index, 'ui-autoload', 'next')).toMatchObject({
+      objectPrefix: 'channels/ui-autoload/main-abcdef1',
+    });
+    expect(resolveBareRoot(index, 'ui-autoload')).toMatchObject({
+      version: '2.0.0',
+      objectPrefix: 'releases/ui-autoload/2.0.0',
+    });
+  });
 });
 
 describe('js-toolkit version resolution', () => {

--- a/packages/cdn/worker/index.ts
+++ b/packages/cdn/worker/index.ts
@@ -31,6 +31,7 @@ import {
   parseVersionsIndex,
   resolveBareRoot,
   resolveCurrentJsToolkit,
+  resolveCurrentUiAutoloadRef,
   resolveCurrentUiMapboxRef,
   resolveCurrentUiRef,
   resolveVersion,
@@ -43,6 +44,7 @@ const MAX_LINK_HEADER_BYTES = 7_500;
 const PUBLIC_PACKAGE_NAMES: Record<PackageName, string> = {
   ui: '@studiometa/ui-cdn',
   'ui-mapbox': '@studiometa/ui-cdn-mapbox',
+  'ui-autoload': '@studiometa/ui-cdn-autoload',
   'js-toolkit': '@studiometa/ui-cdn-js-toolkit',
 };
 const SAFE_METADATA_PATH = /^(?!\/)(?!.*(?:^|\/)\.\.?(?:\/|$))(?!.*\\)[0-9A-Za-z._@+/-]+$/;
@@ -254,6 +256,7 @@ async function handleRegistry(
   const versions = await readVersionsForRegistry(environment.ASSETS, recorder);
   const currentUiRef = versions ? resolveCurrentUiRef(versions) : null;
   const currentUiMapboxRef = versions ? resolveCurrentUiMapboxRef(versions) : null;
+  const currentUiAutoloadRef = versions ? resolveCurrentUiAutoloadRef(versions) : null;
   const currentJsToolkit = versions ? resolveCurrentJsToolkit(versions) : null;
 
   async function loadCurrentBuild(
@@ -286,6 +289,7 @@ async function handleRegistry(
     versions,
     currentUiRef,
     currentUiMapboxRef,
+    currentUiAutoloadRef,
     currentJsToolkit,
     currentUiBuild,
     currentUiMapboxBuild,

--- a/packages/cdn/worker/queries.ts
+++ b/packages/cdn/worker/queries.ts
@@ -1,6 +1,11 @@
 import type { CanonicalQuery, PackageName, PackageRoot, ParsedRoute } from './types.ts';
 
-const PACKAGE_NAMES: ReadonlySet<PackageName> = new Set(['ui', 'ui-mapbox', 'js-toolkit']);
+const PACKAGE_NAMES: ReadonlySet<PackageName> = new Set([
+  'ui',
+  'ui-mapbox',
+  'ui-autoload',
+  'js-toolkit',
+]);
 
 const VERSION_TOKEN_PATTERN = /^[0-9A-Za-z.+-]+$/;
 const ASSET_SEGMENT_PATTERN = /^[0-9A-Za-z._@+-]+$/;
@@ -42,7 +47,7 @@ export function parseRoute(pathname: string): ParsedRoute {
 
   // A versionless package segment (e.g. `/ui/Action`, `/js-toolkit/utils`) has no `@version`; the
   // caller resolves it the same way a bare package root does (via `resolveBareRoot`) so it works for
-  // every package — `ui`/`ui-mapbox` follow their `latest` tag and the tagless `js-toolkit` its
+  // every package — `ui`/`ui-mapbox`/`ui-autoload` follow their `latest` tag and the tagless `js-toolkit` its
   // highest release — then redirects to the resolved exact version. `requestedVersion` stays `latest`
   // so the request always classifies as mutable and canonicalizes to that redirect.
   const versionless = separator === -1;

--- a/packages/cdn/worker/registry.ts
+++ b/packages/cdn/worker/registry.ts
@@ -9,6 +9,8 @@ export interface RegistryInput {
   currentUiRef: string | null;
   /** The reference reported as the current ui-mapbox surface, resolved from the index. */
   currentUiMapboxRef: string | null;
+  /** The reference reported as the current ui-autoload surface, resolved from the index. */
+  currentUiAutoloadRef: string | null;
   /** The version reported as the current js-toolkit surface, resolved from the index. */
   currentJsToolkit: string | null;
   /** The current ui ref's build metadata, or `undefined` when it is absent or unreadable. */
@@ -29,12 +31,14 @@ export function buildRegistry(input: RegistryInput): RegistryDocument {
     versions,
     currentUiRef,
     currentUiMapboxRef,
+    currentUiAutoloadRef,
     currentJsToolkit,
     currentUiBuild,
     currentUiMapboxBuild,
   } = input;
   const ui = versions?.packages.ui;
   const uiMapbox = versions?.packages['ui-mapbox'];
+  const uiAutoload = versions?.packages['ui-autoload'];
   const jsToolkit = versions?.packages['js-toolkit'];
 
   // Each package's components import from their own versioned tree: `@studiometa/ui` from
@@ -85,6 +89,11 @@ export function buildRegistry(input: RegistryInput): RegistryDocument {
         channels: uiMapbox ? [...uiMapbox.channels] : [],
         distTags: uiMapbox ? { ...uiMapbox.distTags } : {},
       },
+      'ui-autoload': {
+        releases: uiAutoload ? [...uiAutoload.releases] : [],
+        channels: uiAutoload ? [...uiAutoload.channels] : [],
+        distTags: uiAutoload ? { ...uiAutoload.distTags } : {},
+      },
       'js-toolkit': {
         releases: jsToolkit ? [...jsToolkit.releases] : [],
       },
@@ -92,6 +101,7 @@ export function buildRegistry(input: RegistryInput): RegistryDocument {
     current: {
       ui: currentUiRef,
       'ui-mapbox': currentUiMapboxRef,
+      'ui-autoload': currentUiAutoloadRef,
       'js-toolkit': currentJsToolkit,
     },
     entries,

--- a/packages/cdn/worker/types.ts
+++ b/packages/cdn/worker/types.ts
@@ -21,7 +21,7 @@ export interface WorkerEnvironment {
   OBSERVABILITY_SAMPLE_RATE?: string;
 }
 
-export type PackageName = 'ui' | 'ui-mapbox' | 'js-toolkit';
+export type PackageName = 'ui' | 'ui-mapbox' | 'ui-autoload' | 'js-toolkit';
 
 export interface UiPackageIndex {
   releases: string[];
@@ -41,11 +41,12 @@ export interface VersionsIndex {
   schemaVersion: 2;
   packages: {
     ui: UiPackageIndex;
-    // `ui-mapbox` is an additive, optional package under schema 2, versioned in lockstep with `ui`
-    // and carrying the same full ui semantics (releases, immutable channels and distribution tags).
-    // An index predating the ui-mapbox tree omits it; the Worker defaults it to an empty package on
-    // read, so this key is always populated on the parsed index.
+    // `ui-mapbox` and `ui-autoload` are additive, optional packages under schema 2, versioned in
+    // lockstep with `ui` and carrying the same full ui semantics (releases, immutable channels and
+    // distribution tags). An index predating either tree omits it; the Worker defaults it to an
+    // empty package on read, so both keys are always populated on the parsed index.
     'ui-mapbox': UiPackageIndex;
+    'ui-autoload': UiPackageIndex;
     'js-toolkit': JsToolkitPackageIndex;
   };
 }
@@ -133,6 +134,7 @@ export interface RegistryDocument {
   packages: {
     ui: RegistryUiPackage;
     'ui-mapbox': RegistryUiPackage;
+    'ui-autoload': RegistryUiPackage;
     'js-toolkit': {
       releases: string[];
     };
@@ -140,6 +142,7 @@ export interface RegistryDocument {
   current: {
     ui: string | null;
     'ui-mapbox': string | null;
+    'ui-autoload': string | null;
     'js-toolkit': string | null;
   };
   entries: Record<string, string>;

--- a/packages/cdn/worker/versions.ts
+++ b/packages/cdn/worker/versions.ts
@@ -92,28 +92,36 @@ function validateJsToolkitPackage(value: unknown): void {
 
 const EMPTY_UI_PACKAGE: UiPackageIndex = { releases: [], channels: [], distTags: {} };
 
+// The additive, optional ui-like packages under schema 2. Each shares the full ui semantics and is
+// validated identically when present; when absent (an old index that predates the tree) it defaults
+// to an empty package so the index still parses and every route for it cleanly 404s until the
+// package is populated by a later publish. This is the two-phase rollout contract: a live index that
+// omits one of these keys stays valid, so the Worker can deploy before the tree is published.
+const OPTIONAL_UI_PACKAGE_NAMES = ['ui-mapbox', 'ui-autoload'] as const;
+
 export function parseVersionsIndex(value: unknown): VersionsIndex {
   // The index stays schemaVersion 2 so the currently-deployed Worker keeps parsing it. `ui-mapbox`
-  // is an additive, optional package: an index predating the ui-mapbox tree omits it, so it is not
-  // required for a valid schema-2 index.
+  // and `ui-autoload` are additive, optional packages: an index predating either tree omits it, so
+  // neither is required for a valid schema-2 index.
   if (!isRecord(value) || value.schemaVersion !== 2) {
     throw new Error('Unsupported versions index.');
   }
   if (!isRecord(value.packages)) throw new Error('Invalid packages index.');
   validateUiPackage(value.packages.ui);
   validateJsToolkitPackage(value.packages['js-toolkit']);
-  // ui-mapbox shares the full ui semantics and is validated identically when present. When absent
-  // (an old index that predates the ui-mapbox tree) it defaults to an empty package so the index
-  // still parses and every `/ui-mapbox` route cleanly 404s until the package is populated.
-  const uiMapbox = value.packages['ui-mapbox'];
-  if (uiMapbox === undefined) {
-    return {
-      ...(value as Record<string, unknown>),
-      packages: { ...value.packages, 'ui-mapbox': { ...EMPTY_UI_PACKAGE } },
-    } as unknown as VersionsIndex;
+  const packages: Record<string, unknown> = { ...value.packages };
+  for (const name of OPTIONAL_UI_PACKAGE_NAMES) {
+    const pkg = value.packages[name];
+    if (pkg === undefined) {
+      packages[name] = { ...EMPTY_UI_PACKAGE };
+    } else {
+      validateUiPackage(pkg);
+    }
   }
-  validateUiPackage(uiMapbox);
-  return value as unknown as VersionsIndex;
+  return {
+    ...(value as Record<string, unknown>),
+    packages,
+  } as unknown as VersionsIndex;
 }
 
 function compareStableVersions(left: string, right: string): number {
@@ -132,8 +140,8 @@ function exactRelease(packageName: PackageName, version: string): ExactVersion {
 }
 
 // Immutable channels are namespaced per package under `channels/`. The `ui` channels keep the
-// original flat `channels/<id>` layout; every other channel-carrying package (currently `ui-mapbox`)
-// is namespaced as `channels/<package>/<id>` so its snapshots never collide with ui's.
+// original flat `channels/<id>` layout; every other channel-carrying package (`ui-mapbox`,
+// `ui-autoload`) is namespaced as `channels/<package>/<id>` so its snapshots never collide with ui's.
 function exactChannel(packageName: PackageName, version: string): ExactVersion {
   const objectPrefix =
     packageName === 'ui' ? `channels/${version}` : `channels/${packageName}/${version}`;
@@ -141,13 +149,13 @@ function exactChannel(packageName: PackageName, version: string): ExactVersion {
 }
 
 /**
- * Resolves a requested version for a ui-like package (`ui` or `ui-mapbox`): exact semver, immutable
- * `main-<sha>` channels, the `latest`/`next`/`main` distribution tags, major and minor aliases, and
- * (via a `latest` request) the versionless default.
+ * Resolves a requested version for a ui-like package (`ui`, `ui-mapbox` or `ui-autoload`): exact
+ * semver, immutable `main-<sha>` channels, the `latest`/`next`/`main` distribution tags, major and
+ * minor aliases, and (via a `latest` request) the versionless default.
  */
 function resolveUiLikeVersion(
   index: VersionsIndex,
-  packageName: 'ui' | 'ui-mapbox',
+  packageName: 'ui' | 'ui-mapbox' | 'ui-autoload',
   requested: string,
 ): ExactVersion | undefined {
   const pkg = index.packages[packageName];
@@ -196,10 +204,10 @@ function resolveUiLikeVersion(
 }
 
 /**
- * Resolves a requested version for a package. The `ui` and `ui-mapbox` packages keep the full
- * semantics — exact semver, immutable `main-<sha>` channels, the `latest`/`next`/`main` distribution
- * tags, major and minor aliases, and (via a `latest` request) the versionless default. The
- * `js-toolkit` package is exact-version only: it resolves solely to an exact semver present in its
+ * Resolves a requested version for a package. The `ui`, `ui-mapbox` and `ui-autoload` packages keep
+ * the full semantics — exact semver, immutable `main-<sha>` channels, the `latest`/`next`/`main`
+ * distribution tags, major and minor aliases, and (via a `latest` request) the versionless default.
+ * The `js-toolkit` package is exact-version only: it resolves solely to an exact semver present in its
  * release inventory, so every alias, channel, and distribution tag (including `latest` and the
  * versionless default) is a 404.
  */
@@ -227,7 +235,7 @@ export function resolveBareRoot(
   index: VersionsIndex,
   packageName: PackageName,
 ): ExactVersion | undefined {
-  if (packageName === 'ui' || packageName === 'ui-mapbox') {
+  if (packageName === 'ui' || packageName === 'ui-mapbox' || packageName === 'ui-autoload') {
     return resolveVersion(index, packageName, 'latest');
   }
   const highest = [...index.packages['js-toolkit'].releases].sort(compareStableVersions).at(-1);
@@ -268,6 +276,23 @@ export function resolveCurrentUiMapboxRef(index: VersionsIndex): string | null {
     uiMapbox.distTags.latest ??
     uiMapbox.distTags.main ??
     highestStableRelease(uiMapbox.releases) ??
+    null
+  );
+}
+
+/**
+ * Resolves the reference the registry reports as the current ui-autoload surface, using the same
+ * fallback ladder as {@link resolveCurrentUiRef}. It is versioned in lockstep with ui, so in a
+ * consistent index this equals `resolveCurrentUiRef`, but it is resolved independently so a partial
+ * index (one that omits the ui-autoload key entirely, as the currently-live index does) still
+ * degrades gracefully to `null`.
+ */
+export function resolveCurrentUiAutoloadRef(index: VersionsIndex): string | null {
+  const uiAutoload = index.packages['ui-autoload'];
+  return (
+    uiAutoload.distTags.latest ??
+    uiAutoload.distTags.main ??
+    highestStableRelease(uiAutoload.releases) ??
     null
   );
 }


### PR DESCRIPTION
## Summary

This is the **deploy-first half of a two-phase rollout**. It makes the Cloudflare Worker CDN accept a new fourth package tree, `ui-autoload`, on the **READ path only** (routing, resolution, registry, and `versions.json` tolerance). It mirrors exactly how `ui-mapbox` was added earlier as an additive optional package.

Key property: **worker read-tolerance for a not-yet-published `ui-autoload` tree.** The `versions.json` schema stays `schemaVersion: 2`, `ui-autoload` is an **additive, optional** package key, and the change is **backward-compatible with the currently-live index** (which has no `ui-autoload` key). An index without the key still parses, still serves the other packages, and every `/ui-autoload` route resolves to a clean 404 until the tree exists.

**Publishing the `ui-autoload` tree comes in a follow-up PR** — the publish/build scripts (`packages/cdn/scripts/**`) and `versions.json` releases are intentionally untouched here.

## What changed (worker READ path)

- **`queries.ts`** — `ui-autoload` added to `PACKAGE_NAMES` so `/ui-autoload` and `/ui-autoload@<ref>/…` routes parse.
- **`types.ts`** — `ui-autoload` added to the `PackageName` union, the `VersionsIndex.packages` shape, and the registry document (`packages` + `current`), mirroring the `ui-mapbox` entries.
- **`versions.ts`** — `parseVersionsIndex` now validates `ui-autoload` when present and **defaults it to `EMPTY_UI_PACKAGE` when absent** (additive; schema stays 2). Resolution (`resolveVersion` / `resolveUiLikeVersion` / `resolveBareRoot`) treats `ui-autoload` as ui-like — exact semver, aliases, `latest`/`next`/`main`, immutable `main-<sha>` channels namespaced under `channels/ui-autoload/`. New `resolveCurrentUiAutoloadRef` uses the same fallback ladder as ui/ui-mapbox.
- **`registry.ts`** — `ui-autoload` listed in `packages` + `current`, degrading to an empty inventory and `null` current when the live index omits the key.
- **`index.ts`** — `ui-autoload` maps to the `@studiometa/ui-cdn-autoload` build identity and its `releases/ui-autoload/<v>` / `channels/ui-autoload/<id>` prefixes; the current ref is wired into the registry.

Net effect after deploy: `/ui-autoload@<v>/…`, `/ui-autoload@next|main/…`, versionless `/ui-autoload/…`, and bare `/ui-autoload` all resolve the same way the `ui` tree does. They 404 at the asset layer only because nothing is published yet — expected until the publish PR.

## Tests

- **ui-autoload routing + registry (key present):** exact versions, `latest`/`next`/`main`, aliases, immutable channels, versionless and bare/ref roots, `X-TypeScript-Types`, and the registry listing it (`packages` + `current`). The fixture synthesizes a `ui-autoload` tree by cloning the ui-mapbox tree (real tree published later).
- **Two-phase backward-compat (index WITHOUT the `ui-autoload` key):** proves the live index still parses, the other packages still serve, every `/ui-autoload` route 404s (never a 400/502), and the registry empties `ui-autoload` gracefully — both at the worker request level (`index.test.ts`) and the pure resolution level (`versions.test.ts`).

## Verification

- `versions.test.ts` (pure unit, incl. the two new ui-autoload tests): **25/25 pass**.
- `tsgo` typecheck (`lint:types`): **pass** — validates all worker + test TypeScript.
- `npm run lint`: **0 errors** (pre-existing baseline warnings only); changed files are Prettier-clean.
- The full CDN build succeeded standalone (`exit 0`), confirming the source and fixtures are structurally valid.
- **Skipped here:** `index.test.ts` and the full CDN vitest could not run — their `beforeAll` builds the ui/ui-mapbox/js-toolkit trees (dts eager compile, ~4.5 GB RSS), which OOMs on this ~7.6 GB / heavily-swapped machine. This is an environment limitation, not a code issue; the tests are expected to pass in CI on standard hardware.

## Ambiguity resolved

The brief mentioned the "public npm name `@studiometa/ui-autoload`" for `PUBLIC_PACKAGE_NAMES`, but that map holds the **CDN build identity** (`@studiometa/ui-cdn`, `@studiometa/ui-cdn-mapbox`, `@studiometa/ui-cdn-js-toolkit`). I followed the existing convention and used **`@studiometa/ui-cdn-autoload`** so it matches what the build's `build.json` `package.name` will carry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014FQxYGj2RqgcP8BkubpiNu