### PR TITLE
Prepare 1.10.0-beta.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "studiometa/ui",
   "type": "composer-plugin",
-  "version": "1.10.0-beta.4",
+  "version": "1.10.0-beta.5",
   "description": "Accessible and composable JavaScript behaviors and Twig templates.",
   "license": "MIT",
   "require": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@studiometa/ui-workspace",
-  "version": "1.10.0-beta.4",
+  "version": "1.10.0-beta.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@studiometa/ui-workspace",
-      "version": "1.10.0-beta.4",
+      "version": "1.10.0-beta.5",
       "hasInstallScript": true,
       "workspaces": [
         "packages/*"
@@ -21868,11 +21868,11 @@
     },
     "packages/api": {
       "name": "@studiometa/ui-api",
-      "version": "1.10.0-beta.4"
+      "version": "1.10.0-beta.5"
     },
     "packages/docs": {
       "name": "@studiometa/ui-docs",
-      "version": "1.10.0-beta.4",
+      "version": "1.10.0-beta.5",
       "dependencies": {
         "@studiometa/js-toolkit": "3.8.0"
       },
@@ -21893,7 +21893,7 @@
     },
     "packages/eslint-plugin-ui": {
       "name": "@studiometa/eslint-plugin-ui",
-      "version": "1.10.0-beta.4",
+      "version": "1.10.0-beta.5",
       "license": "MIT",
       "dependencies": {
         "@oxlint/plugins": "1.63.0"
@@ -21922,7 +21922,7 @@
     },
     "packages/playground": {
       "name": "@studiometa/ui-playground",
-      "version": "1.10.0-beta.4",
+      "version": "1.10.0-beta.5",
       "dependencies": {
         "@studiometa/playground": "^0.3.13"
       },
@@ -21989,7 +21989,7 @@
     },
     "packages/tests": {
       "name": "@studiometa/ui-tests",
-      "version": "1.10.0-beta.4",
+      "version": "1.10.0-beta.5",
       "license": "MIT",
       "dependencies": {
         "@happy-dom/global-registrator": "^20.8.8",
@@ -22243,7 +22243,7 @@
     },
     "packages/ui": {
       "name": "@studiometa/ui",
-      "version": "1.10.0-beta.4",
+      "version": "1.10.0-beta.5",
       "license": "MIT",
       "dependencies": {
         "alien-signals": "^3.2.1",
@@ -22266,7 +22266,7 @@
     },
     "packages/ui-mapbox": {
       "name": "@studiometa/ui-mapbox",
-      "version": "1.10.0-beta.4",
+      "version": "1.10.0-beta.5",
       "license": "MIT",
       "devDependencies": {
         "@mapbox/mapbox-gl-geocoder": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-workspace",
-  "version": "1.10.0-beta.4",
+  "version": "1.10.0-beta.5",
   "type": "module",
   "private": true,
   "workspaces": [

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-api",
-  "version": "1.10.0-beta.4",
+  "version": "1.10.0-beta.5",
   "private": true,
   "type": "commonjs"
 }

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-docs",
-  "version": "1.10.0-beta.4",
+  "version": "1.10.0-beta.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/eslint-plugin-ui/package.json
+++ b/packages/eslint-plugin-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/eslint-plugin-ui",
-  "version": "1.10.0-beta.4",
+  "version": "1.10.0-beta.5",
   "description": "ESLint plugin to help developers discover and use @studiometa/ui components",
   "publishConfig": {
     "access": "public"

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-playground",
-  "version": "1.10.0-beta.4",
+  "version": "1.10.0-beta.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-tests",
-  "version": "1.10.0-beta.4",
+  "version": "1.10.0-beta.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/ui-mapbox/package.json
+++ b/packages/ui-mapbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-mapbox",
-  "version": "1.10.0-beta.4",
+  "version": "1.10.0-beta.5",
   "description": "Vanilla js-toolkit components to build Mapbox GL maps declaratively",
   "publishConfig": {
     "access": "public"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui",
-  "version": "1.10.0-beta.4",
+  "version": "1.10.0-beta.5",
   "description": "Accessible and composable JavaScript behaviors and templates",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Bump the workspace to `1.10.0-beta.5` (root, all packages, `composer.json`, and the lockfile) ahead of tagging the release.

The `1.10.0-beta.5` changelog entry landed with the autoload cleanup in #617.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HKLcgvaDcjK9ohA3fg7Ssq