### PR TITLE
Publish @studiometa/ui-autoload as its own CDN tree

### DIFF
--- a/packages/cdn/scripts/build.ts
+++ b/packages/cdn/scripts/build.ts
@@ -880,12 +880,12 @@ const uiAutoloadTreePrefix = `releases/ui-autoload/${uiVersion}`;
 const uiAutoloadOutputDirectory = resolve(outputDirectory, uiAutoloadTreePrefix);
 const UI_AUTOLOAD_BUILD_NAME = '@studiometa/ui-cdn-autoload';
 // The composed autoload reuses each package's manifest from that package's own versioned tree rather
-// than re-bundling it. The absolute origin pins these cross-tree imports to the canonical CDN
-// regardless of where the ui-autoload bundle itself is loaded from; the version is the lockstep
-// `uiVersion`, mirroring the `/ui-mapbox@<uiVersion>/…` URLs `externalizeUiMapboxPlugin` bakes.
-const CDN_ORIGIN = 'https://cdn.studiometa.dev';
-const uiManifestCdnUrl = `${CDN_ORIGIN}/ui@${uiVersion}/manifest.js`;
-const uiMapboxManifestCdnUrl = `${CDN_ORIGIN}/ui-mapbox@${uiVersion}/manifest.js`;
+// than re-bundling it. These are baked as origin-relative absolute paths (leading `/`, no host),
+// exactly like the js-toolkit URL and the `/ui-mapbox@<uiVersion>/…` cross-tree imports
+// `externalizeUiMapboxPlugin` bakes — so every channel (releases and PR previews alike) resolves the
+// manifest same-origin and stays host-portable. The version is the lockstep `uiVersion`.
+const uiManifestCdnUrl = `/ui@${uiVersion}/manifest.js`;
+const uiMapboxManifestCdnUrl = `/ui-mapbox@${uiVersion}/manifest.js`;
 
 const currentSourceState = await sourceState();
 if (!currentSourceState.clean && !allowDirty) {

--- a/packages/cdn/scripts/build.ts
+++ b/packages/cdn/scripts/build.ts
@@ -329,6 +329,27 @@ function externalizeUiMapboxPlugin(urlByModule: ReadonlyMap<string, string>): Pl
   };
 }
 
+/**
+ * Rewrites the ui-autoload tree's cross-package `@studiometa/ui/manifest` and
+ * `@studiometa/ui-mapbox/manifest` specifiers to baked, absolute CDN URLs and marks them external,
+ * mirroring `externalizeToolkitPlugin`. Neither component manifest is bundled into the ui-autoload
+ * tree: each side-effect entry imports the SAME versioned manifest module already served from its own
+ * tree, so the composed autoload reuses one manifest — and the lazily-loaded component chunks it
+ * references — per package rather than re-bundling any component source. The baked version is the
+ * lockstep `uiVersion`, the same version `externalizeUiMapboxPlugin` bakes into the ui tree, so the
+ * manifest URLs pin consistently with the rest of the build.
+ */
+function externalizeUiAutoloadManifestsPlugin(mapping: Record<string, string>): Plugin {
+  return {
+    name: 'cdn-externalize-ui-autoload-manifests',
+    resolveId(id: string) {
+      const url = mapping[id];
+      if (!url) return undefined;
+      return { id: url, external: true };
+    },
+  };
+}
+
 // Rolldown reports every module id it bundles as an absolute path; keep only real, in-repository
 // source files (dropping rolldown's virtual/runtime modules) and normalise them to the same
 // repository-relative POSIX keys esbuild's metafile inputs used.
@@ -493,6 +514,39 @@ function assertUiExternals(
   return {
     toolkitUrls: external.filter((url) => url === jsToolkitIndexUrl || url === jsToolkitUtilsUrl),
   };
+}
+
+/**
+ * Asserts the ui-autoload tree's externalization invariants: js-toolkit and both component manifests
+ * are its only external imports, every required URL is present (so the externalization actually
+ * fired), and no js-toolkit, ui or ui-mapbox source is bundled into the tree — only the generic
+ * autoloader engine (from `packages/ui-autoload`) is.
+ */
+function assertUiAutoloadExternals(
+  metafile: Metafile,
+  requiredUrls: readonly string[],
+  allowedUrls: readonly string[],
+): void {
+  const external = collectExternalImports(metafile);
+  const allowed = new Set(allowedUrls);
+  const disallowed = external.filter((url) => !allowed.has(url));
+  if (disallowed.length > 0) {
+    throw new Error(`The ui-autoload tree has unexpected external imports: ${disallowed.join(', ')}`);
+  }
+  const missing = requiredUrls.filter((url) => !external.includes(url));
+  if (missing.length > 0) {
+    throw new Error(`The ui-autoload tree is missing expected external import(s): ${missing.join(', ')}`);
+  }
+  const bundled = Object.keys(metafile.inputs).filter((input) =>
+    ['node_modules/@studiometa/js-toolkit/', 'packages/ui/', 'packages/ui-mapbox/'].some((needle) =>
+      toPosix(input).includes(needle),
+    ),
+  );
+  if (bundled.length > 0) {
+    throw new Error(
+      `The ui-autoload tree bundled a cross-package dependency instead of externalizing it: ${bundled.join(', ')}`,
+    );
+  }
 }
 
 // Rolldown keeps a bare *dynamic* external as a runtime `import('<specifier>')` in the emitted code
@@ -820,6 +874,18 @@ const uiMapboxOutputDirectory = resolve(outputDirectory, uiMapboxTreePrefix);
 const jsToolkitOutputDirectory = resolve(outputDirectory, jsToolkitTreePrefix);
 const UI_MAPBOX_BUILD_NAME = '@studiometa/ui-cdn-mapbox';
 const uiMapboxComponentUrl = (subpath: string): string => `/ui-mapbox@${uiVersion}/${subpath}.js`;
