### PR TITLE
Prepare 1.10.0-beta.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [v1.10.0-beta.3](https://github.com/studiometa/ui/compare/1.10.0-beta.2..1.10.0-beta.3) (2026-08-05)
+
+### Fixed
+
+- **Browser CDN:** declaration files now re-export through `.d.ts` chunk specifiers (e.g. `./chunks/Action-<hash>.d.ts`) instead of `.js`, matching esm.sh, so a cross-origin TypeScript language server — such as the playground editor (modern-monaco) — resolves real types and JSDoc from the CDN instead of falling back to `any` ([#608](https://github.com/studiometa/ui/pull/608))
+
+### Added
+
+- **Browser CDN:** serve a static `Link: rel=modulepreload` header advertising each entry's bootstrap dependencies (the autoload runtime chunk and the package manifest) so they load in parallel; component chunks stay lazy and are never preloaded ([#606](https://github.com/studiometa/ui/pull/606))
+
+### Changed
+
+- **@studiometa/ui-autoload:** declare `@studiometa/ui` and `@studiometa/ui-mapbox` as exact-version, optional peer dependencies, kept in lockstep on every release, so consumers (and esm.sh) resolve the matching component manifest version ([#607](https://github.com/studiometa/ui/pull/607))
+
 ## [v1.10.0-beta.2](https://github.com/studiometa/ui/compare/1.10.0-beta.1..1.10.0-beta.2) (2026-08-05)
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "studiometa/ui",
   "type": "composer-plugin",
-  "version": "1.10.0-beta.2",
+  "version": "1.10.0-beta.3",
   "description": "Accessible and composable JavaScript behaviors and Twig templates.",
   "license": "MIT",
   "require": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@studiometa/ui-workspace",
-  "version": "1.10.0-beta.2",
+  "version": "1.10.0-beta.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@studiometa/ui-workspace",
-      "version": "1.10.0-beta.2",
+      "version": "1.10.0-beta.3",
       "hasInstallScript": true,
       "workspaces": [
         "packages/*"
@@ -23374,11 +23374,11 @@
     },
     "packages/api": {
       "name": "@studiometa/ui-api",
-      "version": "1.10.0-beta.2"
+      "version": "1.10.0-beta.3"
     },
     "packages/cdn": {
       "name": "@studiometa/ui-cdn",
-      "version": "1.10.0-beta.2",
+      "version": "1.10.0-beta.3",
       "license": "MIT",
       "dependencies": {
         "@studiometa/ui": "file:../ui",
@@ -23621,7 +23621,7 @@
     },
     "packages/docs": {
       "name": "@studiometa/ui-docs",
-      "version": "1.10.0-beta.2",
+      "version": "1.10.0-beta.3",
       "dependencies": {
         "@studiometa/js-toolkit": "3.8.0"
       },
@@ -23642,7 +23642,7 @@
     },
     "packages/eslint-plugin-ui": {
       "name": "@studiometa/eslint-plugin-ui",
-      "version": "1.10.0-beta.2",
+      "version": "1.10.0-beta.3",
       "license": "MIT",
       "dependencies": {
         "@oxlint/plugins": "1.63.0"
@@ -23671,7 +23671,7 @@
     },
     "packages/playground": {
       "name": "@studiometa/ui-playground",
-      "version": "1.10.0-beta.2",
+      "version": "1.10.0-beta.3",
       "dependencies": {
         "@studiometa/playground": "0.3.10"
       },
@@ -23738,7 +23738,7 @@
     },
     "packages/tests": {
       "name": "@studiometa/ui-tests",
-      "version": "1.10.0-beta.2",
+      "version": "1.10.0-beta.3",
       "license": "MIT",
       "dependencies": {
         "@happy-dom/global-registrator": "^20.8.8",
@@ -23993,7 +23993,7 @@
     },
     "packages/ui": {
       "name": "@studiometa/ui",
-      "version": "1.10.0-beta.2",
+      "version": "1.10.0-beta.3",
       "license": "MIT",
       "dependencies": {
         "alien-signals": "^3.2.1",
@@ -24021,7 +24021,7 @@
     },
     "packages/ui-autoload": {
       "name": "@studiometa/ui-autoload",
-      "version": "1.10.0-beta.2",
+      "version": "1.10.0-beta.3",
       "license": "MIT",
       "devDependencies": {
         "@studiometa/js-toolkit": "^3.8.0",
@@ -24029,8 +24029,8 @@
       },
       "peerDependencies": {
         "@studiometa/js-toolkit": "^3.8.0",
-        "@studiometa/ui": "1.10.0-beta.2",
-        "@studiometa/ui-mapbox": "1.10.0-beta.2"
+        "@studiometa/ui": "1.10.0-beta.3",
+        "@studiometa/ui-mapbox": "1.10.0-beta.3"
       },
       "peerDependenciesMeta": {
         "@studiometa/ui": {
@@ -24043,7 +24043,7 @@
     },
     "packages/ui-mapbox": {
       "name": "@studiometa/ui-mapbox",
-      "version": "1.10.0-beta.2",
+      "version": "1.10.0-beta.3",
       "license": "MIT",
       "devDependencies": {
         "@mapbox/mapbox-gl-geocoder": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-workspace",
-  "version": "1.10.0-beta.2",
+  "version": "1.10.0-beta.3",
   "type": "module",
   "private": true,
   "workspaces": [

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-api",
-  "version": "1.10.0-beta.2",
+  "version": "1.10.0-beta.3",
   "private": true,
   "type": "commonjs"
 }

--- a/packages/cdn/package.json
+++ b/packages/cdn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-cdn",
-  "version": "1.10.0-beta.2",
+  "version": "1.10.0-beta.3",
   "description": "Private browser CDN build for @studiometa/ui",
   "private": true,
   "type": "module",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-docs",
-  "version": "1.10.0-beta.2",
+  "version": "1.10.0-beta.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/eslint-plugin-ui/package.json
+++ b/packages/eslint-plugin-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/eslint-plugin-ui",
-  "version": "1.10.0-beta.2",
+  "version": "1.10.0-beta.3",
   "description": "ESLint plugin to help developers discover and use @studiometa/ui components",
   "publishConfig": {
     "access": "public"

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-playground",
-  "version": "1.10.0-beta.2",
+  "version": "1.10.0-beta.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-tests",
-  "version": "1.10.0-beta.2",
+  "version": "1.10.0-beta.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/ui-autoload/package.json
+++ b/packages/ui-autoload/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-autoload",
-  "version": "1.10.0-beta.2",
+  "version": "1.10.0-beta.3",
   "description": "Generic, side-effect-free declarative autoloader for @studiometa/ui component manifests",
   "publishConfig": {
     "access": "public"
@@ -46,8 +46,8 @@
   "homepage": "https://github.com/studiometa/ui#readme",
   "peerDependencies": {
     "@studiometa/js-toolkit": "^3.8.0",
-    "@studiometa/ui": "1.10.0-beta.2",
-    "@studiometa/ui-mapbox": "1.10.0-beta.2"
+    "@studiometa/ui": "1.10.0-beta.3",
+    "@studiometa/ui-mapbox": "1.10.0-beta.3"
   },
   "peerDependenciesMeta": {
     "@studiometa/ui": {

--- a/packages/ui-mapbox/package.json
+++ b/packages/ui-mapbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-mapbox",
-  "version": "1.10.0-beta.2",
+  "version": "1.10.0-beta.3",
   "description": "Vanilla js-toolkit components to build Mapbox GL maps declaratively",
   "publishConfig": {
     "access": "public"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui",
-  "version": "1.10.0-beta.2",
+  "version": "1.10.0-beta.3",
   "description": "Accessible and composable JavaScript behaviors and templates",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Version bump to `1.10.0-beta.3` across all workspaces + the Composer package. ui-autoload's exact lockstep peers are auto-synced to `1.10.0-beta.3` by `postversion`.

This prerelease ships the CDN type-resolution fixes so the playground editor gets real types + JSDoc:
- `.d.ts` chunk specifiers on the CDN (matching esm.sh) so modern-monaco resolves ui/ui-mapbox types instead of `any` (#608)
- static `Link: rel=modulepreload` bootstrap header (#606)
- exact-version lockstep peers on `@studiometa/ui-autoload` (#607)

Note: js-toolkit's CDN `.d.ts` still requires a separate js-toolkit version bump to surface (the immutable `3.8.0` tree can't be retrofitted) — tracked as a follow-up.

Tag `1.10.0-beta.3` (no `v` prefix) will be pushed after merge to trigger the release workflow (npm `next` + provenance, CDN release trees + `next`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014FQxYGj2RqgcP8BkubpiNu