### PR TITLE
Replace `export *` barrels with explicit named exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
-- **@studiometa/ui, @studiometa/ui-mapbox:** replace every `export *` barrel re-export with explicit named `export { ... }` (values and `type`-only specifiers) so the public surface is statically analyzable. This lets bundlers and esm.sh keep every export name and tree-shake reliably, matching the same change made in `@studiometa/js-toolkit` 3.8.1. The exported API is unchanged — a type-checker snapshot of each barrel's full surface guards against regressions ([#PR](https://github.com/studiometa/ui/pull/PR))
+- **@studiometa/ui, @studiometa/ui-mapbox:** replace every `export *` barrel re-export with explicit named `export { ... }` (values and `type`-only specifiers) so the public surface is statically analyzable. This lets bundlers and esm.sh keep every export name and tree-shake reliably, matching the same change made in `@studiometa/js-toolkit` 3.8.1. The exported API is unchanged — a type-checker snapshot of each barrel's full surface guards against regressions ([#611](https://github.com/studiometa/ui/pull/611))
 
 ## [v1.10.0-beta.3](https://github.com/studiometa/ui/compare/1.10.0-beta.2..1.10.0-beta.3) (2026-08-05)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Changed
+
+- **@studiometa/ui, @studiometa/ui-mapbox:** replace every `export *` barrel re-export with explicit named `export { ... }` (values and `type`-only specifiers) so the public surface is statically analyzable. This lets bundlers and esm.sh keep every export name and tree-shake reliably, matching the same change made in `@studiometa/js-toolkit` 3.8.1. The exported API is unchanged — a type-checker snapshot of each barrel's full surface guards against regressions ([#PR](https://github.com/studiometa/ui/pull/PR))
+
 ## [v1.10.0-beta.3](https://github.com/studiometa/ui/compare/1.10.0-beta.2..1.10.0-beta.3) (2026-08-05)
 
 ### Fixed

