### PR TITLE
Prepare 1.10.0-beta.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "studiometa/ui",
   "type": "composer-plugin",
-  "version": "1.10.0-beta.1",
+  "version": "1.10.0-beta.2",
   "description": "Accessible and composable JavaScript behaviors and Twig templates.",
   "license": "MIT",
   "require": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@studiometa/ui-workspace",
-  "version": "1.10.0-beta.1",
+  "version": "1.10.0-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@studiometa/ui-workspace",
-      "version": "1.10.0-beta.1",
+      "version": "1.10.0-beta.2",
       "hasInstallScript": true,
       "workspaces": [
         "packages/*"
@@ -23374,11 +23374,11 @@
     },
     "packages/api": {
       "name": "@studiometa/ui-api",
-      "version": "1.10.0-beta.1"
+      "version": "1.10.0-beta.2"
     },
     "packages/cdn": {
       "name": "@studiometa/ui-cdn",
-      "version": "1.10.0-beta.1",
+      "version": "1.10.0-beta.2",
       "license": "MIT",
       "dependencies": {
         "@studiometa/ui": "file:../ui",
@@ -23621,7 +23621,7 @@
     },
     "packages/docs": {
       "name": "@studiometa/ui-docs",
-      "version": "1.10.0-beta.1",
+      "version": "1.10.0-beta.2",
       "dependencies": {
         "@studiometa/js-toolkit": "3.8.0"
       },
@@ -23642,7 +23642,7 @@
     },
     "packages/eslint-plugin-ui": {
       "name": "@studiometa/eslint-plugin-ui",
-      "version": "1.10.0-beta.1",
+      "version": "1.10.0-beta.2",
       "license": "MIT",
       "dependencies": {
         "@oxlint/plugins": "1.63.0"
@@ -23671,7 +23671,7 @@
     },
     "packages/playground": {
       "name": "@studiometa/ui-playground",
-      "version": "1.10.0-beta.1",
+      "version": "1.10.0-beta.2",
       "dependencies": {
         "@studiometa/playground": "0.3.10"
       },
@@ -23738,7 +23738,7 @@
     },
     "packages/tests": {
       "name": "@studiometa/ui-tests",
-      "version": "1.10.0-beta.1",
+      "version": "1.10.0-beta.2",
       "license": "MIT",
       "dependencies": {
         "@happy-dom/global-registrator": "^20.8.8",
@@ -23993,7 +23993,7 @@
     },
     "packages/ui": {
       "name": "@studiometa/ui",
-      "version": "1.10.0-beta.1",
+      "version": "1.10.0-beta.2",
       "license": "MIT",
       "dependencies": {
         "alien-signals": "^3.2.1",
@@ -24021,7 +24021,7 @@
     },
     "packages/ui-autoload": {
       "name": "@studiometa/ui-autoload",
-      "version": "1.10.0-beta.1",
+      "version": "1.10.0-beta.2",
       "license": "MIT",
       "devDependencies": {
         "@studiometa/js-toolkit": "^3.8.0",
@@ -24033,7 +24033,7 @@
     },
     "packages/ui-mapbox": {
       "name": "@studiometa/ui-mapbox",
-      "version": "1.10.0-beta.1",
+      "version": "1.10.0-beta.2",
       "license": "MIT",
       "devDependencies": {
         "@mapbox/mapbox-gl-geocoder": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-workspace",
-  "version": "1.10.0-beta.1",
+  "version": "1.10.0-beta.2",
   "type": "module",
   "private": true,
   "workspaces": [

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-api",
-  "version": "1.10.0-beta.1",
+  "version": "1.10.0-beta.2",
   "private": true,
   "type": "commonjs"
 }

--- a/packages/cdn/package.json
+++ b/packages/cdn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-cdn",
-  "version": "1.10.0-beta.1",
+  "version": "1.10.0-beta.2",
   "description": "Private browser CDN build for @studiometa/ui",
   "private": true,
   "type": "module",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-docs",
-  "version": "1.10.0-beta.1",
+  "version": "1.10.0-beta.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/eslint-plugin-ui/package.json
+++ b/packages/eslint-plugin-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/eslint-plugin-ui",
-  "version": "1.10.0-beta.1",
+  "version": "1.10.0-beta.2",
   "description": "ESLint plugin to help developers discover and use @studiometa/ui components",
   "publishConfig": {
     "access": "public"

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-playground",
-  "version": "1.10.0-beta.1",
+  "version": "1.10.0-beta.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-tests",
-  "version": "1.10.0-beta.1",
+  "version": "1.10.0-beta.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/ui-autoload/package.json
+++ b/packages/ui-autoload/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-autoload",
-  "version": "1.10.0-beta.1",
+  "version": "1.10.0-beta.2",
   "description": "Generic, side-effect-free declarative autoloader for @studiometa/ui component manifests",
   "publishConfig": {
     "access": "public"

--- a/packages/ui-mapbox/package.json
+++ b/packages/ui-mapbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-mapbox",
-  "version": "1.10.0-beta.1",
+  "version": "1.10.0-beta.2",
   "description": "Vanilla js-toolkit components to build Mapbox GL maps declaratively",
   "publishConfig": {
     "access": "public"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui",
-  "version": "1.10.0-beta.1",
+  "version": "1.10.0-beta.2",
   "description": "Accessible and composable JavaScript behaviors and templates",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Version bump to `1.10.0-beta.2` across all workspaces + the Composer package.

This prerelease makes the `@studiometa/ui-autoload` autoloading feature coherent end-to-end: the ui-autoload CDN tree (`/ui-autoload@1.10.0-beta.2/ui`) bakes the fixed per-package manifest endpoint (`/ui@1.10.0-beta.2/manifest.js`, exporting `manifest`), so importing the tree links a real manifest rather than the pre-fix release.

CHANGELOG `[v1.10.0-beta.2]` section was added in #603 and covers: the new `@studiometa/ui-autoload` per-package side-effect entries + `<meta name="studiometa-ui:eager">` config + programmatic `autoload()`, the ui-autoload CDN tree + per-package `/…/manifest.js` endpoints, and the removal of the old `/ui@<v>/autoload.js` + `?components=`.

Tag `1.10.0-beta.2` (no `v` prefix) will be pushed after merge to trigger the release workflow (npm `next` + provenance, CDN release tree + `next`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014FQxYGj2RqgcP8BkubpiNu