### PR TITLE
Serve each package's own manifest from its CDN tree

### DIFF
--- a/packages/cdn/scripts/build.ts
+++ b/packages/cdn/scripts/build.ts
@@ -976,7 +976,11 @@ uiMapboxExternalUrls.sort();
 const uiEntryPoints = {
   autoload: resolve(repositoryDirectory, 'packages/cdn/src/autoload.ts'),
   loader: resolve(repositoryDirectory, 'packages/cdn/src/loader.ts'),
-  manifest: resolve(repositoryDirectory, 'packages/cdn/src/manifest.ts'),
+  // The `/ui@<v>/manifest.js` entry serves the @studiometa/ui PACKAGE manifest (ui components only,
+  // exporting `manifest`), not the composed `src/manifest.ts`. The ui-autoload runtime composes the
+  // per-package manifests at runtime. The old bespoke `autoload` entry keeps bundling the composed
+  // `src/manifest.ts` internally and is unaffected by this repointing.
+  manifest: resolve(repositoryDirectory, 'packages/cdn/src/manifest-ui.ts'),
   index: resolve(repositoryDirectory, 'packages/cdn/src/barrel-ui.ts'),
   ...componentEntryPoints,
 };
@@ -1008,13 +1012,17 @@ const uiMetafile = metafileFromChunks(chunksOf(uiResults));
 // one runtime instance and one component registry), and mapbox-gl and the geocoder stay external
 // bare specifiers resolved by the consumer's import map. @studiometa/ui-mapbox has no
 // @studiometa/ui dependency, so nothing ui-related is bundled or externalized here.
-const reservedUiMapboxEntryNames = new Set(['index']);
+const reservedUiMapboxEntryNames = new Set(['manifest', 'index']);
 const uiMapboxComponentEntryPoints = componentEntryPointsFor(
   mapboxDefinitions,
   reservedUiMapboxEntryNames,
   'ui-mapbox',
 );
 const uiMapboxEntryPoints = {
+  // The `/ui-mapbox@<v>/manifest.js` entry serves the @studiometa/ui-mapbox PACKAGE manifest (Mapbox
+  // components only, exporting `manifest`). Bundled alongside the Mapbox component entries, rolldown
+  // rewrites its lazy `import('./<Component>.js')` loaders to the flat `../<Component>.js` chunks.
+  manifest: resolve(repositoryDirectory, 'packages/cdn/src/manifest-ui-mapbox.ts'),
   index: resolve(repositoryDirectory, 'packages/cdn/src/barrel-ui-mapbox.ts'),
   ...uiMapboxComponentEntryPoints,
 };
@@ -1177,9 +1185,11 @@ for (const [output, metadata] of Object.entries(uiMapboxMetafile.outputs)) {
   if (!metadata.entryPoint) continue;
   uiMapboxComponentOutputBySource.set(resolve(repositoryDirectory, metadata.entryPoint), output);
 }
-const uiMapboxEntryOutputs = { index: 'index.js' };
-if (!uiMapboxMetafile.outputs['index.js']) {
-  throw new Error('Missing ui-mapbox entry output index.js.');
+const uiMapboxEntryOutputs = { manifest: 'manifest.js', index: 'index.js' };
+for (const [name, file] of Object.entries(uiMapboxEntryOutputs)) {
+  if (!uiMapboxMetafile.outputs[file]) {
+    throw new Error(`Missing ui-mapbox entry output ${file} for ${name}.`);
+  }
 }
 
 // The ui-autoload tree externalizes js-toolkit and both component manifests; nothing else may be an

--- a/packages/cdn/scripts/smoke.ts
+++ b/packages/cdn/scripts/smoke.ts
@@ -224,6 +224,42 @@ async function checkUiAutoloadArtifact(config: SmokeConfig, version: string): Pr
         'ui-autoload ui.js does not reference the baked cross-tree /ui@<version>/manifest.js URL.',
       );
     }