--- a/packages/tests/barrel-exports/barrel-exports.spec.ts
+++ b/packages/tests/barrel-exports/barrel-exports.spec.ts
@@ -1,0 +1,328 @@
+import { test, expect } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import ts from 'typescript';
+
+// Snapshot the FULL public export surface of each package barrel — values AND
+// type-only exports — so converting `export *` re-exports to explicit named
+// `export { ... }` cannot silently drop a name or flip a value into a
+// type-only export. A runtime `Object.keys` snapshot (see `index.spec.ts`)
+// only covers value exports; the type-only exports are erased at runtime, so
+// they need a static, type-checker-based enumeration to be guarded.
+//
+// `typescript` is resolved from the workspace root — it is the compiler the
+// whole repo already relies on — so it is not a direct dependency here.
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
+
+const { config } = ts.readConfigFile(resolve(ROOT, 'tsconfig.json'), ts.sys.readFile);
+const parsed = ts.parseJsonConfigFileContent(config, ts.sys, ROOT);
+
+const ENTRIES = {
+  '@studiometa/ui': 'packages/ui/index.ts',
+  '@studiometa/ui-mapbox': 'packages/ui-mapbox/index.ts',
+  '@studiometa/ui-autoload': 'packages/ui-autoload/index.ts',
+};
+
+const program = ts.createProgram(
+  Object.values(ENTRIES).map((rel) => resolve(ROOT, rel)),
+  parsed.options,
+);
+const checker = program.getTypeChecker();
+
+/**
+ * Enumerate the exported members of a package barrel, tagged with whether each
+ * carries a runtime value (`value`) or is type-only (`type`). Re-export aliases
+ * are resolved to their target before the kind is read, so `export { foo }`
+ * and `export * from '...'` are classified the same way.
+ */
+function surface(rel: string): string[] {
+  const sourceFile = program.getSourceFile(resolve(ROOT, rel));
+  if (!sourceFile) throw new Error(`Could not load ${rel}`);
+  const moduleSymbol = checker.getSymbolAtLocation(sourceFile);
+  if (!moduleSymbol) throw new Error(`No module symbol for ${rel}`);
+  return checker
+    .getExportsOfModule(moduleSymbol)
+    .map((symbol) => {
+      const resolved =
+        symbol.flags & ts.SymbolFlags.Alias ? checker.getAliasedSymbol(symbol) : symbol;
+      const kind = resolved.flags & ts.SymbolFlags.Value ? 'value' : 'type';
+      return `${symbol.getName()} [${kind}]`;
+    })
+    .sort();
+}
+
+test('@studiometa/ui barrel export surface', () => {
+  expect(surface(ENTRIES['@studiometa/ui'])).toMatchInlineSnapshot(`
+    [
+      "AbstractCarouselChild [value]",
+      "AbstractCarouselChildProps [type]",
+      "AbstractCarouselComponent [value]",
+      "AbstractCarouselComponentProps [type]",
+      "AbstractFrameTrigger [value]",
+      "AbstractFrameTriggerProps [type]",
+      "AbstractPrefetch [value]",
+      "AbstractPrefetchProps [type]",
+      "AbstractScrollAnimation [value]",
+      "AbstractScrollAnimationProps [type]",
+      "AbstractSliderChild [value]",
+      "AbstractSliderChildProps [type]",
+      "Accordion [value]",
+      "AccordionItem [value]",
+      "AccordionItemProps [type]",
+      "Action [value]",
+      "ActionProps [type]",
+      "AnchorNav [value]",
+      "AnchorNavLink [value]",
+      "AnchorNavLinkProps [type]",
+      "AnchorNavProps [type]",
+      "AnchorNavTarget [value]",
+      "AnchorScrollTo [value]",
+      "AnchorScrollToProps [type]",
+      "AnimationScrollWithEaseInterface [type]",
+      "AnimationScrollWithEaseProps [type]",
+      "Carousel [value]",
+      "CarouselBtn [value]",
+      "CarouselBtnProps [type]",
+      "CarouselDrag [value]",
+      "CarouselDragProps [type]",
+      "CarouselItem [value]",
+      "CarouselItemProps [type]",
+      "CarouselProps [type]",
+      "CarouselStore [type]",
+      "CarouselWrapper [value]",
+      "CarouselWrapperProps [type]",
+      "CircularMarquee [value]",
+      "CircularMarqueeProps [type]",
+      "ClickOutside [value]",
+      "ClickOutsideProps [type]",
+      "Cursor [value]",
+      "CursorProps [type]",
+      "DataBind [value]",
+      "DataBindProps [type]",
+      "DataComputed [value]",
+      "DataComputedProps [type]",
+      "DataEffect [value]",
+      "DataEffectProps [type]",
+      "DataModel [value]",
+      "DataModelProps [type]",
+      "DataScope [value]",
+      "DataScopeProps [type]",
+      "DataValue [type]",
+      "DeprecationInterface [type]",
+      "DeprecationProps [type]",
+      "Dialog [value]",
+      "DialogProps [type]",
+      "Disclosure [value]",
+      "DisclosureGroup [value]",
+      "DisclosureGroupProps [type]",
+      "DisclosureProps [type]",
+      "Draggable [value]",
+      "DraggableProps [type]",
+      "Fetch [value]",
+      "FetchConstructor [type]",
+      "FetchProps [type]",
+      "FetchShopifyPartial [value]",
+      "FetchShopifyPartialConstructor [type]",
+      "FetchShopifyPartialProps [type]",
+      "FetchShopifySection [value]",
+      "FetchShopifySectionConstructor [type]",
+      "FetchShopifySectionProps [type]",
+      "Figure [value]",
+      "FigureProps [type]",
+      "FigureShopify [value]",
+      "FigureShopifyProps [type]",
+      "FigureTwicpics [value]",
+      "FigureTwicpicsProps [type]",
+      "FigureVideo [value]",
+      "FigureVideoProps [type]",
+      "FigureVideoTwicpics [value]",
+      "FigureVideoTwicpicsProps [type]",
+      "Frame [value]",
+      "FrameAnchor [value]",
+      "FrameAnchorProps [type]",
+      "FrameContentAfterEvent [type]",
+      "FrameContentEvent [type]",
+      "FrameErrorEvent [type]",
+      "FrameFetchAfterEvent [type]",
+      "FrameFetchBeforeEvent [type]",
+      "FrameFetchEvent [type]",
+      "FrameForm [value]",
+      "FrameFormProps [type]",
+      "FrameLoader [value]",
+      "FrameLoaderProps [type]",
+      "FrameProps [type]",
+      "FrameRequestInit [type]",
+      "FrameTarget [value]",
+      "FrameTargetProps [type]",
+      "FrameTriggerEvent [type]",
+      "FrameTriggerLoader [value]",
+      "FrameTriggerLoaderProps [type]",
+      "Hoverable [value]",
+      "HoverableProps [type]",
+      "InView [value]",
+      "InViewOnce [value]",
+      "Indexable [value]",
+      "IndexableBoundary [type]",
+      "IndexableInstructions [type]",
+      "IndexableInterface [type]",
+      "IndexableProps [type]",
+      "LargeText [value]",
+      "LargeTextProps [type]",
+      "LazyInclude [value]",
+      "LazyIncludeProps [type]",
+      "Menu [value]",
+      "MenuBtn [value]",
+      "MenuList [value]",
+      "MenuListProps [type]",
+      "MenuProps [type]",
+      "Modal [value]",
+      "ModalProps [type]",
+      "ModalWithTransition [value]",
+      "Panel [value]",
+      "PanelProps [type]",
+      "PrefetchWhenOver [value]",
+      "PrefetchWhenVisible [value]",
+      "ScrollAnimation [value]",
+      "ScrollAnimationChild [value]",
+      "ScrollAnimationChildProps [type]",
+      "ScrollAnimationChildWithEase [value]",
+      "ScrollAnimationParent [value]",
+      "ScrollAnimationParentProps [type]",
+      "ScrollAnimationProps [type]",
+      "ScrollAnimationTarget [value]",
+      "ScrollAnimationTargetProps [type]",
+      "ScrollAnimationTimeline [value]",
+      "ScrollAnimationTimelineProps [type]",
+      "ScrollAnimationWithEase [value]",
+      "ScrollReveal [value]",
+      "ScrollRevealProps [type]",
+      "Sentinel [value]",
+      "Slider [value]",
+      "SliderBtn [value]",
+      "SliderBtnProps [type]",
+      "SliderCount [value]",
+      "SliderCountProps [type]",
+      "SliderDots [value]",
+      "SliderDotsProps [type]",
+      "SliderDrag [value]",
+      "SliderDragProps [type]",
+      "SliderItem [value]",
+      "SliderItemProps [type]",
+      "SliderModes [type]",
+      "SliderProgress [value]",
+      "SliderProgressProps [type]",
+      "SliderProps [type]",
+      "SliderStore [type]",
+      "Sticky [value]",
+      "StickyProps [type]",
+      "Tabs [value]",
+      "TabsProps [type]",
+      "Target [value]",
+      "TargetProps [type]",
+      "Timer [value]",
+      "TimerProgress [value]",
+      "TimerProps [type]",
+      "Toast [value]",
+      "ToastProps [type]",
+      "Toaster [value]",
+      "ToasterProps [type]",
+      "ToasterShowOptions [type]",
+      "Track [value]",
+      "TrackContext [value]",
+      "TrackContextProps [type]",
+      "TrackProps [type]",
+      "TrackShopify [value]",
+      "TrackShopifyProps [type]",
+      "Transition [value]",
+      "TransitionConstructor [type]",
+      "TransitionInterface [type]",
+      "TransitionProps [type]",
+      "ViewTransition [value]",
+      "ViewTransitionProps [type]",
+      "WithScrollAnimationDebugInterface [type]",
+      "WithScrollAnimationDebugProps [type]",
+      "animationScrollWithEase [value]",
+      "viewTransition [value]",
+      "withDeprecation [value]",
+      "withIndex [value]",
+      "withScrollAnimationDebug [value]",
+      "withTransition [value]",
+    ]
+  `);
+});
+
+test('@studiometa/ui-mapbox barrel export surface', () => {
+  expect(surface(ENTRIES['@studiometa/ui-mapbox'])).toMatchInlineSnapshot(`
+    [
+      "AbstractMapboxControl [value]",
+      "AbstractMapboxControlProps [type]",
+      "AbstractMapboxMapChild [value]",
+      "AbstractMapboxMapChildProps [type]",
+      "MAPBOX_CLUSTER_CONNECTED [value]",
+      "MAPBOX_MAP_CONNECTED [value]",
+      "MapboxCluster [value]",
+      "MapboxClusterItem [value]",
+      "MapboxClusterItemProps [type]",
+      "MapboxClusterProps [type]",
+      "MapboxFullscreenControl [value]",
+      "MapboxFullscreenControlProps [type]",
+      "MapboxGeocoder [value]",
+      "MapboxGeocoderConstructor [type]",
+      "MapboxGeocoderControl [type]",
+      "MapboxGeocoderProps [type]",
+      "MapboxGeolocateControl [value]",
+      "MapboxGeolocateControlProps [type]",
+      "MapboxGl [type]",
+      "MapboxImage [value]",
+      "MapboxImageProps [type]",
+      "MapboxImages [value]",
+      "MapboxImagesProps [type]",
+      "MapboxLayer [value]",
+      "MapboxLayerProps [type]",
+      "MapboxMap [value]",
+      "MapboxMapProps [type]",
+      "MapboxMarker [value]",
+      "MapboxMarkerProps [type]",
+      "MapboxNavigationControl [value]",
+      "MapboxNavigationControlProps [type]",
+      "MapboxPopup [value]",
+      "MapboxPopupProps [type]",
+      "MapboxSource [value]",
+      "MapboxSourceProps [type]",
+      "StoreLocator [value]",
+      "StoreLocatorProps [type]",
+      "provideMapboxGeocoder [value]",
+      "provideMapboxGl [value]",
+      "resolveMapboxGeocoder [value]",
+      "resolveMapboxGl [value]",
+    ]
+  `);
+});
+
+test('@studiometa/ui-autoload barrel export surface', () => {
+  expect(surface(ENTRIES['@studiometa/ui-autoload'])).toMatchInlineSnapshot(`
+    [
+      "AutoloadHandle [type]",
+      "AutoloadOptions [type]",
+      "AutoloadRuntime [type]",
+      "ComponentCatalog [type]",
+      "ComponentLoadStrategy [type]",
+      "ComponentLoader [value]",
+      "ComponentLoaderOptions [type]",
+      "ComponentLoaderStartOptions [type]",
+      "ComponentManifest [type]",
+      "ComponentManifestEntry [type]",
+      "CuratedComponentMetadata [type]",
+      "DEFAULT_DIAGNOSTIC_PREFIX [value]",
+      "IDLE_TIMEOUT [value]",
+      "LoaderDependencies [type]",
+      "RegisterManifestOptions [type]",
+      "VISIBLE_ROOT_MARGIN [value]",
+      "autoload [value]",
+      "composeManifests [value]",
+      "readEagerTokens [value]",
+      "registerManifest [value]",
+    ]
+  `);
+});