+// The ui-autoload tree is also versioned in lockstep with ui, so it reuses `uiVersion` for both its
+// own prefix and the cross-tree manifest URLs it bakes.
+const uiAutoloadTreePrefix = `releases/ui-autoload/${uiVersion}`;
+const uiAutoloadOutputDirectory = resolve(outputDirectory, uiAutoloadTreePrefix);
+const UI_AUTOLOAD_BUILD_NAME = '@studiometa/ui-cdn-autoload';
+// The composed autoload reuses each package's manifest from that package's own versioned tree rather
+// than re-bundling it. The absolute origin pins these cross-tree imports to the canonical CDN
+// regardless of where the ui-autoload bundle itself is loaded from; the version is the lockstep
+// `uiVersion`, mirroring the `/ui-mapbox@<uiVersion>/…` URLs `externalizeUiMapboxPlugin` bakes.
+const CDN_ORIGIN = 'https://cdn.studiometa.dev';
+const uiManifestCdnUrl = `${CDN_ORIGIN}/ui@${uiVersion}/manifest.js`;
+const uiMapboxManifestCdnUrl = `${CDN_ORIGIN}/ui-mapbox@${uiVersion}/manifest.js`;
 
 const currentSourceState = await sourceState();
 if (!currentSourceState.clean && !allowDirty) {
@@ -835,6 +901,7 @@ const mapboxDefinitions = definitions.filter(
 await rm(outputDirectory, { recursive: true, force: true });
 await mkdir(uiOutputDirectory, { recursive: true });
 await mkdir(uiMapboxOutputDirectory, { recursive: true });
+await mkdir(uiAutoloadOutputDirectory, { recursive: true });
 await mkdir(jsToolkitOutputDirectory, { recursive: true });
 
 const buildTime = reproducibleBuildTime();
@@ -963,17 +1030,54 @@ await tsdownBuild({
 });
 const uiMapboxMetafile = metafileFromChunks(chunksOf(uiMapboxResults));
 
+// Pass D — the @studiometa/ui-autoload tree, versioned in lockstep with ui. It bundles the generic
+// autoloader engine (loader, autoload, runtime, types) and emits three stable entries: the pure
+// `index.js` barrel plus the two side-effect entries `ui.js` and `ui-mapbox.js`. js-toolkit is
+// rewritten to the same external, versioned URL every other tree uses (so all trees share one runtime
+// instance and one component registry), and the `@studiometa/ui` and `@studiometa/ui-mapbox` component
+// manifests are externalized to their own trees' `/…/manifest.js` URLs — no component source, and no
+// manifest, is re-bundled here. The engine and `runtime.ts` are bundled INTO the tree.
+const uiAutoloadEntryPoints = {
+  index: resolve(repositoryDirectory, 'packages/ui-autoload/index.ts'),
+  ui: resolve(repositoryDirectory, 'packages/ui-autoload/ui.ts'),
+  'ui-mapbox': resolve(repositoryDirectory, 'packages/ui-autoload/ui-mapbox.ts'),
+};
+const uiAutoloadManifestMapping: Record<string, string> = {
+  '@studiometa/ui/manifest': uiManifestCdnUrl,
+  '@studiometa/ui-mapbox/manifest': uiMapboxManifestCdnUrl,
+};
+const uiAutoloadResults = await tsdownBuild({
+  ...sharedBundleOptions(uiAutoloadOutputDirectory),
+  entry: uiAutoloadEntryPoints,
+  plugins: [
+    externalizeToolkitPlugin(),
+    externalizeUiAutoloadManifestsPlugin(uiAutoloadManifestMapping),
+  ],
+});
+await tsdownBuild({
+  ...sharedDeclarationOptions(uiAutoloadOutputDirectory, [
+    '@studiometa/js-toolkit',
+    '@studiometa/js-toolkit/utils',
+    '@studiometa/ui/manifest',
+    '@studiometa/ui-mapbox/manifest',
+  ]),
+  entry: uiAutoloadEntryPoints,
+});
+const uiAutoloadMetafile = metafileFromChunks(chunksOf(uiAutoloadResults));
+
 // Re-export facade entries carry no source map from rolldown; synthesize the empty maps so the
-// public source-map invariant holds across both trees.
+// public source-map invariant holds across every tree.
 await synthesizeFacadeSourceMaps(jsToolkitOutputDirectory);
 await synthesizeFacadeSourceMaps(uiOutputDirectory);
 await synthesizeFacadeSourceMaps(uiMapboxOutputDirectory);
+await synthesizeFacadeSourceMaps(uiAutoloadOutputDirectory);
 
 // Mapbox GL and the geocoder are external (import-map resolved) and no longer bundled, so the CDN
 // serves neither their JavaScript, their stylesheets nor their license notices — consumers load
 // those from the same source they point their import map at.
 await writeThirdPartyNotices(uiMetafile, uiOutputDirectory);
 await writeThirdPartyNotices(uiMapboxMetafile, uiMapboxOutputDirectory);
+await writeThirdPartyNotices(uiAutoloadMetafile, uiAutoloadOutputDirectory);
 await writeThirdPartyNotices(jsToolkitMetafile, jsToolkitOutputDirectory);
 
 const uiEntryNames = ['autoload', 'loader', 'manifest', 'index'];
@@ -1076,6 +1180,38 @@ for (const [output, metadata] of Object.entries(uiMapboxMetafile.outputs)) {
 const uiMapboxEntryOutputs = { index: 'index.js' };
 if (!uiMapboxMetafile.outputs['index.js']) {
   throw new Error('Missing ui-mapbox entry output index.js.');
+}
+
+// The ui-autoload tree externalizes js-toolkit and both component manifests; nothing else may be an
+// external import, both manifests and the js-toolkit URL must be present, and no js-toolkit/ui/
+// ui-mapbox source may be bundled into it.
+const uiAutoloadRequiredUrls = [jsToolkitIndexUrl, uiManifestCdnUrl, uiMapboxManifestCdnUrl];
+const uiAutoloadAllowedUrls = [
+  jsToolkitIndexUrl,
+  jsToolkitUtilsUrl,
+  uiManifestCdnUrl,
+  uiMapboxManifestCdnUrl,
+];
+assertUiAutoloadExternals(uiAutoloadMetafile, uiAutoloadRequiredUrls, uiAutoloadAllowedUrls);
+const uiAutoloadInitialFiles = (await listFiles(uiAutoloadOutputDirectory)).filter(
+  (file) => !file.endsWith('.json'),
+);
+await assertBrowserImports(
+  uiAutoloadMetafile,
+  uiAutoloadOutputDirectory,
+  uiAutoloadInitialFiles,
+  new Set(uiAutoloadAllowedUrls),
+);
+for (const file of uiAutoloadInitialFiles.filter((path) => path.endsWith('.js'))) {
+  if (!uiAutoloadInitialFiles.includes(`${file}.map`))
+    throw new Error(`Missing public sourcemap for ${file}.`);
+}
+const uiAutoloadSizes = await fileSizes(uiAutoloadOutputDirectory, uiAutoloadInitialFiles);
+const uiAutoloadEntryOutputs = { index: 'index.js', ui: 'ui.js', 'ui-mapbox': 'ui-mapbox.js' };
+for (const [name, file] of Object.entries(uiAutoloadEntryOutputs)) {
+  if (!uiAutoloadMetafile.outputs[file]) {
+    throw new Error(`Missing ui-autoload entry output ${file} for ${name}.`);
+  }
 }
 
 const jsToolkitEntryOutputs = Object.fromEntries(
@@ -1479,12 +1615,76 @@ const uiMapboxBuildMetadata = {
   },
 };
 
-// The js-toolkit and ui-mapbox trees are each self-contained (they record no total:release), so
-// their metadata is stable and written once. Each integrity manifest hashes every file in its tree
-// including its own build.json.
+const uiAutoloadBuildMetadata = {
+  schemaVersion: 1,
+  format: {
+    name: 'studiometa-browser-cdn-autoload',
+    version: 1,
+    module: 'esm',
+    target: 'es2020',
+    splitting: true,
+    sourcemaps: true,
+    declarations: true,
+    bundler: bundlerLabel,
+  },
+  // The ui-autoload tree is versioned in lockstep with ui, so it reports the ui version.
+  package: { name: UI_AUTOLOAD_BUILD_NAME, version: uiVersion },
+  dependencies: { '@studiometa/js-toolkit': jsToolkitVersion },
+  build: {
+    commit,
+    identifier: `${UI_AUTOLOAD_BUILD_NAME}@${uiVersion}+${commit}`,
+    clean: currentSourceState.clean,
+    publishable: currentSourceState.clean,
+    createdAt: buildTime.iso,
+    sourceDateEpoch: buildTime.epoch,
+    timeSource: buildTime.source,
+  },
+  entries: entryMetadataFor(uiAutoloadMetafile, uiAutoloadOutputDirectory, uiAutoloadEntryOutputs),
+  // The ui-autoload tree serves the generic engine and side-effect entries only; it declares no
+  // components of its own (each component still lives in its package's own tree).
+  components: {},
+  outputs: outputMetadataFor(uiAutoloadInitialFiles, uiAutoloadSizes),
+  licenses: {
+    thirdPartyNotices: 'licenses/THIRD_PARTY_LICENSES.txt',
+    legalComments: 'none',
+  },
+  integrations: {
+    'js-toolkit': {
+      status: 'external-versioned-artifact',
+      version: jsToolkitVersion,
+      urls: [jsToolkitIndexUrl],
+      release: jsToolkitTreePrefix,
+      note: 'js-toolkit is built as its own versioned artifact and imported by an absolute, origin-relative URL so the ui-autoload engine shares one runtime instance with the ui and ui-mapbox trees.',
+    },
+    'ui-manifest': {
+      status: 'external-cross-tree',
+      url: uiManifestCdnUrl,
+      note: 'The @studiometa/ui component manifest is reused from the ui tree (`/ui@<version>/manifest.js`) rather than re-bundled, so the side-effect `ui.js` entry loads exactly one manifest and its lazily-loaded component chunks from that tree.',
+    },
+    'ui-mapbox-manifest': {
+      status: 'external-cross-tree',
+      url: uiMapboxManifestCdnUrl,
+      note: 'The @studiometa/ui-mapbox component manifest is reused from the ui-mapbox tree (`/ui-mapbox@<version>/manifest.js`) rather than re-bundled.',
+    },
+  },
+  assertions: {
+    jsToolkitIdentities: [toolkitIdentity],
+    jsToolkitExternalUrls: [jsToolkitIndexUrl],
+    treeBundlesToolkit: false,
+    manifestExternalUrls: [uiManifestCdnUrl, uiMapboxManifestCdnUrl],
+    treeBundlesManifests: false,
+    onlyAllowedBareExternals: true,
+    publicSourceMaps: true,
+  },
+};
+
+// The js-toolkit, ui-mapbox and ui-autoload trees are each self-contained (they record no
+// total:release), so their metadata is stable and written once. Each integrity manifest hashes every
+// file in its tree including its own build.json.
 for (const [treeDirectory, treeFiles, metadata] of [
   [jsToolkitOutputDirectory, jsToolkitInitialFiles, jsToolkitBuildMetadata] as const,
   [uiMapboxOutputDirectory, uiMapboxInitialFiles, uiMapboxBuildMetadata] as const,
+  [uiAutoloadOutputDirectory, uiAutoloadInitialFiles, uiAutoloadBuildMetadata] as const,
 ]) {
   await writeJson(resolve(treeDirectory, 'build.json'), metadata);
   const integrityFiles = [...treeFiles, 'build.json'].sort();
@@ -1538,5 +1738,5 @@ enforceSizeBudgets(observedBudgets);
 
 const totalPublicFiles = (await listFiles(outputDirectory)).length;
 console.log(
-  `Built ${definitions.length} components and ${totalPublicFiles} public files across ${uiTreePrefix}, ${uiMapboxTreePrefix} and ${jsToolkitTreePrefix}.`,
+  `Built ${definitions.length} components and ${totalPublicFiles} public files across ${uiTreePrefix}, ${uiMapboxTreePrefix}, ${uiAutoloadTreePrefix} and ${jsToolkitTreePrefix}.`,
 );

--- a/packages/cdn/scripts/lib/publication.ts
+++ b/packages/cdn/scripts/lib/publication.ts
@@ -169,6 +169,13 @@ export interface PublishOptions {
    * channel, or preview channel at the same identity). Omitted for js-toolkit publications.
    */
   lockstepUiMapbox?: Artifact;
+  /**
+   * The lockstep @studiometa/ui-autoload artifact published alongside a ui publication, handled
+   * identically to {@link PublishOptions.lockstepUiMapbox}: staged, verified and copied into the
+   * ui-autoload tree before the single versions.json write, and advanced to the same identity by
+   * that same index write. Omitted for js-toolkit publications.
+   */
+  lockstepUiAutoload?: Artifact;
 }
 
 export interface PublishResult {
@@ -261,23 +268,31 @@ async function stageAndCopyArtifact(
   });
 }
 
-// The ui-mapbox tree is published in lockstep with ui at the same identity. Its releases are
-// namespaced under `releases/ui-mapbox/<version>` and its channels under `channels/ui-mapbox/<id>`
-// so they never collide with the ui tree's `releases/ui/<version>` and flat `channels/<id>`.
-function lockstepUiMapboxPrefix(target: PublishTarget, identity: string): string {
+// The additive lockstep trees (`ui-mapbox`, `ui-autoload`) are published in lockstep with ui at the
+// same identity. Their releases are namespaced under `releases/<package>/<version>` and their
+// channels under `channels/<package>/<id>` so they never collide with the ui tree's
+// `releases/ui/<version>` and flat `channels/<id>`.
+type LockstepPackageName = 'ui-mapbox' | 'ui-autoload';
+
+function lockstepPrefix(
+  packageName: LockstepPackageName,
+  target: PublishTarget,
+  identity: string,
+): string {
   return target.kind === 'release'
-    ? `releases/ui-mapbox/${target.version}`
-    : `channels/ui-mapbox/${identity}`;
+    ? `releases/${packageName}/${target.version}`
+    : `channels/${packageName}/${identity}`;
 }
 
-function advanceUiMapboxLockstep(
+function advanceLockstep(
   index: WorkingVersionsIndex,
+  packageName: LockstepPackageName,
   target: PublishTarget,
   identity: string,
 ): WorkingVersionsIndex {
-  if (target.kind === 'channel') return addChannel(index, 'ui-mapbox', identity);
-  if (target.kind === 'preview') return addPreviewChannel(index, 'ui-mapbox', identity);
-  return addRelease(index, 'ui-mapbox', target.version);
+  if (target.kind === 'channel') return addChannel(index, packageName, identity);
+  if (target.kind === 'preview') return addPreviewChannel(index, packageName, identity);
+  return addRelease(index, packageName, target.version);
 }
 
 export async function publish(
@@ -301,18 +316,27 @@ export async function publish(
     );
   }
 
-  const lockstep = options.lockstepUiMapbox;
-  const lockstepPrefix = lockstep ? lockstepUiMapboxPrefix(target, identity) : undefined;
-  if (lockstep) {
+  // The additive lockstep trees are staged, copied and indexed alongside ui in the same atomic
+  // versions.json write, in a stable order (ui-mapbox then ui-autoload). Each shares ui's identity.
+  const lockstepArtifacts: Array<{ packageName: LockstepPackageName; artifact: Artifact }> = [];
+  if (options.lockstepUiMapbox) {
+    lockstepArtifacts.push({ packageName: 'ui-mapbox', artifact: options.lockstepUiMapbox });
+  }
+  if (options.lockstepUiAutoload) {
+    lockstepArtifacts.push({ packageName: 'ui-autoload', artifact: options.lockstepUiAutoload });
+  }
+  for (const { packageName, artifact: lockstepArtifact } of lockstepArtifacts) {
     if (
       (target.kind === 'channel' || target.kind === 'preview') &&
-      lockstep.build.build.commit !== target.commit
+      lockstepArtifact.build.build.commit !== target.commit
     ) {
-      throw new Error('The ui-mapbox build commit does not match the requested channel commit.');
-    }
-    if (target.kind === 'release' && lockstep.build.package.version !== target.version) {
       throw new Error(
-        `The ui-mapbox build version ${lockstep.build.package.version} does not match the release tag ${target.version}.`,
+        `The ${packageName} build commit does not match the requested channel commit.`,
+      );
+    }
+    if (target.kind === 'release' && lockstepArtifact.build.package.version !== target.version) {
+      throw new Error(
+        `The ${packageName} build version ${lockstepArtifact.build.package.version} does not match the release tag ${target.version}.`,
       );
     }
   }
@@ -322,40 +346,50 @@ export async function publish(
   // below so re-running a publish for an already-published release moves its distribution tag. A
   // channel or preview is commit-addressed and re-publishing one is a mistake, so it still hard-fails.
   const finalAlreadyPublished = (await store.head(`${finalPrefix}/build.json`)) !== undefined;
-  const lockstepAlreadyPublished =
-    lockstepPrefix !== undefined &&
-    (await store.head(`${lockstepPrefix}/build.json`)) !== undefined;
+  const preparedLockstep = await Promise.all(
+    lockstepArtifacts.map(async ({ packageName, artifact: lockstepArtifact }) => {
+      const prefix = lockstepPrefix(packageName, target, identity);
+      return {
+        packageName,
+        artifact: lockstepArtifact,
+        finalPrefix: prefix,
+        alreadyPublished: (await store.head(`${prefix}/build.json`)) !== undefined,
+      };
+    }),
+  );
   if (target.kind !== 'release') {
     if (finalAlreadyPublished) {
       throw new Error(`${identity} is already published and immutable; refusing to overwrite it.`);
     }
-    if (lockstepAlreadyPublished) {
-      throw new Error(
-        `${identity} (ui-mapbox) is already published and immutable; refusing to overwrite it.`,
-      );
+    for (const tree of preparedLockstep) {
+      if (tree.alreadyPublished) {
+        throw new Error(
+          `${identity} (${tree.packageName}) is already published and immutable; refusing to overwrite it.`,
+        );
+      }
     }
   }
 
   const now = options.now ?? Date.now();
   const publicationId = options.publicationId ?? `${identity}-${now}`;
   const temporaryPrefix = `tmp/${publicationId}`;
-  const lockstepTemporaryPrefix = `tmp/${publicationId}-ui-mapbox`;
 
   if (finalAlreadyPublished) {
     log(`${identity} is already published; skipping its upload and only advancing dist-tags.`);
   } else {
     await stageAndCopyArtifact(store, artifact, finalPrefix, temporaryPrefix, identity, log);
   }
-  if (lockstep && lockstepPrefix) {
-    if (lockstepAlreadyPublished) {
-      log(`${identity} (ui-mapbox) is already published; skipping its upload.`);
+  for (const tree of preparedLockstep) {
+    const treeTemporaryPrefix = `tmp/${publicationId}-${tree.packageName}`;
+    if (tree.alreadyPublished) {
+      log(`${identity} (${tree.packageName}) is already published; skipping its upload.`);
     } else {
       await stageAndCopyArtifact(
         store,
-        lockstep,
-        lockstepPrefix,
-        lockstepTemporaryPrefix,
-        `${identity} (ui-mapbox)`,
+        tree.artifact,
+        tree.finalPrefix,
+        treeTemporaryPrefix,
+        `${identity} (${tree.packageName})`,
         log,
       );
     }
@@ -373,8 +407,8 @@ export async function publish(
   } else {
     nextIndex = addJsToolkitRelease(currentIndex, target.version);
   }
-  if (lockstep) {
-    nextIndex = advanceUiMapboxLockstep(nextIndex, target, identity);
+  for (const tree of preparedLockstep) {
+    nextIndex = advanceLockstep(nextIndex, tree.packageName, target, identity);
   }
   const serialized = new Uint8Array(Buffer.from(serializeVersionsIndex(nextIndex), 'utf8'));
   await store.put(VERSIONS_KEY, serialized, {
@@ -389,10 +423,13 @@ export async function publish(
       store.delete(`${temporaryPrefix}/${file.path}`),
     );
   }
-  if (lockstep && !lockstepAlreadyPublished) {
-    await forEachWithConcurrency(lockstep.files, (file) =>
-      store.delete(`${lockstepTemporaryPrefix}/${file.path}`),
-    );
+  for (const tree of preparedLockstep) {
+    if (!tree.alreadyPublished) {
+      const treeTemporaryPrefix = `tmp/${publicationId}-${tree.packageName}`;
+      await forEachWithConcurrency(tree.artifact.files, (file) =>
+        store.delete(`${treeTemporaryPrefix}/${file.path}`),
+      );
+    }
   }
 
   return {
@@ -401,7 +438,9 @@ export async function publish(
     publicationId,
     uploadedFiles: [
       ...artifact.files.map((file) => file.path),
-      ...(lockstep ? lockstep.files.map((file) => `ui-mapbox/${file.path}`) : []),
+      ...preparedLockstep.flatMap((tree) =>
+        tree.artifact.files.map((file) => `${tree.packageName}/${file.path}`),
+      ),
     ],
     index: nextIndex,
   };
@@ -433,9 +472,10 @@ export async function rollback(
   const index = parseWorkingVersionsIndex(existing);
   const ui = index.packages.ui;
   const uiMapbox = index.packages['ui-mapbox'];
+  const uiAutoload = index.packages['ui-autoload'];
 
-  // ui-mapbox is versioned in lockstep with ui, so a rollback moves both packages' tags together to
-  // the same identity and requires both trees' immutable objects to be present.
+  // ui-mapbox and ui-autoload are versioned in lockstep with ui, so a rollback moves every package's
+  // tags together to the same identity and requires all three trees' immutable objects to be present.
   if (target.kind === 'release') {
     if (!isStableVersion(target.version)) {
       throw new Error('The latest tag can only point at a stable, non-prerelease release.');
@@ -443,6 +483,7 @@ export async function rollback(
     for (const [packageName, pkg] of [
       ['ui', ui],
       ['ui-mapbox', uiMapbox],
+      ['ui-autoload', uiAutoload],
     ] as const) {
       if (!pkg.releases.includes(target.version)) {
         throw new Error(
@@ -459,6 +500,7 @@ export async function rollback(
     }
     ui.distTags.latest = target.version;
     uiMapbox.distTags.latest = target.version;
+    uiAutoload.distTags.latest = target.version;
     log(`Rolling the latest tag back to ${target.version}.`);
   } else {
     if (!isChannelId(target.channelId)) {
@@ -467,6 +509,7 @@ export async function rollback(
     for (const [packageName, pkg, prefix] of [
       ['ui', ui, `channels/${target.channelId}`],
       ['ui-mapbox', uiMapbox, `channels/ui-mapbox/${target.channelId}`],
+      ['ui-autoload', uiAutoload, `channels/ui-autoload/${target.channelId}`],
     ] as const) {
       if (!pkg.channels.includes(target.channelId)) {
         throw new Error(
@@ -483,6 +526,8 @@ export async function rollback(
     ui.distTags.main = target.channelId;
     uiMapbox.distTags.next = target.channelId;
     uiMapbox.distTags.main = target.channelId;
+    uiAutoload.distTags.next = target.channelId;
+    uiAutoload.distTags.main = target.channelId;
     log(`Rolling the next and main tags back to ${target.channelId}.`);
   }
 
@@ -519,13 +564,15 @@ export async function pruneUiPreviewChannelsForPr(
   }
   const index = parseWorkingVersionsIndex(existing);
   const prefix = `pr-${pr}-`;
-  // ui and ui-mapbox share the same lockstep preview channel identities; prune both packages' copies
-  // of every `pr-<pr>-<sha>` channel. The reported set is the union of ids removed from either.
+  // ui, ui-mapbox and ui-autoload share the same lockstep preview channel identities; prune every
+  // package's copy of each `pr-<pr>-<sha>` channel. The reported set is the union of ids removed.
   const removed = [
     ...new Set(
-      [...index.packages.ui.channels, ...index.packages['ui-mapbox'].channels].filter(
-        (channel) => channel.startsWith(prefix) && isPreviewChannelId(channel),
-      ),
+      [
+        ...index.packages.ui.channels,
+        ...index.packages['ui-mapbox'].channels,
+        ...index.packages['ui-autoload'].channels,
+      ].filter((channel) => channel.startsWith(prefix) && isPreviewChannelId(channel)),
     ),
   ].sort();
   if (removed.length === 0) {
@@ -537,6 +584,7 @@ export async function pruneUiPreviewChannelsForPr(
   for (const channelId of removed) {
     nextIndex = removeUiChannel(nextIndex, channelId);
     nextIndex = removeChannel(nextIndex, 'ui-mapbox', channelId);
+    nextIndex = removeChannel(nextIndex, 'ui-autoload', channelId);
   }
   const serialized = new Uint8Array(Buffer.from(serializeVersionsIndex(nextIndex), 'utf8'));
   await store.put(VERSIONS_KEY, serialized, {

--- a/packages/cdn/scripts/lib/versions.ts
+++ b/packages/cdn/scripts/lib/versions.ts
@@ -34,23 +34,24 @@ export interface JsToolkitPackageIndex {
   releases: string[];
 }
 
-export type UiLikePackageName = 'ui' | 'ui-mapbox';
+export type UiLikePackageName = 'ui' | 'ui-mapbox' | 'ui-autoload';
 
 /**
  * Working representation of the schemaVersion 2 `versions.json`. Releases are namespaced per
- * package: `ui` and `ui-mapbox` each keep releases, immutable channels and distribution tags (and
- * are versioned in lockstep); `js-toolkit` is exact-version only and carries just a release
- * inventory. `ui-mapbox` is an additive, optional package: an index predating the ui-mapbox tree
- * simply omits it, and it is bootstrapped empty and populated in place under the same
- * schemaVersion 2. It intentionally allows partial distribution tags so the tooling can bootstrap
- * the index before a stable release and a main channel exist. Once fully populated it satisfies the
- * strict schema the Worker validates on read.
+ * package: `ui`, `ui-mapbox` and `ui-autoload` each keep releases, immutable channels and
+ * distribution tags (and are versioned in lockstep with ui); `js-toolkit` is exact-version only and
+ * carries just a release inventory. `ui-mapbox` and `ui-autoload` are additive, optional packages: an
+ * index predating either tree simply omits it, and it is bootstrapped empty and populated in place
+ * under the same schemaVersion 2. They intentionally allow partial distribution tags so the tooling
+ * can bootstrap the index before a stable release and a main channel exist. Once fully populated they
+ * satisfy the strict schema the Worker validates on read.
  */
 export interface WorkingVersionsIndex {
   schemaVersion: 2;
   packages: {
     ui: UiPackageIndex;
     'ui-mapbox': UiPackageIndex;
+    'ui-autoload': UiPackageIndex;
     'js-toolkit': JsToolkitPackageIndex;
   };
 }
@@ -115,6 +116,7 @@ function emptyIndex(): WorkingVersionsIndex {
     packages: {
       ui: { releases: [], channels: [], distTags: {} },
       'ui-mapbox': { releases: [], channels: [], distTags: {} },
+      'ui-autoload': { releases: [], channels: [], distTags: {} },
       'js-toolkit': { releases: [] },
     },
   };
@@ -145,10 +147,10 @@ function parseUiLikePackage(value: unknown): UiPackageIndex {
 /**
  * Parses an existing schemaVersion 2 `versions.json` payload leniently, returning an empty index
  * when the object is absent so a first publication can bootstrap it. Known entries are preserved.
- * A live schema-2 index that predates the ui-mapbox tree (and therefore omits the `ui-mapbox` key)
- * is accepted and migrated in place: the missing package is initialized empty so this publication
- * can add its release/channel while the index stays schemaVersion 2. A valid schema-2 index is
- * never refused.
+ * A live schema-2 index that predates the ui-mapbox or ui-autoload tree (and therefore omits that
+ * key) is accepted and migrated in place: the missing package is initialized empty so this
+ * publication can add its release/channel while the index stays schemaVersion 2. A valid schema-2
+ * index is never refused.
  */
 export function parseWorkingVersionsIndex(text: string | undefined): WorkingVersionsIndex {
   if (text === undefined) return emptyIndex();
@@ -169,6 +171,7 @@ export function parseWorkingVersionsIndex(text: string | undefined): WorkingVers
     packages: {
       ui: parseUiLikePackage(value.packages.ui),
       'ui-mapbox': parseUiLikePackage(value.packages['ui-mapbox']),
+      'ui-autoload': parseUiLikePackage(value.packages['ui-autoload']),
       'js-toolkit': {
         releases: stringArray(jsToolkit.releases),
       },
@@ -201,6 +204,7 @@ export function serializeVersionsIndex(index: WorkingVersionsIndex): string {
     packages: {
       ui: serializeUiLikePackage(index.packages.ui),
       'ui-mapbox': serializeUiLikePackage(index.packages['ui-mapbox']),
+      'ui-autoload': serializeUiLikePackage(index.packages['ui-autoload']),
       'js-toolkit': {
         releases: [...new Set(index.packages['js-toolkit'].releases)].sort(compareStableVersions),
       },

--- a/packages/cdn/scripts/publish.ts
+++ b/packages/cdn/scripts/publish.ts
@@ -96,15 +96,23 @@ async function main(): Promise<void> {
 
   const uiTree = await singleTreeDirectory(resolve(outputDirectory, 'releases/ui'));
   const uiMapboxTree = await singleTreeDirectory(resolve(outputDirectory, 'releases/ui-mapbox'));
+  const uiAutoloadTree = await singleTreeDirectory(resolve(outputDirectory, 'releases/ui-autoload'));
   const jsToolkitTree = await singleTreeDirectory(resolve(outputDirectory, 'releases/js-toolkit'));
   const uiArtifact = await readArtifact(uiTree.directory);
   const uiMapboxArtifact = await readArtifact(uiMapboxTree.directory);
+  const uiAutoloadArtifact = await readArtifact(uiAutoloadTree.directory);
   const jsToolkitArtifact = await readArtifact(jsToolkitTree.directory);
 
-  // ui-mapbox is versioned in lockstep with ui: both trees must carry the same version.
+  // ui-mapbox and ui-autoload are versioned in lockstep with ui: every tree must carry the same
+  // version.
   if (uiMapboxTree.version !== uiTree.version) {
     throw new Error(
       `The ui-mapbox tree version ${uiMapboxTree.version} must equal the ui tree version ${uiTree.version}.`,
+    );
+  }
+  if (uiAutoloadTree.version !== uiTree.version) {
+    throw new Error(
+      `The ui-autoload tree version ${uiAutoloadTree.version} must equal the ui tree version ${uiTree.version}.`,
     );
   }
 
@@ -112,13 +120,21 @@ async function main(): Promise<void> {
   // release gate anymore (Mapbox is external), but validatePublishability stays a dormant safeguard.
   validatePublishability(uiArtifact.build, { requireClean: true });
   validatePublishability(uiMapboxArtifact.build, { requireClean: true });
+  validatePublishability(uiAutoloadArtifact.build, { requireClean: true });
   validatePublishability(jsToolkitArtifact.build, { requireClean: true });
 
   let uiTarget: PublishTarget;
   let mutableAliases: string[];
   if (values['git-tag']) {
     uiTarget = { kind: 'release', packageName: 'ui', version: values['git-tag'] };
-    mutableAliases = ['ui@latest/autoload.js', 'ui@latest/index.js', 'ui-mapbox@latest/index.js'];
+    mutableAliases = [
+      'ui@latest/autoload.js',
+      'ui@latest/index.js',
+      'ui-mapbox@latest/index.js',
+      'ui-autoload@latest/index.js',
+      'ui-autoload@latest/ui.js',
+      'ui-autoload@latest/ui-mapbox.js',
+    ];
   } else if (values.channel === 'main') {
     const commit = values.commit ?? uiArtifact.build.build.commit;
     uiTarget = { kind: 'channel', commit };
@@ -127,6 +143,12 @@ async function main(): Promise<void> {
       'ui@main/autoload.js',
       'ui-mapbox@next/index.js',
       'ui-mapbox@main/index.js',
+      'ui-autoload@next/index.js',
+      'ui-autoload@next/ui.js',
+      'ui-autoload@next/ui-mapbox.js',
+      'ui-autoload@main/index.js',
+      'ui-autoload@main/ui.js',
+      'ui-autoload@main/ui-mapbox.js',
     ];
   } else if (values.pr !== undefined) {
     const pr = Number(values.pr);
@@ -153,14 +175,17 @@ async function main(): Promise<void> {
   // not already present. It must exist before the ui tree that imports it becomes visible.
   await ensureJsToolkitPublished(store, jsToolkitArtifact, jsToolkitTree.version, log);
 
-  // The ui and ui-mapbox trees are published together in one atomic versions.json write: the
-  // lockstep ui-mapbox artifact is staged, verified and copied into its own tree before the index
-  // records both packages at the same identity.
+  // The ui, ui-mapbox and ui-autoload trees are published together in one atomic versions.json
+  // write: the lockstep artifacts are staged, verified and copied into their own trees before the
+  // index records every package at the same identity.
   const result = await publish(store, uiArtifact, uiTarget, {
     log,
     lockstepUiMapbox: uiMapboxArtifact,
+    lockstepUiAutoload: uiAutoloadArtifact,
   });
-  process.stdout.write(`Published ${result.identity} to ${result.finalPrefix} (ui + ui-mapbox).\n`);
+  process.stdout.write(
+    `Published ${result.identity} to ${result.finalPrefix} (ui + ui-mapbox + ui-autoload).\n`,
+  );
 
   // The cache purge is a best-effort optimization that only shortens how long the mutable alias
   // redirects may serve a stale target (their TTL is minutes). The immutable assets and versions.json

--- a/packages/cdn/scripts/rollback.ts
+++ b/packages/cdn/scripts/rollback.ts
@@ -60,7 +60,14 @@ async function main(): Promise<void> {
   let mutableAliases: string[];
   if (values['stable-latest']) {
     target = { kind: 'release', version: values['stable-latest'] };
-    mutableAliases = ['ui@latest/autoload.js', 'ui@latest/index.js', 'ui-mapbox@latest/index.js'];
+    mutableAliases = [
+      'ui@latest/autoload.js',
+      'ui@latest/index.js',
+      'ui-mapbox@latest/index.js',
+      'ui-autoload@latest/index.js',
+      'ui-autoload@latest/ui.js',
+      'ui-autoload@latest/ui-mapbox.js',
+    ];
   } else {
     target = { kind: 'channel', channelId: values.channel as string };
     mutableAliases = [
@@ -68,6 +75,12 @@ async function main(): Promise<void> {
       'ui@main/autoload.js',
       'ui-mapbox@next/index.js',
       'ui-mapbox@main/index.js',
+      'ui-autoload@next/index.js',
+      'ui-autoload@next/ui.js',
+      'ui-autoload@next/ui-mapbox.js',
+      'ui-autoload@main/index.js',
+      'ui-autoload@main/ui.js',
+      'ui-autoload@main/ui-mapbox.js',
     ];
   }
 

--- a/packages/cdn/scripts/smoke.ts
+++ b/packages/cdn/scripts/smoke.ts
@@ -217,7 +217,7 @@ async function checkUiAutoloadArtifact(config: SmokeConfig, version: string): Pr
     );
     const body = await response.text();
     // The `ui.js` side-effect entry reuses the ui tree's manifest cross-tree rather than bundling it,
-    // so its baked absolute URL must reference `/ui@<version>/manifest.js`.
+    // so its baked origin-relative URL must reference `/ui@<version>/manifest.js`.
     if (asset === 'ui.js') {
       assert(
         body.includes(`/ui@${version}/manifest.js`),

--- a/packages/cdn/scripts/smoke.ts
+++ b/packages/cdn/scripts/smoke.ts
@@ -188,6 +188,45 @@ async function checkJsToolkitArtifact(
   }
 }
 
+async function checkUiAutoloadArtifact(config: SmokeConfig, version: string): Promise<void> {
+  // The ui-autoload tree is versioned in lockstep with ui, so it resolves at the same version. Its
+  // pure `index.js` barrel and the two side-effect entries (`ui.js`, `ui-mapbox.js`) must each serve
+  // as an immutable, permissively-CORS'd JavaScript module.
+  for (const asset of ['index.js', 'ui.js', 'ui-mapbox.js']) {
+    const response = await fetchWithTimeout(
+      packageEndpoint(config, 'ui-autoload', version, asset),
+      config,
+      { headers: { Origin: 'https://example.com' } },
+    );
+    assert(response.status === 200, `ui-autoload ${asset} returned HTTP ${response.status}.`);
+    assert(
+      (response.headers.get('Content-Type') ?? '').includes('javascript'),
+      `ui-autoload ${asset} has a non-JavaScript content type: ${response.headers.get('Content-Type')}.`,
+    );
+    assert(
+      (response.headers.get('Cache-Control') ?? '').includes('immutable'),
+      `ui-autoload ${asset} is not immutably cacheable.`,
+    );
+    assert(
+      response.headers.get('Access-Control-Allow-Origin') === '*',
+      `ui-autoload ${asset} is missing a permissive CORS header.`,
+    );
+    assert(
+      response.headers.get('Cross-Origin-Resource-Policy') === 'cross-origin',
+      `ui-autoload ${asset} is missing a cross-origin resource policy.`,
+    );
+    const body = await response.text();
+    // The `ui.js` side-effect entry reuses the ui tree's manifest cross-tree rather than bundling it,
+    // so its baked absolute URL must reference `/ui@<version>/manifest.js`.
+    if (asset === 'ui.js') {
+      assert(
+        body.includes(`/ui@${version}/manifest.js`),
+        'ui-autoload ui.js does not reference the baked cross-tree /ui@<version>/manifest.js URL.',
+      );
+    }
+  }
+}
+
 async function checkSharedToolkitUrl(
   config: SmokeConfig,
   version: string,
@@ -254,12 +293,17 @@ async function checkBrowserExecution(config: SmokeConfig, version: string): Prom
   const browser = await chromium.launch();
   try {
     const page = await browser.newPage();
-    const moduleUrl = endpoint(config, version, 'autoload.js');
-    const evaluated = await page.evaluate(async (url) => {
-      await import(url);
+    // Evaluate both the legacy `ui@<v>/autoload.js` surface and the new ui-autoload side-effect entry
+    // `ui-autoload@<v>/ui.js` (which statically imports the baked cross-tree `/ui@<v>/manifest.js`).
+    const moduleUrls = [
+      endpoint(config, version, 'autoload.js'),
+      packageEndpoint(config, 'ui-autoload', version, 'ui.js'),
+    ];
+    const evaluated = await page.evaluate(async (urls) => {
+      for (const url of urls) await import(url);
       return typeof window.document !== 'undefined';
-    }, moduleUrl);
-    assert(evaluated, 'The autoload module did not evaluate in the browser.');
+    }, moduleUrls);
+    assert(evaluated, 'The autoload modules did not evaluate in the browser.');
     return { name: 'Browser execution', status: 'passed' };
   } finally {
     await browser.close();
@@ -342,6 +386,9 @@ async function main(): Promise<void> {
       detail: 'The ui build.json does not record its @studiometa/js-toolkit dependency version.',
     });
   }
+  results.push(
+    await run(() => checkUiAutoloadArtifact(config, version), 'ui-autoload artifact'),
+  );
   if (config.browser) {
     results.push(await checkBrowserExecution(config, version));
   }

--- a/packages/cdn/size-budgets.json
+++ b/packages/cdn/size-budgets.json
@@ -18,9 +18,9 @@
     "dts:entry:index": 13000,
     "dts:js-toolkit:entry:index": 150000,
     "dts:js-toolkit:entry:utils": 65000,
-    "total:esm": 360000,
-    "total:source-maps": 1600000,
-    "total:declarations": 520000,
-    "total:release": 2200000
+    "total:esm": 380000,
+    "total:source-maps": 1680000,
+    "total:declarations": 560000,
+    "total:release": 2360000
   }
 }

--- a/packages/cdn/tests/publication.test.ts
+++ b/packages/cdn/tests/publication.test.ts
@@ -13,7 +13,7 @@ import type { WorkingVersionsIndex } from '../scripts/lib/versions.ts';
 import { makeArtifact, MemoryObjectStore, seedVersionsIndex } from './store-fixture.ts';
 
 function seed(): WorkingVersionsIndex {
-  // ui-mapbox mirrors ui in lockstep.
+  // ui-mapbox and ui-autoload mirror ui in lockstep.
   const uiLike = {
     releases: ['1.0.0', '2.0.0'],
     channels: ['main-000000000001', 'main-000000000002'],
@@ -24,6 +24,7 @@ function seed(): WorkingVersionsIndex {
     packages: {
       ui: structuredClone(uiLike),
       'ui-mapbox': structuredClone(uiLike),
+      'ui-autoload': structuredClone(uiLike),
       'js-toolkit': { releases: ['3.8.0'] },
     },
   };
@@ -97,6 +98,39 @@ describe('CDN publication', () => {
     expect(store.keysWithPrefix('tmp/')).toHaveLength(0);
   });
 
+  it('publishes the ui, ui-mapbox and ui-autoload trees in lockstep in one atomic versions.json write', async () => {
+    const store = seededStore();
+    const result = await publish(store, makeArtifact(), releaseTarget, {
+      publicationId: 'lock3',
+      lockstepUiMapbox: makeArtifact(),
+      lockstepUiAutoload: makeArtifact(),
+    });
+
+    // All three trees' immutable objects are copied into their namespaced prefixes.
+    expect(store.objects.has('releases/ui/2.1.0/build.json')).toBe(true);
+    expect(store.objects.has('releases/ui-mapbox/2.1.0/build.json')).toBe(true);
+    expect(store.objects.has('releases/ui-autoload/2.1.0/build.json')).toBe(true);
+    expect(store.objects.has('releases/ui-autoload/2.1.0/autoload.js')).toBe(true);
+
+    // versions.json is written exactly once and advances every package's latest tag.
+    expect(
+      store.operations.filter((entry) => entry.op === 'put' && entry.key === 'versions.json'),
+    ).toHaveLength(1);
+    expect(result.index.packages['ui-autoload'].distTags.latest).toBe('2.1.0');
+    expect(result.index.packages['ui-autoload'].releases).toContain('2.1.0');
+
+    // The single versions.json write happens only after every final copy across all trees lands.
+    const versionsPut = store.indexOfPut('versions.json');
+    const lastCopy = Math.max(
+      ...store.operations
+        .map((entry, index) => (entry.op === 'copy' ? index : -1))
+        .filter((index) => index >= 0),
+    );
+    expect(versionsPut).toBeGreaterThan(lastCopy);
+    expect(store.keysWithPrefix('tmp/')).toHaveLength(0);
+    expect(() => parseVersionsIndex(result.index)).not.toThrow();
+  });
+
   it('migrates a live schema-2 index that has no ui-mapbox key in place and stays schema 2', async () => {
     // This is the exact shape the currently-deployed release tooling wrote: schemaVersion 2 with
     // only `ui` and `js-toolkit`. A publish from this branch must accept it, add `ui-mapbox`, and
@@ -134,18 +168,24 @@ describe('CDN publication', () => {
     expect(() => parseVersionsIndex(persisted)).not.toThrow();
   });
 
-  it('publishes a main channel for both lockstep trees under their namespaced prefixes', async () => {
+  it('publishes a main channel for every lockstep tree under their namespaced prefixes', async () => {
     const store = seededStore();
     const result = await publish(
       store,
       makeArtifact({ commit: 'e'.repeat(40) }),
       { kind: 'channel', commit: 'e'.repeat(40) },
-      { publicationId: 'lockchan', lockstepUiMapbox: makeArtifact({ commit: 'e'.repeat(40) }) },
+      {
+        publicationId: 'lockchan',
+        lockstepUiMapbox: makeArtifact({ commit: 'e'.repeat(40) }),
+        lockstepUiAutoload: makeArtifact({ commit: 'e'.repeat(40) }),
+      },
     );
     expect(result.identity).toBe('main-eeeeeeeeeeee');
     expect(store.objects.has('channels/main-eeeeeeeeeeee/build.json')).toBe(true);
     expect(store.objects.has('channels/ui-mapbox/main-eeeeeeeeeeee/build.json')).toBe(true);
+    expect(store.objects.has('channels/ui-autoload/main-eeeeeeeeeeee/build.json')).toBe(true);
     expect(result.index.packages['ui-mapbox'].distTags.main).toBe('main-eeeeeeeeeeee');
+    expect(result.index.packages['ui-autoload'].distTags.main).toBe('main-eeeeeeeeeeee');
     expect(() => parseVersionsIndex(result.index)).not.toThrow();
   });
 
@@ -250,19 +290,19 @@ describe('CDN publication', () => {
       store,
       makeArtifact({ commit: 'a'.repeat(40) }),
       { kind: 'preview', pr: 42, commit: 'a'.repeat(40) },
-      { publicationId: 'p1' },
+      { publicationId: 'p1', lockstepUiAutoload: makeArtifact({ commit: 'a'.repeat(40) }) },
     );
     await publish(
       store,
       makeArtifact({ commit: 'b'.repeat(40) }),
       { kind: 'preview', pr: 42, commit: 'b'.repeat(40) },
-      { publicationId: 'p2' },
+      { publicationId: 'p2', lockstepUiAutoload: makeArtifact({ commit: 'b'.repeat(40) }) },
     );
     await publish(
       store,
       makeArtifact({ commit: 'd'.repeat(40) }),
       { kind: 'preview', pr: 7, commit: 'd'.repeat(40) },
-      { publicationId: 'p3' },
+      { publicationId: 'p3', lockstepUiAutoload: makeArtifact({ commit: 'd'.repeat(40) }) },
     );
 
     const result = await pruneUiPreviewChannelsForPr(store, 42);
@@ -270,6 +310,11 @@ describe('CDN publication', () => {
     const channels = result.index.packages.ui.channels;
     expect(channels).not.toContain('pr-42-aaaaaaaaaaaa');
     expect(channels).not.toContain('pr-42-bbbbbbbbbbbb');
+    // The lockstep ui-autoload preview channels for the pruned PR are removed too.
+    const autoloadChannels = result.index.packages['ui-autoload'].channels;
+    expect(autoloadChannels).not.toContain('pr-42-aaaaaaaaaaaa');
+    expect(autoloadChannels).not.toContain('pr-42-bbbbbbbbbbbb');
+    expect(autoloadChannels).toContain('pr-7-dddddddddddd');
     // The other PR's preview and the main channels are untouched.
     expect(channels).toContain('pr-7-dddddddddddd');
     expect(channels).toContain('main-000000000002');
@@ -398,23 +443,26 @@ describe('publishability gates', () => {
 describe('CDN rollback', () => {
   function rollbackStore(): MemoryObjectStore {
     const store = seededStore();
-    // Both lockstep trees' immutable objects must exist for a rollback to accept the target.
+    // Every lockstep tree's immutable objects must exist for a rollback to accept the target.
     for (const key of [
       'releases/ui/1.0.0/build.json',
       'releases/ui-mapbox/1.0.0/build.json',
+      'releases/ui-autoload/1.0.0/build.json',
       'channels/main-000000000001/build.json',
       'channels/ui-mapbox/main-000000000001/build.json',
+      'channels/ui-autoload/main-000000000001/build.json',
     ]) {
       store.objects.set(key, { body: new Uint8Array(), sha384: 'x' });
     }
     return store;
   }
 
-  it('repoints latest at an older indexed release for both lockstep packages without touching immutable objects', async () => {
+  it('repoints latest at an older indexed release for every lockstep package without touching immutable objects', async () => {
     const store = rollbackStore();
     const result = await rollback(store, { kind: 'release', version: '1.0.0' });
     expect(result.index.packages.ui.distTags.latest).toBe('1.0.0');
     expect(result.index.packages['ui-mapbox'].distTags.latest).toBe('1.0.0');
+    expect(result.index.packages['ui-autoload'].distTags.latest).toBe('1.0.0');
     expect(store.operations.every((entry) => entry.op !== 'copy' && entry.op !== 'delete')).toBe(
       true,
     );
@@ -422,7 +470,7 @@ describe('CDN rollback', () => {
     expect(writes).toEqual([{ op: 'put', key: 'versions.json' }]);
   });
 
-  it('moves next and main together for both lockstep packages on a channel rollback', async () => {
+  it('moves next and main together for every lockstep package on a channel rollback', async () => {
     const result = await rollback(rollbackStore(), {
       kind: 'channel',
       channelId: 'main-000000000001',
@@ -431,6 +479,8 @@ describe('CDN rollback', () => {
     expect(result.index.packages.ui.distTags.main).toBe('main-000000000001');
     expect(result.index.packages['ui-mapbox'].distTags.next).toBe('main-000000000001');
     expect(result.index.packages['ui-mapbox'].distTags.main).toBe('main-000000000001');
+    expect(result.index.packages['ui-autoload'].distTags.next).toBe('main-000000000001');
+    expect(result.index.packages['ui-autoload'].distTags.main).toBe('main-000000000001');
   });
 
   it('refuses a rollback to a target that is not indexed', async () => {

--- a/packages/cdn/tests/worker/versions.test.ts
+++ b/packages/cdn/tests/worker/versions.test.ts
@@ -370,8 +370,8 @@ describe('bare package root resolution', () => {
 });
 
 describe('distribution tag mutators (scripts/lib/versions)', () => {
-  // Builds a working index whose ui and ui-mapbox packages share the given shape (they are versioned
-  // in lockstep). Only `ui` is inspected in these unit tests.
+  // Builds a working index whose ui, ui-mapbox and ui-autoload packages share the given shape (they
+  // are versioned in lockstep). Only `ui` is inspected in these unit tests.
   function workingIndex(ui: {
     releases: string[];
     channels: string[];
@@ -382,6 +382,7 @@ describe('distribution tag mutators (scripts/lib/versions)', () => {
       packages: {
         ui: structuredClone(ui),
         'ui-mapbox': structuredClone(ui),
+        'ui-autoload': structuredClone(ui),
         'js-toolkit': { releases: [] },
       },
     };


### PR DESCRIPTION
## Summary

Publishes `@studiometa/ui-autoload` as its own CDN tree so it resolves on the CDN alongside the `ui`, `ui-mapbox` and `js-toolkit` trees (versioned in lockstep with `ui`):

- `/ui-autoload@<v>/index.js` — the pure engine barrel (`autoload`, `composeManifests`, `registerManifest`, `readEagerTokens`, types).
- `/ui-autoload@<v>/ui.js` — the side-effect entry activating `@studiometa/ui` autoloading.
- `/ui-autoload@<v>/ui-mapbox.js` — the side-effect entry for `@studiometa/ui-mapbox`.
- bare `/ui-autoload` → `/ui-autoload@latest/index.js` plus `@latest`/`@next`/`@main` (the worker already resolves these, #599; this PR builds + publishes the assets).

## This change is ADDITIVE

The existing `/ui@<v>/autoload.js` surface, `packages/cdn/src/autoload.ts`, `manifest.ts`, the `?components=` mechanism, and the `ui@*/autoload.js` aliases are all **retained**. Both the old and new autoload surfaces coexist after this PR; retiring the old surface is a follow-up.

## What changed

- **`scripts/build.ts`** — adds a `ui-autoload` tree (build name `@studiometa/ui-cdn-autoload`) bundling entries `index`, `ui`, `ui-mapbox` from `packages/ui-autoload`. The engine + `runtime.ts` are bundled in; cross-package deps are externalized to baked URLs. Adds `assertUiAutoloadExternals`, facade source-map synthesis, third-party notices, per-entry/output assertions and a `build.json`.
- **`scripts/lib/versions.ts`** — adds an additive `ui-autoload` key to `WorkingVersionsIndex` / `emptyIndex` / parse / serialize. **schemaVersion stays 2** (the deployed worker already tolerates the key per #599; an index that omits it is migrated in place).
- **`scripts/lib/publication.ts`** — generalises the single lockstep tree into an ordered list, adds `lockstepUiAutoload`, and includes `ui-autoload` in `rollback()` and preview-channel pruning.
- **`scripts/publish.ts`** — reads the ui-autoload artifact as a 4th tree, enforces version lockstep, `validatePublishability`, passes it as `lockstepUiAutoload`, and adds its mutable aliases per mode.
- **`scripts/rollback.ts`** — adds ui-autoload mutable aliases to both rollback modes.
- **`scripts/smoke.ts`** — adds a `ui-autoload artifact` probe (index/ui/ui-mapbox serve as immutable, permissively-CORS'd JS; `ui.js` references the baked `/ui@<v>/manifest.js`) and imports `/ui-autoload@<v>/ui.js` in the browser-execution check.
- **`size-budgets.json`** — bumps the four `total:*` ceilings to cover the new tree (measured ≈ 9.4 KB esm, 35.6 KB maps, 13.7 KB dts; headroom exceeds the addition).
- **Tests** — `publication.test.ts` and `worker/versions.test.ts` updated for the ui-autoload lockstep (new three-way lockstep publish test; channel/prune/rollback assertions extended).

## Externalization (mirrors `cdn-externalize-ui-mapbox`)

All baked as **origin-relative absolute paths** (leading `/`, no host), exactly like the js-toolkit URL and the existing cross-tree mapbox imports:

| Specifier | Baked URL |
|---|---|
| `@studiometa/js-toolkit` | `/js-toolkit@<jsToolkitVersion>/index.js` (same URL the other trees bake) |
| `@studiometa/ui/manifest` | `/ui@<uiVersion>/manifest.js` |
| `@studiometa/ui-mapbox/manifest` | `/ui-mapbox@<uiVersion>/manifest.js` |

`<uiVersion>` is the ui package version — the same value `externalizeUiMapboxPlugin` bakes into the ui tree — so the manifest URLs pin consistently with the rest of the build. Origin-relative keeps every channel (releases and PR previews alike) resolving the manifest **same-origin** and host-portable; absolute production URLs would make a preview channel import the manifest from production and hardcode the host. No component source or manifest is re-bundled into the ui-autoload tree.

Verified emitted `ui.js` imports: `["./chunks/runtime-*.js", "/ui@<v>/manifest.js"]`; `ui-mapbox.js`: `["./chunks/runtime-*.js", "/ui-mapbox@<v>/manifest.js"]`; js-toolkit stays `/js-toolkit@<v>/...`.

## versions.json

`ui-autoload` is written on release **and** channel publish additively (via the generalized lockstep advance), sorted deterministically, with `schemaVersion` unchanged at 2.

## Local build/verification limits (rely on CI + PR preview)

- ✅ `npm run lint` (oxlint + `tsgo` type-check + prettier): **0 errors**.
- ✅ CDN unit suites: `publication.test.ts` (incl. new lockstep/prune/rollback), `worker/versions.test.ts`, `observability`, `manifest`, `autoload` — all pass.
- ✅ The ui-autoload tree built in isolation emits `index.js`/`ui.js`/`ui-mapbox.js`, their `.d.ts`, a shared runtime chunk and the baked origin-relative cross-tree manifest paths.
- ⚠️ The **full** `build.ts` and the suites that shell out to it (`build.test.ts`, `worker/index.test.ts`, browser) could **not** run in this worktree: the git worktree has no root `node_modules` (deps live only in `packages/cdn/node_modules`), so `build.ts` fails reading the repo-root js-toolkit `package.json`. Combined with the known OOM risk of the eager-dts full build (~7.6 GB), these are left to CI and the preview channel.

Reviewers: please rely on CI (full build + `build.test.ts` + `worker/index.test.ts` + browser tests) and the PR preview channel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014FQxYGj2RqgcP8BkubpiNu