+    if (asset === 'ui-mapbox.js') {
+      assert(
+        body.includes(`/ui-mapbox@${version}/manifest.js`),
+        'ui-autoload ui-mapbox.js does not reference the baked cross-tree /ui-mapbox@<version>/manifest.js URL.',
+      );
+    }
+  }
+
+  // Serving the side-effect entries is not enough: each `import { manifest } from '…/manifest.js'`
+  // binding must actually resolve. A broken cross-tree link (the manifest module serving but NOT
+  // exporting `manifest`, or 404'ing outright) would leave the ui-autoload runtime importing
+  // `undefined` — the exact class of bug this check exists to catch. Assert both per-package manifest
+  // modules serve AND expose a `manifest` export binding.
+  for (const tree of ['ui', 'ui-mapbox'] as const) {
+    const manifestUrl = packageEndpoint(config, tree, version, 'manifest.js');
+    const response = await fetchWithTimeout(manifestUrl, config, {
+      headers: { Origin: 'https://example.com' },
+    });
+    assert(
+      response.status === 200,
+      `${tree} manifest.js returned HTTP ${response.status} (the ui-autoload ${tree}.js entry imports it).`,
+    );
+    assert(
+      (response.headers.get('Content-Type') ?? '').includes('javascript'),
+      `${tree} manifest.js has a non-JavaScript content type: ${response.headers.get('Content-Type')}.`,
+    );
+    const body = await response.text();
+    // The facade re-exports its package manifest, so the emitted module surfaces `manifest` as a bare
+    // `export const manifest`, a re-export (`export { … as manifest }` / `export{manifest}`), or a
+    // `manifest as` alias in an aggregated export list. Any of these proves the binding exists.
+    assert(
+      /(?:export\s*(?:const|let|var|function|class)\s+manifest\b|(?:^|[\s{,])manifest\s+as\b|\bas\s+manifest\b|[{,]\s*manifest\s*[},])/.test(
+        body,
+      ),
+      `${tree} manifest.js does not export a \`manifest\` binding; the ui-autoload ${tree}.js cross-tree import would resolve to undefined.`,
+    );
   }
 }
 