--- a/packages/ui-mapbox/index.ts
+++ b/packages/ui-mapbox/index.ts
@@ -1,5 +1,9 @@
-export * from './AbstractMapboxControl.js';
-export * from './AbstractMapboxMapChild.js';
+export { AbstractMapboxControl, type AbstractMapboxControlProps } from './AbstractMapboxControl.js';
+export {
+  AbstractMapboxMapChild,
+  MAPBOX_MAP_CONNECTED,
+  type AbstractMapboxMapChildProps,
+} from './AbstractMapboxMapChild.js';
 export {
   provideMapboxGl,
   provideMapboxGeocoder,
@@ -9,17 +13,30 @@ export {
   type MapboxGeocoderControl,
   type MapboxGeocoderConstructor,
 } from './dependencies.js';
-export * from './MapboxCluster.js';
-export * from './MapboxClusterItem.js';
-export * from './MapboxFullscreenControl.js';
-export * from './MapboxGeocoder.js';
-export * from './MapboxGeolocateControl.js';
-export * from './MapboxImage.js';
-export * from './MapboxImages.js';
-export * from './MapboxLayer.js';
-export * from './MapboxMap.js';
-export * from './MapboxMarker.js';
-export * from './MapboxNavigationControl.js';
-export * from './MapboxPopup.js';
-export * from './MapboxSource.js';
-export * from './StoreLocator.js';
+export {
+  MAPBOX_CLUSTER_CONNECTED,
+  MapboxCluster,
+  type MapboxClusterProps,
+} from './MapboxCluster.js';
+export { MapboxClusterItem, type MapboxClusterItemProps } from './MapboxClusterItem.js';
+export {
+  MapboxFullscreenControl,
+  type MapboxFullscreenControlProps,
+} from './MapboxFullscreenControl.js';
+export { MapboxGeocoder, type MapboxGeocoderProps } from './MapboxGeocoder.js';
+export {
+  MapboxGeolocateControl,
+  type MapboxGeolocateControlProps,
+} from './MapboxGeolocateControl.js';
+export { MapboxImage, type MapboxImageProps } from './MapboxImage.js';
+export { MapboxImages, type MapboxImagesProps } from './MapboxImages.js';
+export { MapboxLayer, type MapboxLayerProps } from './MapboxLayer.js';
+export { MapboxMap, type MapboxMapProps } from './MapboxMap.js';
+export { MapboxMarker, type MapboxMarkerProps } from './MapboxMarker.js';
+export {
+  MapboxNavigationControl,
+  type MapboxNavigationControlProps,
+} from './MapboxNavigationControl.js';
+export { MapboxPopup, type MapboxPopupProps } from './MapboxPopup.js';
+export { MapboxSource, type MapboxSourceProps } from './MapboxSource.js';
+export { StoreLocator, type StoreLocatorProps } from './StoreLocator.js';

--- a/packages/ui/Accordion/index.ts
+++ b/packages/ui/Accordion/index.ts
@@ -1,2 +1,2 @@
-export * from './Accordion.js';
-export * from './AccordionItem.js';
+export { Accordion } from './Accordion.js';
+export { AccordionItem, type AccordionItemProps } from './AccordionItem.js';

--- a/packages/ui/Action/index.ts
+++ b/packages/ui/Action/index.ts
@@ -1,2 +1,2 @@
-export * from './Action.js';
-export * from './Target.js';
+export { Action, type ActionProps } from './Action.js';
+export { Target, type TargetProps } from './Target.js';

--- a/packages/ui/AnchorNav/index.ts
+++ b/packages/ui/AnchorNav/index.ts
@@ -1,3 +1,3 @@
-export * from './AnchorNav.js';
-export * from './AnchorNavLink.js';
-export * from './AnchorNavTarget.js';
+export { AnchorNav, type AnchorNavProps } from './AnchorNav.js';
+export { AnchorNavLink, type AnchorNavLinkProps } from './AnchorNavLink.js';
+export { AnchorNavTarget } from './AnchorNavTarget.js';

--- a/packages/ui/AnchorScrollTo/index.ts
+++ b/packages/ui/AnchorScrollTo/index.ts
@@ -1,1 +1,1 @@
-export * from './AnchorScrollTo.js';
+export { AnchorScrollTo, type AnchorScrollToProps } from './AnchorScrollTo.js';

--- a/packages/ui/Carousel/index.ts
+++ b/packages/ui/Carousel/index.ts
@@ -1,7 +1,10 @@
-export * from './Carousel.js';
-export * from './CarouselBtn.js';
-export * from './CarouselDrag.js';
-export * from './CarouselItem.js';
-export * from './CarouselWrapper.js';
-export * from './AbstractCarouselComponent.js';
-export * from './AbstractCarouselChild.js';
+export { Carousel, type CarouselProps, type CarouselStore } from './Carousel.js';
+export { CarouselBtn, type CarouselBtnProps } from './CarouselBtn.js';
+export { CarouselDrag, type CarouselDragProps } from './CarouselDrag.js';
+export { CarouselItem, type CarouselItemProps } from './CarouselItem.js';
+export { CarouselWrapper, type CarouselWrapperProps } from './CarouselWrapper.js';
+export {
+  AbstractCarouselComponent,
+  type AbstractCarouselComponentProps,
+} from './AbstractCarouselComponent.js';
+export { AbstractCarouselChild, type AbstractCarouselChildProps } from './AbstractCarouselChild.js';

--- a/packages/ui/CircularMarquee/index.ts
+++ b/packages/ui/CircularMarquee/index.ts
@@ -1,1 +1,1 @@
-export * from './CircularMarquee.js';
+export { CircularMarquee, type CircularMarqueeProps } from './CircularMarquee.js';

--- a/packages/ui/ClickOutside/index.ts
+++ b/packages/ui/ClickOutside/index.ts
@@ -1,1 +1,1 @@
-export * from './ClickOutside.js';
+export { ClickOutside, type ClickOutsideProps } from './ClickOutside.js';

--- a/packages/ui/Cursor/index.ts
+++ b/packages/ui/Cursor/index.ts
@@ -1,1 +1,1 @@
-export * from './Cursor.js';
+export { Cursor, type CursorProps } from './Cursor.js';

--- a/packages/ui/Data/index.ts
+++ b/packages/ui/Data/index.ts
@@ -1,6 +1,6 @@
-export * from './DataBind.js';
-export * from './DataComputed.js';
-export * from './DataEffect.js';
-export * from './DataModel.js';
+export { DataBind, type DataBindProps } from './DataBind.js';
+export { DataComputed, type DataComputedProps } from './DataComputed.js';
+export { DataEffect, type DataEffectProps } from './DataEffect.js';
+export { DataModel, type DataModelProps } from './DataModel.js';
 export { DataScope } from './DataScope.js';
 export type { DataScopeProps, DataValue } from './DataScope.js';

--- a/packages/ui/Dialog/index.ts
+++ b/packages/ui/Dialog/index.ts
@@ -1,1 +1,1 @@
-export * from './Dialog.js';
+export { Dialog, type DialogProps } from './Dialog.js';

--- a/packages/ui/Draggable/index.ts
+++ b/packages/ui/Draggable/index.ts
@@ -1,1 +1,1 @@
-export * from './Draggable.js';
+export { Draggable, type DraggableProps } from './Draggable.js';

--- a/packages/ui/Fetch/index.ts
+++ b/packages/ui/Fetch/index.ts
@@ -1,3 +1,11 @@
-export * from './Fetch.js';
-export * from './FetchShopifyPartial.js';
-export * from './FetchShopifySection.js';
+export { Fetch, type FetchConstructor, type FetchProps } from './Fetch.js';
+export {
+  FetchShopifyPartial,
+  type FetchShopifyPartialConstructor,
+  type FetchShopifyPartialProps,
+} from './FetchShopifyPartial.js';
+export {
+  FetchShopifySection,
+  type FetchShopifySectionConstructor,
+  type FetchShopifySectionProps,
+} from './FetchShopifySection.js';

--- a/packages/ui/Figure/index.ts
+++ b/packages/ui/Figure/index.ts
@@ -1,3 +1,3 @@
-export * from './Figure.js';
-export * from './FigureTwicpics.js';
-export * from './FigureShopify.js';
+export { Figure, type FigureProps } from './Figure.js';
+export { FigureTwicpics, type FigureTwicpicsProps } from './FigureTwicpics.js';
+export { FigureShopify, type FigureShopifyProps } from './FigureShopify.js';

--- a/packages/ui/FigureVideo/index.ts
+++ b/packages/ui/FigureVideo/index.ts
@@ -1,2 +1,2 @@
-export * from './FigureVideo.js';
-export * from './FigureVideoTwicpics.js';
+export { FigureVideo, type FigureVideoProps } from './FigureVideo.js';
+export { FigureVideoTwicpics, type FigureVideoTwicpicsProps } from './FigureVideoTwicpics.js';

--- a/packages/ui/Frame/index.ts
+++ b/packages/ui/Frame/index.ts
@@ -1,8 +1,17 @@
-export * from './Frame.js';
-export * from './FrameAnchor.js';
-export * from './FrameForm.js';
-export * from './FrameLoader.js';
-export * from './FrameTriggerLoader.js';
-export * from './FrameTarget.js';
-export * from './AbstractFrameTrigger.js';
-export * from './types.js';
+export { Frame, type FrameProps } from './Frame.js';
+export { FrameAnchor, type FrameAnchorProps } from './FrameAnchor.js';
+export { FrameForm, type FrameFormProps } from './FrameForm.js';
+export { FrameLoader, type FrameLoaderProps } from './FrameLoader.js';
+export { FrameTriggerLoader, type FrameTriggerLoaderProps } from './FrameTriggerLoader.js';
+export { FrameTarget, type FrameTargetProps } from './FrameTarget.js';
+export { AbstractFrameTrigger, type AbstractFrameTriggerProps } from './AbstractFrameTrigger.js';
+export {
+  type FrameContentAfterEvent,
+  type FrameContentEvent,
+  type FrameErrorEvent,
+  type FrameFetchAfterEvent,
+  type FrameFetchBeforeEvent,
+  type FrameFetchEvent,
+  type FrameRequestInit,
+  type FrameTriggerEvent,
+} from './types.js';

--- a/packages/ui/Hoverable/index.ts
+++ b/packages/ui/Hoverable/index.ts
@@ -1,1 +1,1 @@
-export * from './Hoverable.js';
+export { Hoverable, type HoverableProps } from './Hoverable.js';

--- a/packages/ui/InView/index.ts
+++ b/packages/ui/InView/index.ts
@@ -1,2 +1,2 @@
-export * from './InView.js';
-export * from './InViewOnce.js';
+export { InView } from './InView.js';
+export { InViewOnce } from './InViewOnce.js';

--- a/packages/ui/Indexable/index.ts
+++ b/packages/ui/Indexable/index.ts
@@ -1,1 +1,1 @@
-export * from './Indexable.js';
+export { Indexable } from './Indexable.js';

--- a/packages/ui/LargeText/index.ts
+++ b/packages/ui/LargeText/index.ts
@@ -1,1 +1,1 @@
-export * from './LargeText.js';
+export { LargeText, type LargeTextProps } from './LargeText.js';

--- a/packages/ui/LazyInclude/index.ts
+++ b/packages/ui/LazyInclude/index.ts
@@ -1,1 +1,1 @@
-export * from './LazyInclude.js';
+export { LazyInclude, type LazyIncludeProps } from './LazyInclude.js';

--- a/packages/ui/Menu/index.ts
+++ b/packages/ui/Menu/index.ts
@@ -1,3 +1,3 @@
-export * from './Menu.js';
-export * from './MenuBtn.js';
-export * from './MenuList.js';
+export { Menu, type MenuProps } from './Menu.js';
+export { MenuBtn } from './MenuBtn.js';
+export { MenuList, type MenuListProps } from './MenuList.js';

--- a/packages/ui/Modal/index.ts
+++ b/packages/ui/Modal/index.ts
@@ -1,2 +1,2 @@
-export * from './Modal.js';
-export * from './ModalWithTransition.js';
+export { Modal, type ModalProps } from './Modal.js';
+export { ModalWithTransition } from './ModalWithTransition.js';

--- a/packages/ui/Panel/index.ts
+++ b/packages/ui/Panel/index.ts
@@ -1,1 +1,1 @@
-export * from './Panel.js';
+export { Panel, type PanelProps } from './Panel.js';

--- a/packages/ui/Prefetch/index.ts
+++ b/packages/ui/Prefetch/index.ts
@@ -1,3 +1,3 @@
-export * from './AbstractPrefetch.js';
-export * from './PrefetchWhenOver.js';
-export * from './PrefetchWhenVisible.js';
+export { AbstractPrefetch, type AbstractPrefetchProps } from './AbstractPrefetch.js';
+export { PrefetchWhenOver } from './PrefetchWhenOver.js';
+export { PrefetchWhenVisible } from './PrefetchWhenVisible.js';

--- a/packages/ui/ScrollAnimation/index.ts
+++ b/packages/ui/ScrollAnimation/index.ts
@@ -1,12 +1,26 @@
-export * from './AbstractScrollAnimation.js';
-export * from './ScrollAnimationTimeline.js';
-export * from './ScrollAnimationTarget.js';
-export * from './withScrollAnimationDebug.js';
+export {
+  AbstractScrollAnimation,
+  type AbstractScrollAnimationProps,
+} from './AbstractScrollAnimation.js';
+export {
+  ScrollAnimationTimeline,
+  type ScrollAnimationTimelineProps,
+} from './ScrollAnimationTimeline.js';
+export { ScrollAnimationTarget, type ScrollAnimationTargetProps } from './ScrollAnimationTarget.js';
+export {
+  withScrollAnimationDebug,
+  type WithScrollAnimationDebugInterface,
+  type WithScrollAnimationDebugProps,
+} from './withScrollAnimationDebug.js';
 
 // Deprecated exports
-export * from './animationScrollWithEase.js';
-export * from './ScrollAnimation.js';
-export * from './ScrollAnimationWithEase.js';
-export * from './ScrollAnimationChild.js';
-export * from './ScrollAnimationChildWithEase.js';
-export * from './ScrollAnimationParent.js';
+export {
+  animationScrollWithEase,
+  type AnimationScrollWithEaseInterface,
+  type AnimationScrollWithEaseProps,
+} from './animationScrollWithEase.js';
+export { ScrollAnimation, type ScrollAnimationProps } from './ScrollAnimation.js';
+export { ScrollAnimationWithEase } from './ScrollAnimationWithEase.js';
+export { ScrollAnimationChild, type ScrollAnimationChildProps } from './ScrollAnimationChild.js';
+export { ScrollAnimationChildWithEase } from './ScrollAnimationChildWithEase.js';
+export { ScrollAnimationParent, type ScrollAnimationParentProps } from './ScrollAnimationParent.js';

--- a/packages/ui/ScrollReveal/index.ts
+++ b/packages/ui/ScrollReveal/index.ts
@@ -1,1 +1,1 @@
-export * from './ScrollReveal.js';
+export { ScrollReveal, type ScrollRevealProps } from './ScrollReveal.js';

--- a/packages/ui/Sentinel/index.ts
+++ b/packages/ui/Sentinel/index.ts
@@ -1,1 +1,1 @@
-export * from './Sentinel.js';
+export { Sentinel } from './Sentinel.js';

--- a/packages/ui/Slider/index.ts
+++ b/packages/ui/Slider/index.ts
@@ -1,8 +1,8 @@
-export * from './AbstractSliderChild.js';
-export * from './Slider.js';
-export * from './SliderBtn.js';
-export * from './SliderCount.js';
-export * from './SliderDrag.js';
-export * from './SliderItem.js';
-export * from './SliderProgress.js';
-export * from './SliderDots.js';
+export { AbstractSliderChild, type AbstractSliderChildProps } from './AbstractSliderChild.js';
+export { Slider, type SliderModes, type SliderProps, type SliderStore } from './Slider.js';
+export { SliderBtn, type SliderBtnProps } from './SliderBtn.js';
+export { SliderCount, type SliderCountProps } from './SliderCount.js';
+export { SliderDrag, type SliderDragProps } from './SliderDrag.js';
+export { SliderItem, type SliderItemProps } from './SliderItem.js';
+export { SliderProgress, type SliderProgressProps } from './SliderProgress.js';
+export { SliderDots, type SliderDotsProps } from './SliderDots.js';

--- a/packages/ui/Sticky/index.ts
+++ b/packages/ui/Sticky/index.ts
@@ -1,1 +1,1 @@
-export * from './Sticky.js';
+export { Sticky, type StickyProps } from './Sticky.js';

--- a/packages/ui/Tabs/index.ts
+++ b/packages/ui/Tabs/index.ts
@@ -1,1 +1,1 @@
-export * from './Tabs.js';
+export { Tabs, type TabsProps } from './Tabs.js';

--- a/packages/ui/Timer/index.ts
+++ b/packages/ui/Timer/index.ts
@@ -1,2 +1,2 @@
-export * from './Timer.js';
-export * from './TimerProgress.js';
+export { Timer, type TimerProps } from './Timer.js';
+export { TimerProgress } from './TimerProgress.js';

--- a/packages/ui/Toaster/index.ts
+++ b/packages/ui/Toaster/index.ts
@@ -1,2 +1,2 @@
-export * from './Toast.js';
-export * from './Toaster.js';
+export { Toast, type ToastProps } from './Toast.js';
+export { Toaster, type ToasterProps, type ToasterShowOptions } from './Toaster.js';

--- a/packages/ui/Track/index.ts
+++ b/packages/ui/Track/index.ts
@@ -1,3 +1,3 @@
-export * from './Track.js';
-export * from './TrackShopify.js';
-export * from './TrackContext.js';
+export { Track, type TrackProps } from './Track.js';
+export { TrackShopify, type TrackShopifyProps } from './TrackShopify.js';
+export { TrackContext, type TrackContextProps } from './TrackContext.js';

--- a/packages/ui/Transition/index.ts
+++ b/packages/ui/Transition/index.ts
@@ -1,1 +1,1 @@
-export * from './Transition.js';
+export { Transition, type TransitionConstructor } from './Transition.js';

--- a/packages/ui/ViewTransition/index.ts
+++ b/packages/ui/ViewTransition/index.ts
@@ -1,2 +1,2 @@
-export * from './ViewTransition.js';
-export * from './scheduler.js';
+export { ViewTransition, type ViewTransitionProps } from './ViewTransition.js';
+export { viewTransition } from './scheduler.js';

--- a/packages/ui/decorators/index.ts
+++ b/packages/ui/decorators/index.ts
@@ -1,3 +1,17 @@
-export * from './withTransition.js';
-export * from './withDeprecation.js';
-export * from './withIndex.js';
+export {
+  withTransition,
+  type TransitionInterface,
+  type TransitionProps,
+} from './withTransition.js';
+export {
+  withDeprecation,
+  type DeprecationInterface,
+  type DeprecationProps,
+} from './withDeprecation.js';
+export {
+  withIndex,
+  type IndexableBoundary,
+  type IndexableInstructions,
+  type IndexableInterface,
+  type IndexableProps,
+} from './withIndex.js';

--- a/packages/ui/index.ts
+++ b/packages/ui/index.ts
@@ -1,37 +1,195 @@
-export * from './Accordion/index.js';
-export * from './Action/index.js';
-export * from './AnchorNav/index.js';
-export * from './AnchorScrollTo/index.js';
-export * from './Carousel/index.js';
-export * from './CircularMarquee/index.js';
-export * from './ClickOutside/index.js';
-export * from './Cursor/index.js';
-export * from './Data/index.js';
-export * from './decorators/index.js';
-export * from './Dialog/index.js';
-export * from './Disclosure/index.js';
-export * from './Draggable/index.js';
-export * from './Fetch/index.js';
-export * from './Figure/index.js';
-export * from './FigureVideo/index.js';
-export * from './Frame/index.js';
-export * from './Hoverable/index.js';
-export * from './Indexable/index.js';
-export * from './InView/index.js';
-export * from './LargeText/index.js';
-export * from './LazyInclude/index.js';
-export * from './Menu/index.js';
-export * from './Modal/index.js';
-export * from './Panel/index.js';
-export * from './Prefetch/index.js';
-export * from './ScrollAnimation/index.js';
-export * from './ScrollReveal/index.js';
-export * from './Sentinel/index.js';
-export * from './Slider/index.js';
-export * from './Sticky/index.js';
-export * from './Tabs/index.js';
-export * from './Timer/index.js';
-export * from './Toaster/index.js';
-export * from './Track/index.js';
-export * from './Transition/index.js';
-export * from './ViewTransition/index.js';
+export { Accordion, AccordionItem, type AccordionItemProps } from './Accordion/index.js';
+export { Action, Target, type ActionProps, type TargetProps } from './Action/index.js';
+export {
+  AnchorNav,
+  AnchorNavLink,
+  AnchorNavTarget,
+  type AnchorNavLinkProps,
+  type AnchorNavProps,
+} from './AnchorNav/index.js';
+export { AnchorScrollTo, type AnchorScrollToProps } from './AnchorScrollTo/index.js';
+export {
+  AbstractCarouselChild,
+  AbstractCarouselComponent,
+  Carousel,
+  CarouselBtn,
+  CarouselDrag,
+  CarouselItem,
+  CarouselWrapper,
+  type AbstractCarouselChildProps,
+  type AbstractCarouselComponentProps,
+  type CarouselBtnProps,
+  type CarouselDragProps,
+  type CarouselItemProps,
+  type CarouselProps,
+  type CarouselStore,
+  type CarouselWrapperProps,
+} from './Carousel/index.js';
+export { CircularMarquee, type CircularMarqueeProps } from './CircularMarquee/index.js';
+export { ClickOutside, type ClickOutsideProps } from './ClickOutside/index.js';
+export { Cursor, type CursorProps } from './Cursor/index.js';
+export {
+  DataBind,
+  DataComputed,
+  DataEffect,
+  DataModel,
+  DataScope,
+  type DataBindProps,
+  type DataComputedProps,
+  type DataEffectProps,
+  type DataModelProps,
+  type DataScopeProps,
+  type DataValue,
+} from './Data/index.js';
+export {
+  withDeprecation,
+  withIndex,
+  withTransition,
+  type DeprecationInterface,
+  type DeprecationProps,
+  type IndexableBoundary,
+  type IndexableInstructions,
+  type IndexableInterface,
+  type IndexableProps,
+  type TransitionInterface,
+  type TransitionProps,
+} from './decorators/index.js';
+export { Dialog, type DialogProps } from './Dialog/index.js';
+export {
+  Disclosure,
+  DisclosureGroup,
+  type DisclosureGroupProps,
+  type DisclosureProps,
+} from './Disclosure/index.js';
+export { Draggable, type DraggableProps } from './Draggable/index.js';
+export {
+  Fetch,
+  FetchShopifyPartial,
+  FetchShopifySection,
+  type FetchConstructor,
+  type FetchProps,
+  type FetchShopifyPartialConstructor,
+  type FetchShopifyPartialProps,
+  type FetchShopifySectionConstructor,
+  type FetchShopifySectionProps,
+} from './Fetch/index.js';
+export {
+  Figure,
+  FigureShopify,
+  FigureTwicpics,
+  type FigureProps,
+  type FigureShopifyProps,
+  type FigureTwicpicsProps,
+} from './Figure/index.js';
+export {
+  FigureVideo,
+  FigureVideoTwicpics,
+  type FigureVideoProps,
+  type FigureVideoTwicpicsProps,
+} from './FigureVideo/index.js';
+export {
+  AbstractFrameTrigger,
+  Frame,
+  FrameAnchor,
+  FrameForm,
+  FrameLoader,
+  FrameTarget,
+  FrameTriggerLoader,
+  type AbstractFrameTriggerProps,
+  type FrameAnchorProps,
+  type FrameContentAfterEvent,
+  type FrameContentEvent,
+  type FrameErrorEvent,
+  type FrameFetchAfterEvent,
+  type FrameFetchBeforeEvent,
+  type FrameFetchEvent,
+  type FrameFormProps,
+  type FrameLoaderProps,
+  type FrameProps,
+  type FrameRequestInit,
+  type FrameTargetProps,
+  type FrameTriggerEvent,
+  type FrameTriggerLoaderProps,
+} from './Frame/index.js';
+export { Hoverable, type HoverableProps } from './Hoverable/index.js';
+export { Indexable } from './Indexable/index.js';
+export { InView, InViewOnce } from './InView/index.js';
+export { LargeText, type LargeTextProps } from './LargeText/index.js';
+export { LazyInclude, type LazyIncludeProps } from './LazyInclude/index.js';
+export { Menu, MenuBtn, MenuList, type MenuListProps, type MenuProps } from './Menu/index.js';
+export { Modal, ModalWithTransition, type ModalProps } from './Modal/index.js';
+export { Panel, type PanelProps } from './Panel/index.js';
+export {
+  AbstractPrefetch,
+  PrefetchWhenOver,
+  PrefetchWhenVisible,
+  type AbstractPrefetchProps,
+} from './Prefetch/index.js';
+export {
+  AbstractScrollAnimation,
+  animationScrollWithEase,
+  ScrollAnimation,
+  ScrollAnimationChild,
+  ScrollAnimationChildWithEase,
+  ScrollAnimationParent,
+  ScrollAnimationTarget,
+  ScrollAnimationTimeline,
+  ScrollAnimationWithEase,
+  withScrollAnimationDebug,
+  type AbstractScrollAnimationProps,
+  type AnimationScrollWithEaseInterface,
+  type AnimationScrollWithEaseProps,
+  type ScrollAnimationChildProps,
+  type ScrollAnimationParentProps,
+  type ScrollAnimationProps,
+  type ScrollAnimationTargetProps,
+  type ScrollAnimationTimelineProps,
+  type WithScrollAnimationDebugInterface,
+  type WithScrollAnimationDebugProps,
+} from './ScrollAnimation/index.js';
+export { ScrollReveal, type ScrollRevealProps } from './ScrollReveal/index.js';
+export { Sentinel } from './Sentinel/index.js';
+export {
+  AbstractSliderChild,
+  Slider,
+  SliderBtn,
+  SliderCount,
+  SliderDots,
+  SliderDrag,
+  SliderItem,
+  SliderProgress,
+  type AbstractSliderChildProps,
+  type SliderBtnProps,
+  type SliderCountProps,
+  type SliderDotsProps,
+  type SliderDragProps,
+  type SliderItemProps,
+  type SliderModes,
+  type SliderProgressProps,
+  type SliderProps,
+  type SliderStore,
+} from './Slider/index.js';
+export { Sticky, type StickyProps } from './Sticky/index.js';
+export { Tabs, type TabsProps } from './Tabs/index.js';
+export { Timer, TimerProgress, type TimerProps } from './Timer/index.js';
+export {
+  Toast,
+  Toaster,
+  type ToasterProps,
+  type ToasterShowOptions,
+  type ToastProps,
+} from './Toaster/index.js';
+export {
+  Track,
+  TrackContext,
+  TrackShopify,
+  type TrackContextProps,
+  type TrackProps,
+  type TrackShopifyProps,
+} from './Track/index.js';
+export { Transition, type TransitionConstructor } from './Transition/index.js';
+export {
+  viewTransition,
+  ViewTransition,
+  type ViewTransitionProps,
+} from './ViewTransition/index.js';


### PR DESCRIPTION
## What

Convert every `export *` re-export in the `@studiometa/ui` and `@studiometa/ui-mapbox` barrels to explicit named `export { ... }` statements, with type-only members carrying the `type` specifier modifier. This mirrors the change made in [`@studiometa/js-toolkit` 3.8.1](https://github.com/studiometa/js-toolkit).

## Why

`export *` from a module that is later externalised (e.g. by esm.sh) drops the static export names — the re-export becomes a runtime `__reExport`, and any bundler that statically analyses the barrel can no longer see the individual names. That is the root cause of the earlier esm.sh `doesn't provide an export named …` failures. Explicit named exports keep the public surface statically analyzable, so bundlers and esm.sh keep every export name and tree-shake reliably.

## TDD / regression net

The first commit adds `packages/tests/barrel-exports/barrel-exports.spec.ts`, which snapshots the **full** public export surface of each package barrel — values **and** type-only exports — via the TypeScript type checker. A runtime `Object.keys` snapshot (the existing `index.spec.ts`) only covers value exports; type-only exports are erased at runtime, so they are enumerated statically instead.

The snapshot is byte-identical before and after the migration, proving the exported API (including every `type`) is unchanged: no name dropped, no value silently flipped to a type-only export.

## Scope

- 143 `export *` statements rewritten across 38 barrel files (127 in `ui`, 16 in `ui-mapbox`).
- `@studiometa/ui-autoload` already used explicit named exports — untouched.
- Output formatted with the repo Prettier config; no runtime or type change.

## Verification

- `npm run test` — 839 passing (incl. the 3 new barrel-surface snapshots).
- `npm run lint` — 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)