### PR TITLE
Preload autoload bootstrap deps via a Link header

### DIFF
--- a/packages/cdn/scripts/build.ts
+++ b/packages/cdn/scripts/build.ts
@@ -1326,14 +1326,22 @@ function outputMetadataFor(
   );
 }
 
+// `externalPreloadByName` advertises already-resolved, origin-relative bootstrap URLs an entry pulls
+// from ANOTHER tree — dependencies the bundler externalized (baked as absolute `/…@<v>/…` paths) and
+// therefore never lists on the static output graph. They are kept in a SEPARATE `externalPreload`
+// field, distinct from the tree-relative `preload` graph, so the Worker prefixes `preload` with the
+// served `/<pkg>@<v>/` root while emitting `externalPreload` verbatim. The field is emitted only when
+// a non-empty list is supplied for an entry, so trees without cross-tree bootstrap deps are unchanged.
 function entryMetadataFor(
   metafile: Metafile,
   outputDirectory: string,
   entries: Record<string, string>,
-): Record<string, { path: string; sourceMap: string; preload: string[] }> {
+  externalPreloadByName: Record<string, readonly string[]> = {},
+): Record<string, { path: string; sourceMap: string; preload: string[]; externalPreload?: string[] }> {
   return Object.fromEntries(
     Object.entries(entries).map(([name, output]) => {
       const path = publicPath(outputDirectory, output);
+      const externalPreload = [...(externalPreloadByName[name] ?? [])].sort();
       return [
         name,
         {
@@ -1343,6 +1351,7 @@ function entryMetadataFor(
             .map((dependency) => publicPath(outputDirectory, dependency))
             .filter((dependency) => dependency !== path)
             .sort(),
+          ...(externalPreload.length > 0 ? { externalPreload } : {}),
         },
       ];
     }),
@@ -1646,7 +1655,15 @@ const uiAutoloadBuildMetadata = {
     sourceDateEpoch: buildTime.epoch,
     timeSource: buildTime.source,
   },
-  entries: entryMetadataFor(uiAutoloadMetafile, uiAutoloadOutputDirectory, uiAutoloadEntryOutputs),
+  // The two side-effect entries each statically import their package's manifest, but that manifest is
+  // an EXTERNALIZED cross-tree import (baked absolute `/…@<v>/manifest.js`), so it never appears on the
+  // bundler's static output graph and thus not in `preload`. Advertise it as `externalPreload` — the
+  // biggest always-needed bootstrap dep — so the Worker can warm it in parallel with the runtime chunk.
+  // The pure `index` barrel imports no manifest and carries none.
+  entries: entryMetadataFor(uiAutoloadMetafile, uiAutoloadOutputDirectory, uiAutoloadEntryOutputs, {
+    ui: [uiManifestCdnUrl],
+    'ui-mapbox': [uiMapboxManifestCdnUrl],
+  }),
   // The ui-autoload tree serves the generic engine and side-effect entries only; it declares no
   // components of its own (each component still lives in its package's own tree).
   components: {},

--- a/packages/cdn/scripts/smoke.ts
+++ b/packages/cdn/scripts/smoke.ts
@@ -184,6 +184,28 @@ async function checkUiAutoloadArtifact(config: SmokeConfig, version: string): Pr
         body.includes(`/ui@${version}/manifest.js`),
         'ui-autoload ui.js does not reference the baked cross-tree /ui@<version>/manifest.js URL.',
       );
+      // The bootstrap-only modulepreload header must warm the always-needed dependencies — the shared
+      // autoload runtime chunk and the cross-tree ui manifest — while NEVER preloading a component
+      // chunk (components stay lazy). This locks the header's safety property against the live edge.
+      const link = response.headers.get('Link') ?? '';
+      assert(
+        link.includes('rel=modulepreload'),
+        'ui-autoload ui.js is missing a modulepreload Link header.',
+      );
+      assert(
+        link.includes(`/ui@${version}/manifest.js`),
+        'ui-autoload ui.js Link header omits the cross-tree /ui@<version>/manifest.js URL.',
+      );
+      assert(
+        new RegExp(`/ui-autoload@${version}/chunks/runtime-[^,>]+\\.js`).test(link),
+        'ui-autoload ui.js Link header omits the autoload runtime chunk.',
+      );
+      for (const token of ['Accordion', 'Action', 'MapboxMap']) {
+        assert(
+          !link.includes(`/${token}.js`),
+          `ui-autoload ui.js Link header unexpectedly preloads a component chunk (${token}.js).`,
+        );
+      }
     }
     if (asset === 'ui-mapbox.js') {
       assert(

--- a/packages/cdn/tests/build.test.ts
+++ b/packages/cdn/tests/build.test.ts
@@ -22,8 +22,9 @@ const jsToolkitVersion = JSON.parse(
   ),
 ).version as string;
 const uiTreePrefix = `releases/ui/${uiVersion}`;
-// ui-mapbox is versioned in lockstep with ui, so its tree lives at the same version.
+// ui-mapbox and ui-autoload are versioned in lockstep with ui, so their trees live at the same version.
 const uiMapboxTreePrefix = `releases/ui-mapbox/${uiVersion}`;
+const uiAutoloadTreePrefix = `releases/ui-autoload/${uiVersion}`;
 const jsToolkitTreePrefix = `releases/js-toolkit/${jsToolkitVersion}`;
 
 interface BuildMetadata {
@@ -56,7 +57,10 @@ interface BuildMetadata {
       pathspecs: string[];
     };
   };
-  entries: Record<string, { path: string; sourceMap: string; preload: string[] }>;
+  entries: Record<
+    string,
+    { path: string; sourceMap: string; preload: string[]; externalPreload?: string[] }
+  >;
   components: Record<
     string,
     {
@@ -118,6 +122,7 @@ async function staticGraphSources(
 
 let build: BuildMetadata;
 let uiMapboxBuild: BuildMetadata;
+let uiAutoloadBuild: BuildMetadata;
 let jsToolkitBuild: {
   package: { name: string; version: string };
   entries: Record<string, { path: string }>;
@@ -127,9 +132,11 @@ let allFiles: string[];
 // The ui tree relative to its own release prefix, used for ui-relative build.json assertions.
 let uiFiles: string[];
 let uiMapboxFiles: string[];
+let uiAutoloadFiles: string[];
 let jsToolkitFiles: string[];
 let uiTree: string;
 let uiMapboxTree: string;
+let uiAutoloadTree: string;
 let jsToolkitTree: string;
 
 beforeAll(async () => {
@@ -144,13 +151,16 @@ beforeAll(async () => {
   }
   uiTree = resolve(firstOutput, uiTreePrefix);
   uiMapboxTree = resolve(firstOutput, uiMapboxTreePrefix);
+  uiAutoloadTree = resolve(firstOutput, uiAutoloadTreePrefix);
   jsToolkitTree = resolve(firstOutput, jsToolkitTreePrefix);
   build = await readJson(uiTree, 'build.json');
   uiMapboxBuild = await readJson(uiMapboxTree, 'build.json');
+  uiAutoloadBuild = await readJson(uiAutoloadTree, 'build.json');
   jsToolkitBuild = await readJson(jsToolkitTree, 'build.json');
   allFiles = await listFiles(firstOutput);
   uiFiles = await listFiles(uiTree);
   uiMapboxFiles = await listFiles(uiMapboxTree);
+  uiAutoloadFiles = await listFiles(uiAutoloadTree);
   jsToolkitFiles = await listFiles(jsToolkitTree);
 }, 60_000);
 
@@ -249,6 +259,46 @@ describe('browser CDN build', () => {
     // Mapbox components lazy-load from flat sibling chunks in the same tree, never a nested source path.
     expect(manifestSource).toContain('import(`./MapboxMap.js`)');
     expect(manifestSource).not.toMatch(/import\(`\.\/[^`]+\/[^`]+\.js`\)/);
+  });
+
+  it('advertises the cross-tree manifest URLs as externalPreload on the ui-autoload side-effect entries', () => {
+    // The ui-autoload tree emits three stable entries: the pure `index` barrel and the `ui` /
+    // `ui-mapbox` side-effect entries. Each entry statically imports the shared autoload runtime, so
+    // its tree-relative `preload` graph is exactly that one runtime chunk — never a component chunk,
+    // since every component is a lazy `import()` absent from the static graph.
+    expect(Object.keys(uiAutoloadBuild.entries).sort()).toEqual(['index', 'ui', 'ui-mapbox']);
+    for (const entry of Object.values(uiAutoloadBuild.entries)) {
+      expect(uiAutoloadFiles).toContain(entry.path);
+      expect(entry.preload.length).toBe(1);
+      expect(entry.preload[0]).toMatch(/^chunks\/runtime-[^/]+\.js$/);
+      expect(uiAutoloadFiles).toContain(entry.preload[0]);
+    }
+
+    // The manifest each side-effect entry imports is an EXTERNALIZED cross-tree module (a baked
+    // absolute `/…@<v>/manifest.js` path), so the bundler never lists it in the tree-relative
+    // `preload` graph. It is carried separately in `externalPreload`, pinned to the lockstep ui
+    // version, so the Worker can advertise it for modulepreload.
+    expect(uiAutoloadBuild.entries.ui.externalPreload).toEqual([`/ui@${uiVersion}/manifest.js`]);
+    expect(uiAutoloadBuild.entries['ui-mapbox'].externalPreload).toEqual([
+      `/ui-mapbox@${uiVersion}/manifest.js`,
+    ]);
+    // The pure barrel imports no manifest, so it carries no externalPreload at all.
+    expect(uiAutoloadBuild.entries.index.externalPreload).toBeUndefined();
+
+    // An externalPreload URL points at ANOTHER tree, so it must never appear in that entry's own
+    // tree-relative preload graph, and it is not a served file of the ui-autoload tree.
+    for (const url of [`/ui@${uiVersion}/manifest.js`, `/ui-mapbox@${uiVersion}/manifest.js`]) {
+      expect(url.startsWith('/')).toBe(true);
+      expect(uiAutoloadFiles).not.toContain(url.replace(/^\//, ''));
+    }
+
+    // The ui and ui-mapbox trees themselves keep the plain tree-relative preload shape (no
+    // externalPreload leaks into a tree whose entries have no cross-tree bootstrap dependency).
+    for (const buildJson of [build, uiMapboxBuild]) {
+      for (const entry of Object.values(buildJson.entries)) {
+        expect(entry.externalPreload).toBeUndefined();
+      }
+    }
   });
 
   it('serves the js-toolkit index and utils entries from the js-toolkit tree', () => {

--- a/packages/cdn/tests/worker/fixtures.ts
+++ b/packages/cdn/tests/worker/fixtures.ts
@@ -155,19 +155,27 @@ export async function createWorkerFixture(): Promise<WorkerFixture> {
   ];
   const uiMapboxFiles = await readTreeFiles(uiMapboxTreeDirectory, uiMapboxAssetPaths);
 
-  // The `ui-autoload` tree is not produced by the build script yet (it is published in a later PR),
-  // so this fixture synthesizes one structurally identical to ui-mapbox: a ui-like tree with its own
-  // namespaced release/channel prefixes and its own CDN build identity. Cloning the ui-mapbox tree is
-  // enough to exercise the Worker's read path — routing, resolution and registry listing — for the
-  // fourth package. The clone rewrites the build name to the ui-autoload CDN build so the Worker's
-  // `PUBLIC_PACKAGE_NAMES['ui-autoload']` expectation is met on both release and channel manifests.
-  const uiAutoloadBuild = structuredClone(uiMapboxBuild);
-  uiAutoloadBuild.package.name = '@studiometa/ui-cdn-autoload';
-  const uiAutoloadAssetPaths = uiMapboxAssetPaths;
-  const uiAutoloadFiles: Record<string, string> = {
-    ...uiMapboxFiles,
-    'build.json': JSON.stringify(uiAutoloadBuild),
-  };
+  // The `ui-autoload` tree is a real build output (the generic autoloader engine plus the pure
+  // `index` barrel and the `ui` / `ui-mapbox` side-effect entries), versioned in lockstep with ui.
+  // Read it straight from the build so the Worker's read path — routing, resolution, and the static
+  // modulepreload `Link` header — is exercised against the real entry graph: each side-effect entry
+  // preloads the shared autoload runtime chunk plus its cross-tree `externalPreload` manifest URL,
+  // and no component chunk (components are lazy imports absent from the static graph).
+  const uiAutoloadTreeDirectory = resolve(
+    outputDirectory,
+    `releases/ui-autoload/${uiPackageVersion}`,
+  );
+  const uiAutoloadBuild = JSON.parse(
+    await readFile(resolve(uiAutoloadTreeDirectory, 'build.json'), 'utf8'),
+  ) as BuildMetadata;
+  // build.json `outputs` inventories every served file except build.json / integrity.json themselves
+  // (which is exactly the set the integrity manifest — and the Worker — expect to be seeded).
+  const uiAutoloadAssetPaths = [
+    ...Object.keys(uiAutoloadBuild.outputs),
+    'build.json',
+    'integrity.json',
+  ].sort();
+  const uiAutoloadFiles = await readTreeFiles(uiAutoloadTreeDirectory, uiAutoloadAssetPaths);
 
   const jsToolkitAssetPaths = [
     'index.js',

--- a/packages/cdn/tests/worker/index.test.ts
+++ b/packages/cdn/tests/worker/index.test.ts
@@ -204,11 +204,11 @@ describe('CDN Worker ui-mapbox package routing', () => {
 describe('CDN Worker ui-autoload package routing', () => {
   // ui-autoload is the fourth CDN package: a ui-like tree versioned in lockstep with ui, carrying
   // releases, immutable channels and the latest/next/main tags. It resolves and serves exactly like
-  // ui and ui-mapbox from its own namespaced trees. (The fixture synthesizes this tree by cloning
-  // ui-mapbox; the real tree is published in a later PR.)
-  it('serves the ui-autoload barrel and per-component modules from the ui-autoload tree', async () => {
+  // ui and ui-mapbox from its own namespaced trees. The fixture reads the real build output, whose
+  // stable entries are the pure `index` barrel and the `ui` / `ui-mapbox` side-effect entries.
+  it('serves the ui-autoload barrel and side-effect entries from the ui-autoload tree', async () => {
     const barrel = await request('/ui-autoload@1.2.0/index.js');
-    const component = await request('/ui-autoload@1.2.0/MapboxMap.js');
+    const sideEffect = await request('/ui-autoload@1.2.0/ui.js');
 
     expect(barrel.status).toBe(200);
     expect(barrel.headers.get('Content-Type')).toBe('text/javascript; charset=utf-8');
@@ -216,22 +216,22 @@ describe('CDN Worker ui-autoload package routing', () => {
     expect(await barrel.text()).toBe(fixture.uiAutoloadFiles['index.js']);
     expectCrossOriginHeaders(barrel);
 
-    expect(component.status).toBe(200);
-    expect(await component.text()).toBe(fixture.uiAutoloadFiles['MapboxMap.js']);
+    expect(sideEffect.status).toBe(200);
+    expect(await sideEffect.text()).toBe(fixture.uiAutoloadFiles['ui.js']);
   });
 
   it('resolves ui-autoload exact versions, aliases, tags and channels exactly like ui', async () => {
-    const alias = await request('/ui-autoload@1/MapboxMap.js');
+    const alias = await request('/ui-autoload@1/ui.js');
     expect(alias.status).toBe(307);
-    expect(alias.headers.get('Location')).toBe(`${origin}/ui-autoload@1.10.0/MapboxMap.js`);
+    expect(alias.headers.get('Location')).toBe(`${origin}/ui-autoload@1.10.0/ui.js`);
 
     const latest = await request('/ui-autoload@latest/index.js');
     expect(latest.status).toBe(307);
     expect(latest.headers.get('Location')).toBe(`${origin}/ui-autoload@2.0.0/index.js`);
 
-    const channel = await request('/ui-autoload@main-abcdef1/MapboxMap.js');
+    const channel = await request('/ui-autoload@main-abcdef1/ui.js');
     expect(channel.status).toBe(200);
-    expect(await channel.text()).toBe(fixture.uiAutoloadFiles['MapboxMap.js']);
+    expect(await channel.text()).toBe(fixture.uiAutoloadFiles['ui.js']);
 
     const next = await request('/ui-autoload@next/index.js');
     expect(next.status).toBe(307);
@@ -243,9 +243,9 @@ describe('CDN Worker ui-autoload package routing', () => {
   });
 
   it('resolves versionless, bare-root and ref-carrying ui-autoload requests', async () => {
-    const versionless = await request('/ui-autoload/MapboxMap');
+    const versionless = await request('/ui-autoload/ui');
     expect(versionless.status).toBe(307);
-    expect(versionless.headers.get('Location')).toBe(`${origin}/ui-autoload@2.0.0/MapboxMap.js`);
+    expect(versionless.headers.get('Location')).toBe(`${origin}/ui-autoload@2.0.0/ui.js`);
 
     for (const path of ['/ui-autoload', '/ui-autoload/']) {
       const root = await request(path);
@@ -259,11 +259,100 @@ describe('CDN Worker ui-autoload package routing', () => {
   });
 
   it('advertises the ui-autoload declaration via X-TypeScript-Types', async () => {
-    const module = await request('/ui-autoload@1.2.0/MapboxMap.js');
-    expect(module.headers.get('X-TypeScript-Types')).toBe(
-      `${origin}/ui-autoload@1.2.0/MapboxMap.d.ts`,
-    );
+    const module = await request('/ui-autoload@1.2.0/ui.js');
+    expect(module.headers.get('X-TypeScript-Types')).toBe(`${origin}/ui-autoload@1.2.0/ui.d.ts`);
     expect(module.headers.get('Access-Control-Expose-Headers')).toContain('X-TypeScript-Types');
+  });
+});
+
+describe('CDN Worker modulepreload Link header', () => {
+  // A served ENTRY advertises its STATIC, bootstrap-only dependencies via `Link: rel=modulepreload`:
+  // its tree-relative `preload` outputs prefixed with the served `/<pkg>@<version>/` root, plus any
+  // already-resolved cross-tree `externalPreload` URLs verbatim. The critical safety property, locked
+  // in below, is that a component chunk is NEVER preloaded — components are lazy `import()`s absent
+  // from every entry's static graph, so reading only `preload`/`externalPreload` can never surface one.
+  const runtimeChunk = /<\/ui-autoload@1\.2\.0\/chunks\/runtime-[^>]+\.js>; rel=modulepreload/;
+
+  function linkTargets(link: string): string[] {
+    return link.split(', ').map((part) => {
+      const match = /^<([^>]+)>; rel=modulepreload$/.exec(part);
+      if (!match) throw new Error(`Malformed Link entry: ${part}`);
+      return match[1];
+    });
+  }
+
+  it('warms the autoload runtime chunk AND the cross-tree ui manifest for ui.js, never a component', async () => {
+    const response = await request('/ui-autoload@1.2.0/ui.js');
+    expect(response.status).toBe(200);
+    const link = response.headers.get('Link');
+    expect(link).toBeTruthy();
+
+    // The always-needed bootstrap: the shared autoload runtime chunk (tree-relative, prefixed) ...
+    expect(link).toMatch(runtimeChunk);
+    // ... and the externalized cross-tree ui manifest, emitted verbatim at its baked ui version.
+    expect(link).toContain(`</ui@${fixture.uiVersion}/manifest.js>; rel=modulepreload`);
+
+    // Every preloaded target is either the runtime chunk or the manifest — no component chunk, ever.
+    const targets = linkTargets(link as string);
+    for (const target of targets) {
+      const isManifest = target === `/ui@${fixture.uiVersion}/manifest.js`;
+      const isRuntime = /^\/ui-autoload@1\.2\.0\/chunks\/runtime-[^/]+\.js$/.test(target);
+      expect(isManifest || isRuntime).toBe(true);
+    }
+    // Explicit negative guard against known component subpaths from the ui and ui-mapbox catalogs.
+    for (const token of ['Accordion', 'Action', 'AccordionItem', 'MapboxMap']) {
+      expect(link).not.toContain(`/${token}.js`);
+    }
+    // The header stays within the reused byte bound.
+    expect(new TextEncoder().encode(link as string).length).toBeLessThanOrEqual(7_500);
+  });
+
+  it('warms the ui-mapbox manifest for the ui-mapbox side-effect entry', async () => {
+    const response = await request('/ui-autoload@1.2.0/ui-mapbox.js');
+    expect(response.status).toBe(200);
+    const link = response.headers.get('Link');
+    expect(link).toMatch(runtimeChunk);
+    expect(link).toContain(`</ui-mapbox@${fixture.uiVersion}/manifest.js>; rel=modulepreload`);
+    // Only the runtime chunk and this package's manifest — no component chunk.
+    for (const target of linkTargets(link as string)) {
+      const isManifest = target === `/ui-mapbox@${fixture.uiVersion}/manifest.js`;
+      const isRuntime = /^\/ui-autoload@1\.2\.0\/chunks\/runtime-[^/]+\.js$/.test(target);
+      expect(isManifest || isRuntime).toBe(true);
+    }
+  });
+
+  it('preloads only the runtime chunk for the pure index barrel, with no manifest', async () => {
+    const response = await request('/ui-autoload@1.2.0/index.js');
+    const link = response.headers.get('Link');
+    expect(link).toMatch(runtimeChunk);
+    // The pure barrel imports no manifest, so none is advertised.
+    expect(link).not.toContain('/manifest.js');
+    expect(linkTargets(link as string)).toEqual([
+      linkTargets(link as string).find((target) =>
+        /^\/ui-autoload@1\.2\.0\/chunks\/runtime-[^/]+\.js$/.test(target),
+      ),
+    ]);
+  });
+
+  it('preserves the Link header on a 304 and for a HEAD request', async () => {
+    const first = await request('/ui-autoload@1.2.0/ui.js');
+    const etag = first.headers.get('ETag');
+    expect(etag).toBeTruthy();
+    const notModified = await request('/ui-autoload@1.2.0/ui.js', {
+      headers: { 'If-None-Match': etag as string },
+    });
+    expect(notModified.status).toBe(304);
+    expect(notModified.headers.get('Link')).toBe(first.headers.get('Link'));
+
+    const head = await request('/ui-autoload@1.2.0/ui.js', { method: 'HEAD' });
+    expect(head.headers.get('Link')).toBe(first.headers.get('Link'));
+  });
+
+  it('emits no Link header for a served output that is not an entry', async () => {
+    // A component chunk is a served output but not an entry, so it carries no modulepreload header.
+    const response = await request('/ui@1.2.0/Action.js');
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Link')).toBeNull();
   });
 });
 

--- a/packages/cdn/worker/index.ts
+++ b/packages/cdn/worker/index.ts
@@ -16,6 +16,7 @@ import {
 } from './responses.ts';
 import { buildRegistry } from './registry.ts';
 import type {
+  BuildGraph,
   BuildMetadata,
   ExactVersion,
   IntegrityMetadata,
@@ -47,6 +48,13 @@ const PUBLIC_PACKAGE_NAMES: Record<PackageName, string> = {
   'js-toolkit': '@studiometa/ui-cdn-js-toolkit',
 };
 const SAFE_METADATA_PATH = /^(?!\/)(?!.*(?:^|\/)\.\.?(?:\/|$))(?!.*\\)[0-9A-Za-z._@+/-]+$/;
+// A cross-tree bootstrap preload URL is origin-relative (leading `/`, no host) and points into
+// ANOTHER package tree (`/ui@<v>/manifest.js`), so unlike SAFE_METADATA_PATH it must start with `/`.
+// It still forbids `..` traversal and backslashes, keeping it safe to echo into a `Link` header.
+const SAFE_EXTERNAL_PRELOAD_URL = /^\/(?!.*(?:^|\/)\.\.?(?:\/|$))(?!.*\\)[0-9A-Za-z._@+/-]+$/;
+// The old component-preload header capped its byte length here; the static bootstrap header reuses
+// the same bound so a large entry graph (e.g. the ui barrel) can never emit an unbounded header.
+const MAX_LINK_HEADER_BYTES = 7_500;
 
 // The npm packages a CDN component may belong to. The registry maps each component's packageName
 // straight into its reported owner, so an unexpected value must be rejected rather than surfaced.
@@ -77,9 +85,26 @@ function validGraph(
     return false;
   }
   const paths = [value[entryKey], ...value.preload];
-  return paths.every(
-    (path) => typeof path === 'string' && SAFE_METADATA_PATH.test(path) && files.has(path),
-  );
+  if (
+    !paths.every(
+      (path) => typeof path === 'string' && SAFE_METADATA_PATH.test(path) && files.has(path),
+    )
+  ) {
+    return false;
+  }
+  // `externalPreload` (entries only) lists cross-tree bootstrap URLs served from ANOTHER tree, so it
+  // is validated for shape alone — never against this tree's file inventory, which does not hold them.
+  if (value.externalPreload !== undefined) {
+    if (!Array.isArray(value.externalPreload)) return false;
+    if (
+      !value.externalPreload.every(
+        (url) => typeof url === 'string' && SAFE_EXTERNAL_PRELOAD_URL.test(url),
+      )
+    ) {
+      return false;
+    }
+  }
+  return true;
 }
 
 function parseReleaseMetadata(
@@ -195,6 +220,35 @@ function canonicalLocation(
   search: string,
 ): string {
   return `${url.origin}/${packageName}@${exactVersion}/${assetPath}${search}`;
+}
+
+// Builds the static, bootstrap-only `Link: …; rel=modulepreload` header for a served ENTRY: its
+// tree-relative `preload` outputs resolved to `/<packageName>@<exactVersion>/<path>`, then its
+// already-resolved cross-tree `externalPreload` URLs verbatim. This preloads only the always-needed
+// bootstrap graph the entry statically imports (for the ui-autoload side-effect entries: the
+// autoload runtime chunk plus the cross-tree manifest); component chunks are lazy `import()`s absent
+// from the static graph, so they are never listed. It is driven purely by `preload`/`externalPreload`
+// — there is no component lookup and nothing query-driven. The byte bound keeps a large entry graph
+// (the ui barrel statically re-exports every component) from emitting an unbounded header.
+function preloadHeader(
+  packageName: PackageName,
+  exactVersion: string,
+  graph: BuildGraph,
+): string | undefined {
+  const links: string[] = [];
+  let length = 0;
+  const targets = [
+    ...graph.preload.map((path) => `/${packageName}@${exactVersion}/${path}`),
+    ...(graph.externalPreload ?? []),
+  ];
+  for (const target of targets) {
+    const link = `<${target}>; rel=modulepreload`;
+    const nextLength = length + (links.length > 0 ? 2 : 0) + link.length;
+    if (nextLength > MAX_LINK_HEADER_BYTES) break;
+    links.push(link);
+    length = nextLength;
+  }
+  return links.length > 0 ? links.join(', ') : undefined;
 }
 
 function objectEtag(object: R2ObjectBodyLike): string | undefined {
@@ -397,6 +451,20 @@ async function handleRequest(
       );
       headers.set('Access-Control-Expose-Headers', 'X-TypeScript-Types');
     }
+  }
+
+  // When the served output is an entry, advertise its static bootstrap graph (and any cross-tree
+  // `externalPreload` URLs) with a `Link: rel=modulepreload` header so the browser can warm those
+  // always-needed dependencies in parallel. It is keyed off `build.entries` only — a served output
+  // that is not an entry (a component chunk, a shared chunk, a `.d.ts`/`.map`) carries no header, and
+  // no component chunk is ever preloaded because components are lazy imports absent from the graph.
+  // Set before the 304 branch so a not-modified response stays consistent, and preserved for HEAD.
+  const entryGraph = Object.values<BuildGraph>(metadata.build.entries).find(
+    (entry) => entry.path === assetPath,
+  );
+  if (entryGraph) {
+    const link = preloadHeader(route.packageName, exact.version, entryGraph);
+    if (link) headers.set('Link', link);
   }
 
   if (etagMatches(request.headers.get('If-None-Match'), etag)) {

--- a/packages/cdn/worker/types.ts
+++ b/packages/cdn/worker/types.ts
@@ -55,6 +55,11 @@ export interface BuildGraph {
   path?: string;
   entry?: string;
   preload: string[];
+  // Optional already-resolved, origin-relative bootstrap URLs an entry pulls from ANOTHER tree
+  // (externalized cross-tree imports the bundler baked as absolute `/…@<v>/…` paths, so they never
+  // appear on the tree-relative `preload` graph). Emitted verbatim in the `Link: rel=modulepreload`
+  // header; only entries carry it (never components).
+  externalPreload?: string[];
 }
 
 export interface BuildComponent extends BuildGraph {


### PR DESCRIPTION
## What

Re-adds a **static, bootstrap-only** `Link: …; rel=modulepreload` response header to the browser CDN worker. When a served output is an **entry**, the worker advertises that entry's static bootstrap graph so the browser can warm the always-needed dependencies in parallel:

- the entry's tree-relative `preload` outputs, each resolved to `/<packageName>@<exactVersion>/<path>`, **and**
- the entry's already-resolved cross-tree `externalPreload` URLs, emitted verbatim.

For the ui-autoload side-effect entries this means the shared **autoload runtime chunk** plus the **cross-tree package manifest** — the two biggest always-needed bootstrap dependencies of loading `ui.js` / `ui-mapbox.js`.

## The `externalPreload` gap it closes

The build already emitted per-entry static `preload` graphs, but the `ui.js` / `ui-mapbox.js` entries also statically import their package **manifest** (`/ui@<v>/manifest.js`, `/ui-mapbox@<v>/manifest.js`). That import is **externalized** (a baked absolute cross-tree path), so the bundler never lists it in the static `preload` graph. The build now advertises it in a new per-entry **`externalPreload: string[]`** field — kept distinct from the tree-relative `preload` so the worker prefixes `preload` with the served `/<pkg>@<v>/` root while emitting `externalPreload` as-is — pinned to the lockstep ui version. The pure `index` barrel imports no manifest and carries no `externalPreload`.

## Explicitly NOT the removed `?components=` header

This is a different, simpler header than the component-preload machinery removed in #602. It is **query-free** (no `?components=`, no query parsing) and reads only `preload` / `externalPreload` from `build.json` — there is **no component lookup**. Components are lazy `import()`s that never appear in an entry's static graph, so a **component chunk is never preloaded**. A test enforces this on the autoload entries: serving `/ui-autoload@<v>/ui.js` emits a header containing the runtime chunk and `/ui@<v>/manifest.js` and nothing else — asserting no `/Accordion.js`, `/Action.js`, `/MapboxMap.js`, and that every preloaded target is either the runtime chunk or the manifest. This **complements npm usage**, where the bundler owns preload; on the CDN the worker advertises the same static bootstrap graph over HTTP. The header reuses the old `MAX_LINK_HEADER_BYTES` (7500) bound, is set alongside `Content-Type`/`ETag`/`X-TypeScript-Types`, and is preserved on the 304 branch and for HEAD.

## Tests

- **worker** — `/ui-autoload@<v>/ui.js` header contains the runtime chunk + `/ui@<v>/manifest.js` and **no component path** (safety property); `ui-mapbox.js` + its manifest; `index.js` preloads only the runtime chunk with no manifest; the byte bound holds; the header is preserved on 304 and HEAD; a non-entry output (a component chunk) carries no header. The worker fixture now reads the **real** ui-autoload build tree instead of a ui-mapbox stand-in.
- **build** — the ui-autoload `ui`/`ui-mapbox` entries carry the manifest URL in `externalPreload`; `index` does not; the ui/ui-mapbox trees keep the plain `preload` shape.
- **smoke** — asserts the live `Link` header on `/ui-autoload@<v>/ui.js` includes the manifest + runtime and excludes components.

## Verification

- `npm run lint` — 0 errors.
- CDN suites run locally and green: worker (86), build (21), versions + observability + publication (58), and the Playwright browser suite (8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014FQxYGj2RqgcP8BkubpiNu