@@ -293,16 +329,38 @@ async function checkBrowserExecution(config: SmokeConfig, version: string): Prom
   const browser = await chromium.launch();
   try {
     const page = await browser.newPage();
-    // Evaluate both the legacy `ui@<v>/autoload.js` surface and the new ui-autoload side-effect entry
-    // `ui-autoload@<v>/ui.js` (which statically imports the baked cross-tree `/ui@<v>/manifest.js`).
+    // Evaluate the legacy `ui@<v>/autoload.js` surface and BOTH ui-autoload side-effect entries
+    // (`ui.js`, `ui-mapbox.js`), each of which statically imports its package's baked cross-tree
+    // `/…@<v>/manifest.js` — so a broken binding or a 404 manifest rejects the dynamic import here.
     const moduleUrls = [
       endpoint(config, version, 'autoload.js'),
       packageEndpoint(config, 'ui-autoload', version, 'ui.js'),
+      packageEndpoint(config, 'ui-autoload', version, 'ui-mapbox.js'),
     ];
-    const evaluated = await page.evaluate(async (urls) => {
-      for (const url of urls) await import(url);
-      return typeof window.document !== 'undefined';
-    }, moduleUrls);
+    // Independently import each per-package manifest module and confirm its `manifest` export links to
+    // a non-empty object — catching a manifest that serves but omits the `manifest` binding.
+    const manifestUrls = [
+      packageEndpoint(config, 'ui', version, 'manifest.js'),
+      packageEndpoint(config, 'ui-mapbox', version, 'manifest.js'),
+    ];
+    const evaluated = await page.evaluate(
+      async ({ modules, manifests }) => {
+        for (const url of modules) await import(url);
+        for (const url of manifests) {
+          const mod = (await import(url)) as { manifest?: unknown };
+          const manifest = mod.manifest;
+          if (
+            !manifest ||
+            typeof manifest !== 'object' ||
+            Object.keys(manifest as object).length === 0
+          ) {
+            throw new Error(`Manifest module ${url} does not export a non-empty \`manifest\` object.`);
+          }
+        }
+        return typeof window.document !== 'undefined';
+      },
+      { modules: moduleUrls, manifests: manifestUrls },
+    );
     assert(evaluated, 'The autoload modules did not evaluate in the browser.');
     return { name: 'Browser execution', status: 'passed' };
   } finally {

--- a/packages/cdn/size-budgets.json
+++ b/packages/cdn/size-budgets.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "bytes": {
-    "entry:autoload": 2800,
+    "entry:autoload": 6500,
     "entry:loader": 350,
     "entry:manifest": 300,
     "entry:index": 15000,

--- a/packages/cdn/src/manifest-ui-mapbox.ts
+++ b/packages/cdn/src/manifest-ui-mapbox.ts
@@ -1,0 +1,8 @@
+// The @studiometa/ui-mapbox component manifest served as the externalizable
+// `/ui-mapbox@<version>/manifest.js` CDN entry point. It re-exports the package's own `manifest`
+// (Mapbox components only) so the ui-autoload runtime's `ui-mapbox.js` side-effect entry — which does
+// `import { manifest } from '@studiometa/ui-mapbox/manifest'` externalized to this URL — resolves the
+// `manifest` binding. Because this entry is bundled alongside every ui-mapbox component entry, rolldown
+// rewrites the manifest's lazy `import('./<Component>.js')` loaders to the flat `../<Component>.js`
+// chunks the CDN serves. The two packages' manifests are composed at runtime by the autoload engine.
+export { manifest } from '@studiometa/ui-mapbox/manifest';

--- a/packages/cdn/src/manifest-ui.ts
+++ b/packages/cdn/src/manifest-ui.ts
@@ -1,0 +1,8 @@
+// The @studiometa/ui component manifest served as the externalizable `/ui@<version>/manifest.js` CDN
+// entry point. It re-exports the package's own `manifest` (ui components only) so the ui-autoload
+// runtime's `ui.js` side-effect entry — which does `import { manifest } from '@studiometa/ui/manifest'`
+// externalized to this URL — resolves the `manifest` binding. Because this entry is bundled alongside
+// every ui component entry, rolldown rewrites the manifest's lazy `import('./<Component>/<Component>.js')`
+// loaders to the flat `../<Component>.js` chunks the CDN serves. The two packages' manifests are
+// composed at runtime by the autoload engine, not pre-composed here.
+export { manifest } from '@studiometa/ui/manifest';

--- a/packages/cdn/tests/build.test.ts
+++ b/packages/cdn/tests/build.test.ts
@@ -225,14 +225,42 @@ describe('browser CDN build', () => {
 
   it('lazy-loads Mapbox components from the ui-mapbox tree in the composed autoload manifest', async () => {
     // The composed autoload's bundled ui-mapbox manifest must resolve each Mapbox component to its
-    // absolute ui-mapbox tree URL rather than a chunk-relative path or a ui-tree chunk.
+    // absolute ui-mapbox tree URL rather than a chunk-relative path or a ui-tree chunk. The composed
+    // manifest lives in the `autoload` entry's static graph (its own file plus its preload chunks) —
+    // NOT in the `/ui@<v>/manifest.js` entry, which now serves the ui PACKAGE manifest (ui components
+    // only) so the ui-autoload runtime can compose the per-package manifests itself.
+    const autoloadGraph = [build.entries.autoload.path, ...build.entries.autoload.preload];
+    let combined = '';
+    for (const file of autoloadGraph) {
+      combined += await readFile(resolve(uiTree, file), 'utf8');
+    }
+    expect(combined).toContain(`/ui-mapbox@${uiVersion}/MapboxMap.js`);
+    expect(combined).toContain(`/ui-mapbox@${uiVersion}/StoreLocator.js`);
+    // The rewritten URL is a genuine absolute origin-relative path, not a `../` chunk-relative one.
+    expect(combined).not.toContain(`../ui-mapbox@${uiVersion}/`);
+
+    // Conversely, the `/ui@<v>/manifest.js` entry serves the ui PACKAGE manifest: it exports
+    // `manifest`, references no Mapbox tree URL, and its lazy component loaders use flat
+    // `../<Component>.js` chunk paths.
     const manifestChunk = uiFiles.find((file) => /^chunks\/manifest-.*\.js$/.test(file));
     expect(manifestChunk).toBeDefined();
-    const source = await readFile(resolve(uiTree, manifestChunk as string), 'utf8');
-    expect(source).toContain(`/ui-mapbox@${uiVersion}/MapboxMap.js`);
-    expect(source).toContain(`/ui-mapbox@${uiVersion}/StoreLocator.js`);
-    // The rewritten URL is a genuine absolute origin-relative path, not a `../` chunk-relative one.
-    expect(source).not.toContain(`../ui-mapbox@${uiVersion}/`);
+    const manifestEntry = await readFile(resolve(uiTree, 'manifest.js'), 'utf8');
+    expect(manifestEntry).toMatch(/\bas manifest\b/);
+    const manifestSource = await readFile(resolve(uiTree, manifestChunk as string), 'utf8');
+    expect(manifestSource).not.toContain(`/ui-mapbox@${uiVersion}/`);
+    expect(manifestSource).toContain('import(`../Accordion.js`)');
+  });
+
+  it('serves the ui-mapbox package manifest exporting `manifest` with flat component paths', async () => {
+    // The `/ui-mapbox@<v>/manifest.js` entry serves the @studiometa/ui-mapbox PACKAGE manifest so the
+    // ui-autoload runtime's `ui-mapbox.js` side-effect entry resolves its `import { manifest }` binding.
+    expect(uiMapboxFiles).toContain('manifest.js');
+    expect(uiMapboxBuild.entries.manifest.path).toBe('manifest.js');
+    const manifestSource = await readFile(resolve(uiMapboxTree, 'manifest.js'), 'utf8');
+    expect(manifestSource).toMatch(/\bas manifest\b/);
+    // Mapbox components lazy-load from flat sibling chunks in the same tree, never a nested source path.
+    expect(manifestSource).toContain('import(`./MapboxMap.js`)');
+    expect(manifestSource).not.toMatch(/import\(`\.\/[^`]+\/[^`]+\.js`\)/);
   });
 
   it('serves the js-toolkit index and utils entries from the js-toolkit tree', () => {


### PR DESCRIPTION
## The defect

The newly-published `ui-autoload` CDN tree was non-functional. Its side-effect entries import per-package manifests:

- `ui.js` → `import { manifest } from '@studiometa/ui/manifest'`, externalized to `/ui@<v>/manifest.js`
- `ui-mapbox.js` → `import { manifest } from '@studiometa/ui-mapbox/manifest'`, externalized to `/ui-mapbox@<v>/manifest.js`

But on the CDN:

- `/ui@<v>/manifest.js` was built from the **composed** `packages/cdn/src/manifest.ts` and exported `componentManifest` / `componentManifests` — **not** `manifest`. So `ui.js`'s `{ manifest }` binding resolved to `undefined`.
- `/ui-mapbox@<v>/manifest.js` **404'd** (the ui-mapbox tree had no `manifest` entry), so `ui-mapbox.js`'s import failed outright.

## The fix — serve each package's OWN manifest, composed at runtime

The intended architecture is per-package manifests (each exporting `manifest`, mirroring the `@studiometa/ui/manifest` and `@studiometa/ui-mapbox/manifest` package exports), composed **at runtime** by the ui-autoload runtime — not a pre-composed CDN manifest.

- **ui tree `manifest` entry**: repointed from the composed `src/manifest.ts` to a new `src/manifest-ui.ts` barrel (`export { manifest } from '@studiometa/ui/manifest'`), so `/ui@<v>/manifest.js` exports `manifest` (ui components only).
- **ui-mapbox tree `manifest` entry**: **added**, sourced from a new `src/manifest-ui-mapbox.ts` barrel (`export { manifest } from '@studiometa/ui-mapbox/manifest'`), so `/ui-mapbox@<v>/manifest.js` serves and exports `manifest`. Reserved the `manifest` entry name and validated its output.

### Component-path rewriting still applies

Because each manifest entry is bundled **alongside its package's component entries**, rolldown's natural chunk-sharing rewrites the manifest's lazy loaders (`import('./Accordion/Accordion.js')`) to the **flat** `../<Component>.js` chunks the CDN serves — no special plugin is keyed to `src/manifest.ts`. Verified against the emitted output:

- `/ui@<v>/manifest.js` exports `manifest`; its chunk uses `import(\`../Accordion.js\`)` etc. (no nested paths).
- `/ui-mapbox@<v>/manifest.js` exports `manifest`; its loaders use flat `./MapboxMap.js` (facade at tree root).

### Old autoload retained and unaffected

`src/manifest.ts` (composed) and `src/autoload.ts` are **kept** for a follow-up retirement PR. The old `ui@*/autoload.js` still imports `./manifest.js` internally and continues to bundle its own composed manifest (verified: `autoload.js`'s graph still externalizes `/ui-mapbox@<v>/MapboxMap.js` and shares the ui manifest chunk). Its entry file grew ~2.3 KB because the composed manifest is no longer shared with the `manifest` entry, so its `entry:autoload` size budget was bumped (2800 → 6500). All other budgets, including cross-tree totals and the new ui-mapbox manifest, stayed under their existing ceilings.

## Hardened smoke

`cdn_preview` passed despite `ui.js` binding to a non-existent export because smoke only checked serving, not the ES-module link. `packages/cdn/scripts/smoke.ts` now:

- asserts both `/ui@<v>/manifest.js` and `/ui-mapbox@<v>/manifest.js` serve **and** expose a `manifest` export binding (a broken binding or a 404 manifest now fails cdn_preview);
- in the browser-execution check, imports **both** side-effect entries (`ui.js`, `ui-mapbox.js`) and independently imports each manifest module, asserting its `manifest` export is a non-empty object.

## Verification

- `npm run lint` (root): 0 errors (pre-existing warnings only).
- `npm run test --workspace @studiometa/ui-cdn`: **175 passed** (incl. `build.test.ts`, extended with assertions that the manifest entries export `manifest` with flat paths and that the composed mapbox URLs now live in the autoload graph).
- Isolated `node scripts/build.ts` build succeeded; emitted manifest outputs inspected to confirm the `manifest` export and flat component paths above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014FQxYGj2RqgcP8BkubpiNu