### PR TITLE
Prepare 1.10.0-beta.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [v1.10.0-beta.4](https://github.com/studiometa/ui/compare/1.10.0-beta.3..1.10.0-beta.4) (2026-08-06)
+
+### Added
+
+- **@studiometa/ui-autoload:** add helpers to build and register a custom component manifest, so an application can autoload its own js-toolkit components alongside the packaged ones. `defineManifest({ modules, … })` turns a record of lazy importers into a manifest (it derives each `data-component` token from the module path and resolves the matching export), `fromMetaGlob()` and `fromWebpackContext()` adapt a Vite `import.meta.glob` or a webpack `import.meta.webpackContext` into that record, and `registerManifests(…)` registers several manifests at once with the shared runtime (the last manifest wins on token collisions). The informational `packageName`, `subpath`, `exportName` and `group` fields of a manifest entry are now optional ([#614](https://github.com/studiometa/ui/pull/614))
+
 ### Changed
 
 - **@studiometa/ui, @studiometa/ui-mapbox:** replace every `export *` barrel re-export with explicit named `export { ... }` (values and `type`-only specifiers) so the public surface is statically analyzable. This lets bundlers and esm.sh keep every export name and tree-shake reliably, matching the same change made in `@studiometa/js-toolkit` 3.8.1. The exported API is unchanged — a type-checker snapshot of each barrel's full surface guards against regressions ([#611](https://github.com/studiometa/ui/pull/611))

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "studiometa/ui",
   "type": "composer-plugin",
-  "version": "1.10.0-beta.3",
+  "version": "1.10.0-beta.4",
   "description": "Accessible and composable JavaScript behaviors and Twig templates.",
   "license": "MIT",
   "require": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@studiometa/ui-workspace",
-  "version": "1.10.0-beta.3",
+  "version": "1.10.0-beta.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@studiometa/ui-workspace",
-      "version": "1.10.0-beta.3",
+      "version": "1.10.0-beta.4",
       "hasInstallScript": true,
       "workspaces": [
         "packages/*"
@@ -21872,11 +21872,11 @@
     },
     "packages/api": {
       "name": "@studiometa/ui-api",
-      "version": "1.10.0-beta.3"
+      "version": "1.10.0-beta.4"
     },
     "packages/docs": {
       "name": "@studiometa/ui-docs",
-      "version": "1.10.0-beta.3",
+      "version": "1.10.0-beta.4",
       "dependencies": {
         "@studiometa/js-toolkit": "3.8.0"
       },
@@ -21897,7 +21897,7 @@
     },
     "packages/eslint-plugin-ui": {
       "name": "@studiometa/eslint-plugin-ui",
-      "version": "1.10.0-beta.3",
+      "version": "1.10.0-beta.4",
       "license": "MIT",
       "dependencies": {
         "@oxlint/plugins": "1.63.0"
@@ -21926,7 +21926,7 @@
     },
     "packages/playground": {
       "name": "@studiometa/ui-playground",
-      "version": "1.10.0-beta.3",
+      "version": "1.10.0-beta.4",
       "dependencies": {
         "@studiometa/playground": "^0.3.13"
       },
@@ -22003,7 +22003,7 @@
     },
     "packages/tests": {
       "name": "@studiometa/ui-tests",
-      "version": "1.10.0-beta.3",
+      "version": "1.10.0-beta.4",
       "license": "MIT",
       "dependencies": {
         "@happy-dom/global-registrator": "^20.8.8",
@@ -22258,7 +22258,7 @@
     },
     "packages/ui": {
       "name": "@studiometa/ui",
-      "version": "1.10.0-beta.3",
+      "version": "1.10.0-beta.4",
       "license": "MIT",
       "dependencies": {
         "alien-signals": "^3.2.1",
@@ -22286,7 +22286,7 @@
     },
     "packages/ui-autoload": {
       "name": "@studiometa/ui-autoload",
-      "version": "1.10.0-beta.3",
+      "version": "1.10.0-beta.4",
       "license": "MIT",
       "devDependencies": {
         "@studiometa/js-toolkit": "^3.8.0",
@@ -22308,7 +22308,7 @@
     },
     "packages/ui-mapbox": {
       "name": "@studiometa/ui-mapbox",
-      "version": "1.10.0-beta.3",
+      "version": "1.10.0-beta.4",
       "license": "MIT",
       "devDependencies": {
         "@mapbox/mapbox-gl-geocoder": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-workspace",
-  "version": "1.10.0-beta.3",
+  "version": "1.10.0-beta.4",
   "type": "module",
   "private": true,
   "workspaces": [

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-api",
-  "version": "1.10.0-beta.3",
+  "version": "1.10.0-beta.4",
   "private": true,
   "type": "commonjs"
 }

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-docs",
-  "version": "1.10.0-beta.3",
+  "version": "1.10.0-beta.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/eslint-plugin-ui/package.json
+++ b/packages/eslint-plugin-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/eslint-plugin-ui",
-  "version": "1.10.0-beta.3",
+  "version": "1.10.0-beta.4",
   "description": "ESLint plugin to help developers discover and use @studiometa/ui components",
   "publishConfig": {
     "access": "public"

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-playground",
-  "version": "1.10.0-beta.3",
+  "version": "1.10.0-beta.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-tests",
-  "version": "1.10.0-beta.3",
+  "version": "1.10.0-beta.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/ui-autoload/package.json
+++ b/packages/ui-autoload/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-autoload",
-  "version": "1.10.0-beta.3",
+  "version": "1.10.0-beta.4",
   "description": "Generic, side-effect-free declarative autoloader for @studiometa/ui component manifests",
   "publishConfig": {
     "access": "public"
@@ -46,8 +46,8 @@
   "homepage": "https://github.com/studiometa/ui#readme",
   "peerDependencies": {
     "@studiometa/js-toolkit": "^3.8.0",
-    "@studiometa/ui": "1.10.0-beta.3",
-    "@studiometa/ui-mapbox": "1.10.0-beta.3"
+    "@studiometa/ui": "1.10.0-beta.4",
+    "@studiometa/ui-mapbox": "1.10.0-beta.4"
   },
   "peerDependenciesMeta": {
     "@studiometa/ui": {

--- a/packages/ui-mapbox/package.json
+++ b/packages/ui-mapbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-mapbox",
-  "version": "1.10.0-beta.3",
+  "version": "1.10.0-beta.4",
   "description": "Vanilla js-toolkit components to build Mapbox GL maps declaratively",
   "publishConfig": {
     "access": "public"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui",
-  "version": "1.10.0-beta.3",
+  "version": "1.10.0-beta.4",
   "description": "Accessible and composable JavaScript behaviors and templates",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Prepare the `1.10.0-beta.4` prerelease.

- Bump every package to `1.10.0-beta.4` (root, all workspaces, `composer.json`, and the `@studiometa/ui-autoload` lockstep peers) via `npm version`.
- Add the `CHANGELOG.md` entry for the release, headlined by the custom component manifest helpers ([#614](https://github.com/studiometa/ui/pull/614)).

Merge, then tag `1.10.0-beta.4` and push the tag to trigger the `release` workflow (publishes to npm under the `next` tag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HKLcgvaDcjK9ohA3fg7Ssq