### PR TITLE
Import js-toolkit symbols from dedicated subpaths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Changed
+
+- **@studiometa/ui, @studiometa/ui-mapbox:** import js-toolkit values from their per-symbol subpaths instead of the package barrel, shrinking every component's esm.sh footprint ([#619](https://github.com/studiometa/ui/pull/619))
+
 ## [v1.10.0-beta.5](https://github.com/studiometa/ui/compare/1.10.0-beta.4..1.10.0-beta.5) (2026-08-06)
 
 ### Changed

--- a/packages/ui-mapbox/AbstractMapboxMapChild.ts
+++ b/packages/ui-mapbox/AbstractMapboxMapChild.ts
@@ -1,4 +1,5 @@
-import { Base, type BaseConfig, type BaseProps } from '@studiometa/js-toolkit';
+import { Base } from '@studiometa/js-toolkit/Base';
+import type { BaseConfig, BaseProps } from '@studiometa/js-toolkit';
 import type { Map } from 'mapbox-gl';
 import type { MapboxMap } from './MapboxMap.js';
 

--- a/packages/ui-mapbox/MapboxCluster.ts
+++ b/packages/ui-mapbox/MapboxCluster.ts
@@ -1,5 +1,5 @@
 import { type BaseProps, type BaseConfig } from '@studiometa/js-toolkit';
-import { debounce } from '@studiometa/js-toolkit/utils';
+import { debounce } from '@studiometa/js-toolkit/utils/debounce';
 import type {
   Map,
   CircleLayerSpecification,

--- a/packages/ui-mapbox/MapboxClusterItem.ts
+++ b/packages/ui-mapbox/MapboxClusterItem.ts
@@ -1,4 +1,5 @@
-import { Base, type BaseProps, type BaseConfig } from '@studiometa/js-toolkit';
+import { Base } from '@studiometa/js-toolkit/Base';
+import type { BaseProps, BaseConfig } from '@studiometa/js-toolkit';
 import { MAPBOX_CLUSTER_CONNECTED, type MapboxCluster } from './MapboxCluster.js';
 
 export interface MapboxClusterItemProps extends BaseProps {

--- a/packages/ui-mapbox/MapboxFullscreenControl.ts
+++ b/packages/ui-mapbox/MapboxFullscreenControl.ts
@@ -1,4 +1,4 @@
-import { withExtraConfig } from '@studiometa/js-toolkit';
+import { withExtraConfig } from '@studiometa/js-toolkit/withExtraConfig';
 import type { FullscreenControlOptions } from 'mapbox-gl';
 import {
   AbstractMapboxControl,

--- a/packages/ui-mapbox/MapboxGeolocateControl.ts
+++ b/packages/ui-mapbox/MapboxGeolocateControl.ts
@@ -1,4 +1,4 @@
-import { withExtraConfig } from '@studiometa/js-toolkit';
+import { withExtraConfig } from '@studiometa/js-toolkit/withExtraConfig';
 import type { GeolocateControlOptions } from 'mapbox-gl';
 import {
   AbstractMapboxControl,

--- a/packages/ui-mapbox/MapboxMap.ts
+++ b/packages/ui-mapbox/MapboxMap.ts
@@ -1,4 +1,5 @@
-import { Base, type BaseConfig, type BaseProps } from '@studiometa/js-toolkit';
+import { Base } from '@studiometa/js-toolkit/Base';
+import type { BaseConfig, BaseProps } from '@studiometa/js-toolkit';
 import type { Map, MapOptions } from 'mapbox-gl';
 import { resolveMapboxGl } from './dependencies.js';
 import { MAPBOX_MAP_CONNECTED } from './AbstractMapboxMapChild.js';

--- a/packages/ui-mapbox/MapboxNavigationControl.ts
+++ b/packages/ui-mapbox/MapboxNavigationControl.ts
@@ -1,4 +1,4 @@
-import { withExtraConfig } from '@studiometa/js-toolkit';
+import { withExtraConfig } from '@studiometa/js-toolkit/withExtraConfig';
 import type { NavigationControlOptions } from 'mapbox-gl';
 import {
   AbstractMapboxControl,

--- a/packages/ui-mapbox/StoreLocator.ts
+++ b/packages/ui-mapbox/StoreLocator.ts
@@ -1,5 +1,6 @@
-import { Base, type BaseProps, type BaseConfig } from '@studiometa/js-toolkit';
-import { nextTick } from '@studiometa/js-toolkit/utils';
+import { Base } from '@studiometa/js-toolkit/Base';
+import type { BaseProps, BaseConfig } from '@studiometa/js-toolkit';
+import { nextTick } from '@studiometa/js-toolkit/utils/nextTick';
 import type { Map, LngLatLike, LngLatBoundsLike, Popup } from 'mapbox-gl';
 import { getMapboxGl } from './dependencies.js';
 import { MapboxMap } from './MapboxMap.js';

--- a/packages/ui-mapbox/autoload.ts
+++ b/packages/ui-mapbox/autoload.ts
@@ -1,4 +1,4 @@
-import { registerManifest } from '@studiometa/js-toolkit';
+import { registerManifest } from '@studiometa/js-toolkit/registerManifest';
 import { manifest } from './manifest.js';
 
 // Side-effect entry: importing this module registers the `@studiometa/ui-mapbox` manifest with the

--- a/packages/ui/Accordion/AccordionCore.ts
+++ b/packages/ui/Accordion/AccordionCore.ts
@@ -1,4 +1,4 @@
-import { Base } from '@studiometa/js-toolkit';
+import { Base } from '@studiometa/js-toolkit/Base';
 import type { BaseConfig, BaseProps } from '@studiometa/js-toolkit';
 import type { AccordionItem, AccordionItemProps } from './AccordionItem';
 

--- a/packages/ui/Accordion/AccordionItem.ts
+++ b/packages/ui/Accordion/AccordionItem.ts
@@ -1,7 +1,8 @@
 import deepmerge from 'deepmerge';
-import { Base, BaseConfig } from '@studiometa/js-toolkit';
+import { Base } from '@studiometa/js-toolkit/Base';
+import type { BaseConfig } from '@studiometa/js-toolkit';
 import type { BaseProps } from '@studiometa/js-toolkit';
-import { transition } from '@studiometa/js-toolkit/utils';
+import { transition } from '@studiometa/js-toolkit/utils/transition';
 import type { AccordionCore as Accordion } from './AccordionCore.js';
 
 type AccordionItemStates = Partial<

--- a/packages/ui/Action/Action.ts
+++ b/packages/ui/Action/Action.ts
@@ -1,4 +1,4 @@
-import { Base } from '@studiometa/js-toolkit';
+import { Base } from '@studiometa/js-toolkit/Base';
 import type { BaseProps, BaseConfig } from '@studiometa/js-toolkit';
 import { ActionEvent } from './ActionEvent.js';
 

--- a/packages/ui/Action/ActionEvent.ts
+++ b/packages/ui/Action/ActionEvent.ts
@@ -1,6 +1,6 @@
-import { getInstances } from '@studiometa/js-toolkit';
+import { getInstances } from '@studiometa/js-toolkit/getInstances';
 import type { Base } from '@studiometa/js-toolkit';
-import { isFunction } from '@studiometa/js-toolkit/utils';
+import { isFunction } from '@studiometa/js-toolkit/utils/isFunction';
 
 /**
  * Extract component name and an optional additional selector from a string.

--- a/packages/ui/Action/Target.ts
+++ b/packages/ui/Action/Target.ts
@@ -1,4 +1,4 @@
-import { Base } from '@studiometa/js-toolkit';
+import { Base } from '@studiometa/js-toolkit/Base';
 import type { BaseConfig, BaseProps } from '@studiometa/js-toolkit';
 
 export interface TargetProps extends BaseProps {}

--- a/packages/ui/AnchorNav/AnchorNav.ts
+++ b/packages/ui/AnchorNav/AnchorNav.ts
@@ -1,4 +1,4 @@
-import { Base } from '@studiometa/js-toolkit';
+import { Base } from '@studiometa/js-toolkit/Base';
 import type { BaseProps, BaseConfig } from '@studiometa/js-toolkit';
 import { AnchorNavLink } from './AnchorNavLink.js';
 import { AnchorNavTarget } from './AnchorNavTarget.js';

--- a/packages/ui/AnchorNav/AnchorNavTarget.ts
+++ b/packages/ui/AnchorNav/AnchorNavTarget.ts
@@ -1,4 +1,5 @@
-import { Base, withMountWhenInView } from '@studiometa/js-toolkit';
+import { Base } from '@studiometa/js-toolkit/Base';
+import { withMountWhenInView } from '@studiometa/js-toolkit/withMountWhenInView';
 import type { BaseProps, BaseConfig } from '@studiometa/js-toolkit';
 
 /**

--- a/packages/ui/AnchorScrollTo/AnchorScrollTo.ts
+++ b/packages/ui/AnchorScrollTo/AnchorScrollTo.ts
@@ -1,6 +1,6 @@
-import { Base } from '@studiometa/js-toolkit';
+import { Base } from '@studiometa/js-toolkit/Base';
 import type { BaseProps, BaseConfig } from '@studiometa/js-toolkit';
-import { scrollTo } from '@studiometa/js-toolkit/utils';
+import { scrollTo } from '@studiometa/js-toolkit/utils/scrollTo';
 
 export interface AnchorScrollToProps extends BaseProps {
   $el: HTMLAnchorElement;

--- a/packages/ui/Carousel/AbstractCarouselChild.ts
+++ b/packages/ui/Carousel/AbstractCarouselChild.ts
@@ -1,5 +1,7 @@
 import type { BaseConfig, BaseProps } from '@studiometa/js-toolkit';
-import { nextFrame, domScheduler, isFunction } from '@studiometa/js-toolkit/utils';
+import { nextFrame } from '@studiometa/js-toolkit/utils/nextFrame';
+import { domScheduler } from '@studiometa/js-toolkit/utils/domScheduler';
+import { isFunction } from '@studiometa/js-toolkit/utils/isFunction';
 import { AbstractCarouselComponent } from './AbstractCarouselComponent.js';
 import type { Carousel } from './Carousel.js';
 

--- a/packages/ui/Carousel/AbstractCarouselComponent.ts
+++ b/packages/ui/Carousel/AbstractCarouselComponent.ts
@@ -1,4 +1,4 @@
-import { Base } from '@studiometa/js-toolkit';
+import { Base } from '@studiometa/js-toolkit/Base';
 import type { BaseConfig, BaseProps } from '@studiometa/js-toolkit';
 import type { Carousel } from './Carousel.js';
 

--- a/packages/ui/Carousel/Carousel.ts
+++ b/packages/ui/Carousel/Carousel.ts
@@ -1,10 +1,8 @@
 import type { Base, BaseConfig } from '@studiometa/js-toolkit';
-import {
-  createMemoryStorageProvider,
-  createStorage,
-  isNumber,
-  nextFrame,
-} from '@studiometa/js-toolkit/utils';
+import { createMemoryStorageProvider } from '@studiometa/js-toolkit/utils/createMemoryStorageProvider';
+import { createStorage } from '@studiometa/js-toolkit/utils/createStorage';
+import { isNumber } from '@studiometa/js-toolkit/utils/isNumber';
+import { nextFrame } from '@studiometa/js-toolkit/utils/nextFrame';
 import type { IndexableInstructions, IndexableProps } from '../decorators/index.js';
 import { Indexable } from '../Indexable/index.js';
 import { AbstractCarouselChild } from './AbstractCarouselChild.js';

--- a/packages/ui/Carousel/CarouselDrag.ts
+++ b/packages/ui/Carousel/CarouselDrag.ts
@@ -1,6 +1,7 @@
 import type { BaseConfig, BaseProps, DragServiceProps } from '@studiometa/js-toolkit';
-import { withDrag, withMountOnMediaQuery } from '@studiometa/js-toolkit';
-import { inertiaFinalValue } from '@studiometa/js-toolkit/utils';
+import { withDrag } from '@studiometa/js-toolkit/withDrag';
+import { withMountOnMediaQuery } from '@studiometa/js-toolkit/withMountOnMediaQuery';
+import { inertiaFinalValue } from '@studiometa/js-toolkit/utils/inertiaFinalValue';
 import { AbstractCarouselComponent } from './AbstractCarouselComponent.js';
 import { getClosestIndex } from './utils.js';
 

--- a/packages/ui/Carousel/CarouselWrapper.ts
+++ b/packages/ui/Carousel/CarouselWrapper.ts
@@ -1,5 +1,5 @@
 import type { BaseConfig, BaseProps } from '@studiometa/js-toolkit';
-import { clamp } from '@studiometa/js-toolkit/utils';
+import { clamp } from '@studiometa/js-toolkit/utils/clamp';
 import { AbstractCarouselComponent } from './AbstractCarouselComponent.js';
 import { getClosestIndex } from './utils.js';
 

--- a/packages/ui/CircularMarquee/CircularMarquee.ts
+++ b/packages/ui/CircularMarquee/CircularMarquee.ts
@@ -1,5 +1,7 @@
-import { Base, BaseConfig, BaseProps } from '@studiometa/js-toolkit';
-import { damp, transform } from '@studiometa/js-toolkit/utils';
+import { Base } from '@studiometa/js-toolkit/Base';
+import type { BaseConfig, BaseProps } from '@studiometa/js-toolkit';
+import { damp } from '@studiometa/js-toolkit/utils/damp';
+import { transform } from '@studiometa/js-toolkit/utils/transform';
 
 export interface CircularMarqueeProps extends BaseProps {
   $options: {

--- a/packages/ui/ClickOutside/ClickOutside.ts
+++ b/packages/ui/ClickOutside/ClickOutside.ts
@@ -1,4 +1,4 @@
-import { Base } from '@studiometa/js-toolkit';
+import { Base } from '@studiometa/js-toolkit/Base';
 import type { BaseConfig, BaseProps, BaseEventHookParams } from '@studiometa/js-toolkit';
 
 export interface ClickOutsideProps extends BaseProps {}

--- a/packages/ui/Cursor/Cursor.ts
+++ b/packages/ui/Cursor/Cursor.ts
@@ -1,6 +1,7 @@
-import { Base } from '@studiometa/js-toolkit';
+import { Base } from '@studiometa/js-toolkit/Base';
 import type { BaseConfig, PointerServiceProps, BaseProps } from '@studiometa/js-toolkit';
-import { damp, matrix } from '@studiometa/js-toolkit/utils';
+import { damp } from '@studiometa/js-toolkit/utils/damp';
+import { matrix } from '@studiometa/js-toolkit/utils/matrix';
 
 export interface CursorProps extends BaseProps {
   $options: {

--- a/packages/ui/Data/DataBind.ts
+++ b/packages/ui/Data/DataBind.ts
@@ -1,6 +1,7 @@
-import { Base, withGroup } from '@studiometa/js-toolkit';
+import { Base } from '@studiometa/js-toolkit/Base';
+import { withGroup } from '@studiometa/js-toolkit/withGroup';
 import type { BaseConfig, BaseProps } from '@studiometa/js-toolkit';
-import { nextTick } from '@studiometa/js-toolkit/utils';
+import { nextTick } from '@studiometa/js-toolkit/utils/nextTick';
 import { getDataChannel } from './DataChannel.js';
 import { DataScope, getDataScope, DATA_GROUP_NAMESPACE } from './DataScope.js';
 import type { DataScopeMember, DataValue } from './DataScope.js';

--- a/packages/ui/Data/DataScope.ts
+++ b/packages/ui/Data/DataScope.ts
@@ -1,6 +1,7 @@
-import { Base, getScopedGroups } from '@studiometa/js-toolkit';
+import { Base } from '@studiometa/js-toolkit/Base';
+import { getScopedGroups } from '@studiometa/js-toolkit/getScopedGroups';
 import type { BaseConfig, BaseProps } from '@studiometa/js-toolkit';
-import { nextTick } from '@studiometa/js-toolkit/utils';
+import { nextTick } from '@studiometa/js-toolkit/utils/nextTick';
 import { DataChannel } from './DataChannel.js';
 
 export const DATA_GROUP_NAMESPACE = 'data:';

--- a/packages/ui/Data/formControl.ts
+++ b/packages/ui/Data/formControl.ts
@@ -1,4 +1,4 @@
-import { camelCase } from '@studiometa/js-toolkit/utils';
+import { camelCase } from '@studiometa/js-toolkit/utils/camelCase';
 import type { DataValue } from './DataScope.js';
 
 export interface DataControlMember {

--- a/packages/ui/Dialog/Dialog.ts
+++ b/packages/ui/Dialog/Dialog.ts
@@ -1,6 +1,8 @@
-import { Base } from '@studiometa/js-toolkit';
+import { Base } from '@studiometa/js-toolkit/Base';
 import type { BaseProps, BaseConfig, KeyServiceProps } from '@studiometa/js-toolkit';
-import { trapFocus, untrapFocus, saveActiveElement } from '@studiometa/js-toolkit/utils';
+import { trapFocus } from '@studiometa/js-toolkit/utils/trapFocus';
+import { untrapFocus } from '@studiometa/js-toolkit/utils/untrapFocus';
+import { saveActiveElement } from '@studiometa/js-toolkit/utils/saveActiveElement';
 import { Transition } from '../Transition/index.js';
 import { ViewTransition } from '../ViewTransition/index.js';
 

--- a/packages/ui/Disclosure/Disclosure.ts
+++ b/packages/ui/Disclosure/Disclosure.ts
@@ -1,4 +1,5 @@
-import { Base, useMutation } from '@studiometa/js-toolkit';
+import { Base } from '@studiometa/js-toolkit/Base';
+import { useMutation } from '@studiometa/js-toolkit/useMutation';
 import type { BaseConfig, BaseProps, MutationServiceInterface } from '@studiometa/js-toolkit';
 import { Transition } from '../Transition/index.js';
 import { ViewTransition } from '../ViewTransition/index.js';

--- a/packages/ui/Disclosure/DisclosureGroup.ts
+++ b/packages/ui/Disclosure/DisclosureGroup.ts
@@ -1,6 +1,6 @@
-import { Base } from '@studiometa/js-toolkit';
+import { Base } from '@studiometa/js-toolkit/Base';
 import type { BaseConfig, BaseProps } from '@studiometa/js-toolkit';
-import { nextTick } from '@studiometa/js-toolkit/utils';
+import { nextTick } from '@studiometa/js-toolkit/utils/nextTick';
 import { DISCLOSURE_CONNECTED, DISCLOSURE_GROUP_CONNECTED, type Disclosure } from './Disclosure.js';
 
 export interface DisclosureGroupProps extends BaseProps {

--- a/packages/ui/Draggable/Draggable.ts
+++ b/packages/ui/Draggable/Draggable.ts
@@ -1,13 +1,12 @@
-import { Base, withDrag } from '@studiometa/js-toolkit';
+import { Base } from '@studiometa/js-toolkit/Base';
+import { withDrag } from '@studiometa/js-toolkit/withDrag';
 import type { BaseProps, BaseConfig, DragServiceProps } from '@studiometa/js-toolkit';
-import {
-  clamp,
-  damp,
-  domScheduler,
-  getOffsetSizes,
-  map,
-  transform,
-} from '@studiometa/js-toolkit/utils';
+import { clamp } from '@studiometa/js-toolkit/utils/clamp';
+import { damp } from '@studiometa/js-toolkit/utils/damp';
+import { domScheduler } from '@studiometa/js-toolkit/utils/domScheduler';
+import { getOffsetSizes } from '@studiometa/js-toolkit/utils/getOffsetSizes';
+import { map } from '@studiometa/js-toolkit/utils/map';
+import { transform } from '@studiometa/js-toolkit/utils/transform';
 
 export interface DraggableProps extends BaseProps {
   $refs: {

--- a/packages/ui/Fetch/Fetch.ts
+++ b/packages/ui/Fetch/Fetch.ts
@@ -1,5 +1,8 @@
-import { Base, type BaseConfig, type BaseProps, BaseInterface } from '@studiometa/js-toolkit';
-import { domScheduler, historyPush, isFunction } from '@studiometa/js-toolkit/utils';
+import { Base } from '@studiometa/js-toolkit/Base';
+import type { BaseConfig, BaseProps, BaseInterface } from '@studiometa/js-toolkit';
+import { domScheduler } from '@studiometa/js-toolkit/utils/domScheduler';
+import { historyPush } from '@studiometa/js-toolkit/utils/historyPush';
+import { isFunction } from '@studiometa/js-toolkit/utils/isFunction';
 import morphdom from 'morphdom';
 import { adoptNewScripts, getScripts } from './utils.js';
 

--- a/packages/ui/Fetch/FetchShopifyPartial.ts
+++ b/packages/ui/Fetch/FetchShopifyPartial.ts
@@ -1,5 +1,5 @@
 import { type BaseConfig, type BaseProps } from '@studiometa/js-toolkit';
-import { historyPush } from '@studiometa/js-toolkit/utils';
+import { historyPush } from '@studiometa/js-toolkit/utils/historyPush';
 import { Fetch, type FetchProps } from './Fetch.js';
 
 export interface FetchShopifyPartialProps extends FetchProps {

--- a/packages/ui/Figure/AbstractFigure.ts
+++ b/packages/ui/Figure/AbstractFigure.ts
@@ -1,6 +1,6 @@
-import { withMountWhenInView } from '@studiometa/js-toolkit';
+import { withMountWhenInView } from '@studiometa/js-toolkit/withMountWhenInView';
 import type { BaseConfig, BaseProps } from '@studiometa/js-toolkit';
-import { loadImage } from '@studiometa/js-toolkit/utils';
+import { loadImage } from '@studiometa/js-toolkit/utils/loadImage';
 import { Transition } from '../Transition/index.js';
 
 export interface AbstractFigureProps extends BaseProps {

--- a/packages/ui/Figure/AbstractFigureDynamic.ts
+++ b/packages/ui/Figure/AbstractFigureDynamic.ts
@@ -1,5 +1,5 @@
 import type { BaseConfig, BaseProps } from '@studiometa/js-toolkit';
-import { loadImage } from '@studiometa/js-toolkit/utils';
+import { loadImage } from '@studiometa/js-toolkit/utils/loadImage';
 import { AbstractFigure } from './AbstractFigure.js';
 
 export interface AbstractFigureDynamicProps extends BaseProps {

--- a/packages/ui/Figure/FigureTwicpics.ts
+++ b/packages/ui/Figure/FigureTwicpics.ts
@@ -1,9 +1,7 @@
 import type { BaseConfig, BaseProps } from '@studiometa/js-toolkit';
-import {
-  withLeadingSlash,
-  withoutLeadingSlash,
-  withoutTrailingSlash,
-} from '@studiometa/js-toolkit/utils';
+import { withLeadingSlash } from '@studiometa/js-toolkit/utils/withLeadingSlash';
+import { withoutLeadingSlash } from '@studiometa/js-toolkit/utils/withoutLeadingSlash';
+import { withoutTrailingSlash } from '@studiometa/js-toolkit/utils/withoutTrailingSlash';
 import { AbstractFigureDynamic } from './AbstractFigureDynamic.js';
 import { normalizeSize } from './utils.js';
 

--- a/packages/ui/FigureVideo/FigureVideo.ts
+++ b/packages/ui/FigureVideo/FigureVideo.ts
@@ -1,6 +1,6 @@
-import { withMountWhenInView } from '@studiometa/js-toolkit';
+import { withMountWhenInView } from '@studiometa/js-toolkit/withMountWhenInView';
 import type { BaseConfig, BaseProps } from '@studiometa/js-toolkit';
-import { loadImage } from '@studiometa/js-toolkit/utils';
+import { loadImage } from '@studiometa/js-toolkit/utils/loadImage';
 import { Transition } from '../Transition/index.js';
 
 export interface FigureVideoProps extends BaseProps {

--- a/packages/ui/FigureVideo/FigureVideoTwicpics.ts
+++ b/packages/ui/FigureVideo/FigureVideoTwicpics.ts
@@ -1,10 +1,8 @@
 import type { BaseConfig, BaseProps } from '@studiometa/js-toolkit';
-import {
-  loadImage,
-  withLeadingSlash,
-  withoutLeadingSlash,
-  withoutTrailingSlash,
-} from '@studiometa/js-toolkit/utils';
+import { loadImage } from '@studiometa/js-toolkit/utils/loadImage';
+import { withLeadingSlash } from '@studiometa/js-toolkit/utils/withLeadingSlash';
+import { withoutLeadingSlash } from '@studiometa/js-toolkit/utils/withoutLeadingSlash';
+import { withoutTrailingSlash } from '@studiometa/js-toolkit/utils/withoutTrailingSlash';
 import { normalizeSize } from '../Figure/utils.js';
 import { FigureVideo } from './FigureVideo.js';
 

--- a/packages/ui/Frame/AbstractFrameTrigger.ts
+++ b/packages/ui/Frame/AbstractFrameTrigger.ts
@@ -1,4 +1,5 @@
-import { Base, getClosestParent } from '@studiometa/js-toolkit';
+import { Base } from '@studiometa/js-toolkit/Base';
+import { getClosestParent } from '@studiometa/js-toolkit/getClosestParent';
 import type { BaseConfig, BaseProps } from '@studiometa/js-toolkit';
 import type { FrameRequestInit } from './types.js';
 import { EVENTS } from './utils.js';

--- a/packages/ui/Frame/Frame.ts
+++ b/packages/ui/Frame/Frame.ts
@@ -1,6 +1,8 @@
-import { Base, getClosestParent } from '@studiometa/js-toolkit';
+import { Base } from '@studiometa/js-toolkit/Base';
+import { getClosestParent } from '@studiometa/js-toolkit/getClosestParent';
 import type { BaseProps, BaseConfig } from '@studiometa/js-toolkit';
-import { domScheduler, historyPush } from '@studiometa/js-toolkit/utils';
+import { domScheduler } from '@studiometa/js-toolkit/utils/domScheduler';
+import { historyPush } from '@studiometa/js-toolkit/utils/historyPush';
 import { FrameAnchor } from './FrameAnchor.js';
 import { FrameForm } from './FrameForm.js';
 import { FrameTarget } from './FrameTarget.js';

--- a/packages/ui/Hoverable/Hoverable.ts
+++ b/packages/ui/Hoverable/Hoverable.ts
@@ -1,6 +1,11 @@
-import { Base, withRelativePointer } from '@studiometa/js-toolkit';
+import { Base } from '@studiometa/js-toolkit/Base';
+import { withRelativePointer } from '@studiometa/js-toolkit/withRelativePointer';
 import type { BaseConfig, BaseProps, PointerServiceProps } from '@studiometa/js-toolkit';
-import { map, transform, damp, getOffsetSizes, clamp01 } from '@studiometa/js-toolkit/utils';
+import { map } from '@studiometa/js-toolkit/utils/map';
+import { transform } from '@studiometa/js-toolkit/utils/transform';
+import { damp } from '@studiometa/js-toolkit/utils/damp';
+import { getOffsetSizes } from '@studiometa/js-toolkit/utils/getOffsetSizes';
+import { clamp01 } from '@studiometa/js-toolkit/utils/clamp01';
 
 export interface HoverableProps extends BaseProps {
   $refs: {

--- a/packages/ui/InView/InView.ts
+++ b/packages/ui/InView/InView.ts
@@ -1,4 +1,5 @@
-import { Base, withMountWhenInView } from '@studiometa/js-toolkit';
+import { Base } from '@studiometa/js-toolkit/Base';
+import { withMountWhenInView } from '@studiometa/js-toolkit/withMountWhenInView';
 import type { BaseConfig } from '@studiometa/js-toolkit';
 
 /**

--- a/packages/ui/Indexable/Indexable.ts
+++ b/packages/ui/Indexable/Indexable.ts
@@ -1,4 +1,5 @@
-import { Base, BaseConfig, BaseProps } from '@studiometa/js-toolkit';
+import { Base } from '@studiometa/js-toolkit/Base';
+import type { BaseConfig, BaseProps } from '@studiometa/js-toolkit';
 import { withIndex } from '../decorators/index.js';
 
 /**

--- a/packages/ui/LargeText/LargeText.ts
+++ b/packages/ui/LargeText/LargeText.ts
@@ -1,6 +1,9 @@
-import { Base, withMountWhenInView } from '@studiometa/js-toolkit';
+import { Base } from '@studiometa/js-toolkit/Base';
+import { withMountWhenInView } from '@studiometa/js-toolkit/withMountWhenInView';
 import type { BaseProps, BaseInterface, ScrollServiceProps } from '@studiometa/js-toolkit';
-import { damp, clamp, transform } from '@studiometa/js-toolkit/utils';
+import { damp } from '@studiometa/js-toolkit/utils/damp';
+import { clamp } from '@studiometa/js-toolkit/utils/clamp';
+import { transform } from '@studiometa/js-toolkit/utils/transform';
 
 export interface LargeTextProps extends BaseProps {
   $refs: {

--- a/packages/ui/LazyInclude/LazyInclude.ts
+++ b/packages/ui/LazyInclude/LazyInclude.ts
@@ -1,4 +1,4 @@
-import { Base } from '@studiometa/js-toolkit';
+import { Base } from '@studiometa/js-toolkit/Base';
 import type { BaseProps, BaseInterface } from '@studiometa/js-toolkit';
 
 export interface LazyIncludeProps extends BaseProps {

--- a/packages/ui/Menu/Menu.ts
+++ b/packages/ui/Menu/Menu.ts
@@ -1,6 +1,7 @@
-import { Base, getClosestParent } from '@studiometa/js-toolkit';
+import { Base } from '@studiometa/js-toolkit/Base';
+import { getClosestParent } from '@studiometa/js-toolkit/getClosestParent';
 import type { BaseConfig, BaseProps, KeyServiceProps } from '@studiometa/js-toolkit';
-import { nextTick } from '@studiometa/js-toolkit/utils';
+import { nextTick } from '@studiometa/js-toolkit/utils/nextTick';
 import { MenuBtn } from './MenuBtn.js';
 import { MenuList } from './MenuList.js';
 

--- a/packages/ui/Menu/MenuBtn.ts
+++ b/packages/ui/Menu/MenuBtn.ts
@@ -1,4 +1,4 @@
-import { Base } from '@studiometa/js-toolkit';
+import { Base } from '@studiometa/js-toolkit/Base';
 import type { BaseConfig, BaseProps } from '@studiometa/js-toolkit';
 
 /**

--- a/packages/ui/Menu/MenuList.ts
+++ b/packages/ui/Menu/MenuList.ts
@@ -1,5 +1,5 @@
 import type { BaseConfig, BaseProps } from '@studiometa/js-toolkit';
-import { getInstanceFromElement } from '@studiometa/js-toolkit';
+import { getInstanceFromElement } from '@studiometa/js-toolkit/getInstanceFromElement';
 import { Transition } from '../Transition/index.js';
 
 const FOCUSABLE_ELEMENTS = [

--- a/packages/ui/Modal/Modal.ts
+++ b/packages/ui/Modal/Modal.ts
@@ -1,11 +1,10 @@
-import { Base, KeyServiceProps } from '@studiometa/js-toolkit';
+import { Base } from '@studiometa/js-toolkit/Base';
+import type { KeyServiceProps } from '@studiometa/js-toolkit';
 import type { BaseProps, BaseConfig } from '@studiometa/js-toolkit';
-import {
-  transition,
-  trapFocus as trap,
-  untrapFocus as untrap,
-  saveActiveElement,
-} from '@studiometa/js-toolkit/utils';
+import { transition } from '@studiometa/js-toolkit/utils/transition';
+import { trapFocus as trap } from '@studiometa/js-toolkit/utils/trapFocus';
+import { untrapFocus as untrap } from '@studiometa/js-toolkit/utils/untrapFocus';
+import { saveActiveElement } from '@studiometa/js-toolkit/utils/saveActiveElement';
 import { withDeprecation } from '../decorators/index.js';
 
 type ModalStates = Partial<

--- a/packages/ui/Panel/Panel.ts
+++ b/packages/ui/Panel/Panel.ts
@@ -1,5 +1,6 @@
 import type { BaseProps, BaseConfig } from '@studiometa/js-toolkit';
-import { transition, matrix } from '@studiometa/js-toolkit/utils';
+import { transition } from '@studiometa/js-toolkit/utils/transition';
+import { matrix } from '@studiometa/js-toolkit/utils/matrix';
 import { Modal } from '../Modal/index.js';
 
 export interface PanelProps extends BaseProps {

--- a/packages/ui/Prefetch/AbstractPrefetch.ts
+++ b/packages/ui/Prefetch/AbstractPrefetch.ts
@@ -1,4 +1,4 @@
-import { Base } from '@studiometa/js-toolkit';
+import { Base } from '@studiometa/js-toolkit/Base';
 import type { BaseProps, BaseConfig } from '@studiometa/js-toolkit';
 
 export interface AbstractPrefetchProps extends BaseProps {

--- a/packages/ui/Prefetch/PrefetchWhenVisible.ts
+++ b/packages/ui/Prefetch/PrefetchWhenVisible.ts
@@ -1,4 +1,4 @@
-import { withMountWhenInView } from '@studiometa/js-toolkit';
+import { withMountWhenInView } from '@studiometa/js-toolkit/withMountWhenInView';
 import type { BaseConfig } from '@studiometa/js-toolkit';
 import { AbstractPrefetch } from './AbstractPrefetch.js';
 

--- a/packages/ui/ScrollAnimation/AbstractScrollAnimation.ts
+++ b/packages/ui/ScrollAnimation/AbstractScrollAnimation.ts
@@ -1,6 +1,10 @@
-import { Base, withFreezedOptions } from '@studiometa/js-toolkit';
+import { Base } from '@studiometa/js-toolkit/Base';
+import { withFreezedOptions } from '@studiometa/js-toolkit/withFreezedOptions';
 import type { BaseProps, BaseConfig, ScrollInViewProps } from '@studiometa/js-toolkit';
-import { map, clamp01, animate, nextTick } from '@studiometa/js-toolkit/utils';
+import { map } from '@studiometa/js-toolkit/utils/map';
+import { clamp01 } from '@studiometa/js-toolkit/utils/clamp01';
+import { animate } from '@studiometa/js-toolkit/utils/animate';
+import { nextTick } from '@studiometa/js-toolkit/utils/nextTick';
 import type { Keyframe } from '@studiometa/js-toolkit/utils';
 
 export interface AbstractScrollAnimationProps extends BaseProps {

--- a/packages/ui/ScrollAnimation/ScrollAnimation.ts
+++ b/packages/ui/ScrollAnimation/ScrollAnimation.ts
@@ -1,6 +1,6 @@
-import { withScrolledInView } from '@studiometa/js-toolkit';
+import { withScrolledInView } from '@studiometa/js-toolkit/withScrolledInView';
 import type { BaseConfig, BaseProps } from '@studiometa/js-toolkit';
-import { isDev } from '@studiometa/js-toolkit/utils';
+import { isDev } from '@studiometa/js-toolkit/utils/isDev';
 import { AbstractScrollAnimation } from './AbstractScrollAnimation.js';
 
 export interface ScrollAnimationProps extends BaseProps {

--- a/packages/ui/ScrollAnimation/ScrollAnimationChild.ts
+++ b/packages/ui/ScrollAnimation/ScrollAnimationChild.ts
@@ -4,7 +4,10 @@ import type {
   ScrollInViewProps,
   WithScrolledInViewProps,
 } from '@studiometa/js-toolkit';
-import { damp, clamp01, domScheduler, isDev } from '@studiometa/js-toolkit/utils';
+import { damp } from '@studiometa/js-toolkit/utils/damp';
+import { clamp01 } from '@studiometa/js-toolkit/utils/clamp01';
+import { domScheduler } from '@studiometa/js-toolkit/utils/domScheduler';
+import { isDev } from '@studiometa/js-toolkit/utils/isDev';
 import { AbstractScrollAnimation } from './AbstractScrollAnimation.js';
 
 export interface ScrollAnimationChildProps extends BaseProps {

--- a/packages/ui/ScrollAnimation/ScrollAnimationChildWithEase.ts
+++ b/packages/ui/ScrollAnimation/ScrollAnimationChildWithEase.ts
@@ -1,5 +1,5 @@
 import type { BaseConfig } from '@studiometa/js-toolkit';
-import { isDev } from '@studiometa/js-toolkit/utils';
+import { isDev } from '@studiometa/js-toolkit/utils/isDev';
 import { ScrollAnimationChild } from './ScrollAnimationChild.js';
 import { animationScrollWithEase } from './animationScrollWithEase.js';
 

--- a/packages/ui/ScrollAnimation/ScrollAnimationParent.ts
+++ b/packages/ui/ScrollAnimation/ScrollAnimationParent.ts
@@ -1,6 +1,8 @@
-import { Base, ScrollInViewProps, withScrolledInView } from '@studiometa/js-toolkit';
+import { Base } from '@studiometa/js-toolkit/Base';
+import { withScrolledInView } from '@studiometa/js-toolkit/withScrolledInView';
+import type { ScrollInViewProps } from '@studiometa/js-toolkit';
 import type { BaseConfig, BaseProps } from '@studiometa/js-toolkit';
-import { isDev } from '@studiometa/js-toolkit/utils';
+import { isDev } from '@studiometa/js-toolkit/utils/isDev';
 import { ScrollAnimationChild } from './ScrollAnimationChild.js';
 
 export interface ScrollAnimationParentProps extends BaseProps {

--- a/packages/ui/ScrollAnimation/ScrollAnimationTarget.ts
+++ b/packages/ui/ScrollAnimation/ScrollAnimationTarget.ts
@@ -4,7 +4,9 @@ import type {
   ScrollInViewProps,
   WithScrolledInViewProps,
 } from '@studiometa/js-toolkit';
-import { damp, clamp01, domScheduler } from '@studiometa/js-toolkit/utils';
+import { damp } from '@studiometa/js-toolkit/utils/damp';
+import { clamp01 } from '@studiometa/js-toolkit/utils/clamp01';
+import { domScheduler } from '@studiometa/js-toolkit/utils/domScheduler';
 import { AbstractScrollAnimation } from './AbstractScrollAnimation.js';
 
 export interface ScrollAnimationTargetProps extends BaseProps {

--- a/packages/ui/ScrollAnimation/ScrollAnimationTimeline.ts
+++ b/packages/ui/ScrollAnimation/ScrollAnimationTimeline.ts
@@ -1,4 +1,6 @@
-import { Base, ScrollInViewProps, withScrolledInView } from '@studiometa/js-toolkit';
+import { Base } from '@studiometa/js-toolkit/Base';
+import { withScrolledInView } from '@studiometa/js-toolkit/withScrolledInView';
+import type { ScrollInViewProps } from '@studiometa/js-toolkit';
 import type { BaseConfig, BaseProps } from '@studiometa/js-toolkit';
 import { ScrollAnimationTarget } from './ScrollAnimationTarget.js';
 

--- a/packages/ui/ScrollAnimation/ScrollAnimationWithEase.ts
+++ b/packages/ui/ScrollAnimation/ScrollAnimationWithEase.ts
@@ -1,5 +1,5 @@
 import { type BaseConfig } from '@studiometa/js-toolkit';
-import { isDev } from '@studiometa/js-toolkit/utils';
+import { isDev } from '@studiometa/js-toolkit/utils/isDev';
 import { ScrollAnimation } from './ScrollAnimation.js';
 import { animationScrollWithEase } from './animationScrollWithEase.js';
 

--- a/packages/ui/ScrollAnimation/animationScrollWithEase.ts
+++ b/packages/ui/ScrollAnimation/animationScrollWithEase.ts
@@ -1,5 +1,6 @@
 import type { BaseConfig, BaseProps, BaseDecorator, BaseInterface } from '@studiometa/js-toolkit';
-import { ease, isDev } from '@studiometa/js-toolkit/utils';
+import { ease } from '@studiometa/js-toolkit/utils/ease';
+import { isDev } from '@studiometa/js-toolkit/utils/isDev';
 import type { AbstractScrollAnimation } from './AbstractScrollAnimation.js';
 
 const regex = /ease([A-Z])/;

--- a/packages/ui/ScrollAnimation/withScrollAnimationDebug.ts
+++ b/packages/ui/ScrollAnimation/withScrollAnimationDebug.ts
@@ -6,7 +6,7 @@ import type {
   BaseDecorator,
   ScrollInViewProps,
 } from '@studiometa/js-toolkit';
-import { createElement } from '@studiometa/js-toolkit/utils';
+import { createElement } from '@studiometa/js-toolkit/utils/createElement';
 
 /**
  * Debug marker element interface.

--- a/packages/ui/ScrollReveal/ScrollReveal.ts
+++ b/packages/ui/ScrollReveal/ScrollReveal.ts
@@ -1,4 +1,6 @@
-import { withMountWhenInView, useScroll, ScrollServiceProps } from '@studiometa/js-toolkit';
+import { withMountWhenInView } from '@studiometa/js-toolkit/withMountWhenInView';
+import { useScroll } from '@studiometa/js-toolkit/useScroll';
+import type { ScrollServiceProps } from '@studiometa/js-toolkit';
 import type { BaseProps, BaseConfig } from '@studiometa/js-toolkit';
 import { Transition } from '../Transition/index.js';
 

--- a/packages/ui/Sentinel/Sentinel.ts
+++ b/packages/ui/Sentinel/Sentinel.ts
@@ -1,4 +1,5 @@
-import { Base, withIntersectionObserver } from '@studiometa/js-toolkit';
+import { Base } from '@studiometa/js-toolkit/Base';
+import { withIntersectionObserver } from '@studiometa/js-toolkit/withIntersectionObserver';
 import type { BaseConfig } from '@studiometa/js-toolkit';
 
 /**

--- a/packages/ui/Slider/AbstractSliderChild.ts
+++ b/packages/ui/Slider/AbstractSliderChild.ts
@@ -1,6 +1,8 @@
-import { Base } from '@studiometa/js-toolkit';
+import { Base } from '@studiometa/js-toolkit/Base';
 import type { BaseProps, BaseConfig } from '@studiometa/js-toolkit';
-import { nextFrame, domScheduler, isFunction } from '@studiometa/js-toolkit/utils';
+import { nextFrame } from '@studiometa/js-toolkit/utils/nextFrame';
+import { domScheduler } from '@studiometa/js-toolkit/utils/domScheduler';
+import { isFunction } from '@studiometa/js-toolkit/utils/isFunction';
 import type { Slider } from './Slider.js';
 
 export interface AbstractSliderChildProps extends BaseProps {}

--- a/packages/ui/Slider/Slider.ts
+++ b/packages/ui/Slider/Slider.ts
@@ -1,17 +1,15 @@
-import { Base } from '@studiometa/js-toolkit';
+import { Base } from '@studiometa/js-toolkit/Base';
 import type {
   BaseProps,
   BaseConfig,
   DragServiceProps,
   KeyServiceProps,
 } from '@studiometa/js-toolkit';
-import {
-  clamp,
-  createMemoryStorageProvider,
-  createStorage,
-  inertiaFinalValue,
-  nextFrame,
-} from '@studiometa/js-toolkit/utils';
+import { clamp } from '@studiometa/js-toolkit/utils/clamp';
+import { createMemoryStorageProvider } from '@studiometa/js-toolkit/utils/createMemoryStorageProvider';
+import { createStorage } from '@studiometa/js-toolkit/utils/createStorage';
+import { inertiaFinalValue } from '@studiometa/js-toolkit/utils/inertiaFinalValue';
+import { nextFrame } from '@studiometa/js-toolkit/utils/nextFrame';
 import { AbstractSliderChild } from './AbstractSliderChild.js';
 import { SliderDrag } from './SliderDrag.js';
 import { SliderItem } from './SliderItem.js';

--- a/packages/ui/Slider/SliderCount.ts
+++ b/packages/ui/Slider/SliderCount.ts
@@ -1,4 +1,4 @@
-import { domScheduler } from '@studiometa/js-toolkit/utils';
+import { domScheduler } from '@studiometa/js-toolkit/utils/domScheduler';
 import type { BaseProps, BaseConfig } from '@studiometa/js-toolkit';
 import { AbstractSliderChild } from './AbstractSliderChild.js';
 

--- a/packages/ui/Slider/SliderDrag.ts
+++ b/packages/ui/Slider/SliderDrag.ts
@@ -1,5 +1,6 @@
 import type { BaseProps, BaseConfig, DragServiceProps } from '@studiometa/js-toolkit';
-import { Base, withDrag } from '@studiometa/js-toolkit';
+import { Base } from '@studiometa/js-toolkit/Base';
+import { withDrag } from '@studiometa/js-toolkit/withDrag';
 
 export interface SliderDragProps extends BaseProps {
   $options: {

--- a/packages/ui/Slider/SliderItem.ts
+++ b/packages/ui/Slider/SliderItem.ts
@@ -1,6 +1,8 @@
-import { Base } from '@studiometa/js-toolkit';
+import { Base } from '@studiometa/js-toolkit/Base';
 import type { BaseProps, BaseConfig } from '@studiometa/js-toolkit';
-import { damp, domScheduler, transform } from '@studiometa/js-toolkit/utils';
+import { damp } from '@studiometa/js-toolkit/utils/damp';
+import { domScheduler } from '@studiometa/js-toolkit/utils/domScheduler';
+import { transform } from '@studiometa/js-toolkit/utils/transform';
 
 export interface SliderItemProps extends BaseProps {}
 

--- a/packages/ui/Slider/SliderProgress.ts
+++ b/packages/ui/Slider/SliderProgress.ts
@@ -1,5 +1,7 @@
 import type { BaseProps, BaseConfig } from '@studiometa/js-toolkit';
-import { transform, map, domScheduler } from '@studiometa/js-toolkit/utils';
+import { transform } from '@studiometa/js-toolkit/utils/transform';
+import { map } from '@studiometa/js-toolkit/utils/map';
+import { domScheduler } from '@studiometa/js-toolkit/utils/domScheduler';
 import { AbstractSliderChild } from './AbstractSliderChild.js';
 
 export interface SliderProgressProps extends BaseProps {

--- a/packages/ui/Sticky/Sticky.ts
+++ b/packages/ui/Sticky/Sticky.ts
@@ -1,4 +1,4 @@
-import { Base } from '@studiometa/js-toolkit';
+import { Base } from '@studiometa/js-toolkit/Base';
 import type { BaseProps, BaseConfig } from '@studiometa/js-toolkit';
 import { Sentinel } from '../Sentinel/index.js';
 

--- a/packages/ui/Tabs/Tabs.ts
+++ b/packages/ui/Tabs/Tabs.ts
@@ -1,6 +1,6 @@
-import { Base } from '@studiometa/js-toolkit';
+import { Base } from '@studiometa/js-toolkit/Base';
 import type { BaseProps, BaseConfig } from '@studiometa/js-toolkit';
-import { transition } from '@studiometa/js-toolkit/utils';
+import { transition } from '@studiometa/js-toolkit/utils/transition';
 
 type TabItem = {
   btn: HTMLElement;

--- a/packages/ui/Timer/Timer.ts
+++ b/packages/ui/Timer/Timer.ts
@@ -1,4 +1,4 @@
-import { Base } from '@studiometa/js-toolkit';
+import { Base } from '@studiometa/js-toolkit/Base';
 import type { BaseProps, BaseConfig } from '@studiometa/js-toolkit';
 
 export interface TimerProps extends BaseProps {

--- a/packages/ui/Toaster/Toaster.ts
+++ b/packages/ui/Toaster/Toaster.ts
@@ -1,4 +1,4 @@
-import { Base } from '@studiometa/js-toolkit';
+import { Base } from '@studiometa/js-toolkit/Base';
 import type { BaseProps, BaseConfig } from '@studiometa/js-toolkit';
 import { Toast } from './Toast.js';
 import { viewTransition } from '../ViewTransition/index.js';

--- a/packages/ui/Track/AbstractTrack.ts
+++ b/packages/ui/Track/AbstractTrack.ts
@@ -1,7 +1,8 @@
 import deepmerge from 'deepmerge';
-import { Base } from '@studiometa/js-toolkit';
+import { Base } from '@studiometa/js-toolkit/Base';
 import type { BaseProps, BaseConfig } from '@studiometa/js-toolkit';
-import { memo, nextFrame } from '@studiometa/js-toolkit/utils';
+import { memo } from '@studiometa/js-toolkit/utils/memo';
+import { nextFrame } from '@studiometa/js-toolkit/utils/nextFrame';
 import { TrackContext } from './TrackContext.js';
 import { TrackEvent } from './TrackEvent.js';
 import { arrayMerge } from './utils.js';

--- a/packages/ui/Track/TrackContext.ts
+++ b/packages/ui/Track/TrackContext.ts
@@ -1,5 +1,5 @@
 import deepmerge from 'deepmerge';
-import { Base } from '@studiometa/js-toolkit';
+import { Base } from '@studiometa/js-toolkit/Base';
 import type { BaseProps, BaseConfig } from '@studiometa/js-toolkit';
 import { arrayMerge } from './utils.js';
 

--- a/packages/ui/Track/TrackEvent.ts
+++ b/packages/ui/Track/TrackEvent.ts
@@ -1,4 +1,4 @@
-import { throttle } from '@studiometa/js-toolkit/utils';
+import { throttle } from '@studiometa/js-toolkit/utils/throttle';
 import type { AbstractTrack } from './AbstractTrack.js';
 
 export type Modifier =

--- a/packages/ui/Transition/Transition.ts
+++ b/packages/ui/Transition/Transition.ts
@@ -1,4 +1,5 @@
-import { Base, BaseProps } from '@studiometa/js-toolkit';
+import { Base } from '@studiometa/js-toolkit/Base';
+import type { BaseProps } from '@studiometa/js-toolkit';
 import type { BaseConfig } from '@studiometa/js-toolkit';
 import { withTransition } from '../decorators/index.js';
 

--- a/packages/ui/ViewTransition/ViewTransition.ts
+++ b/packages/ui/ViewTransition/ViewTransition.ts
@@ -1,6 +1,7 @@
-import { Base } from '@studiometa/js-toolkit';
+import { Base } from '@studiometa/js-toolkit/Base';
 import type { BaseProps, BaseConfig } from '@studiometa/js-toolkit';
-import { addClass, removeClass } from '@studiometa/js-toolkit/utils';
+import { addClass } from '@studiometa/js-toolkit/utils/addClass';
+import { removeClass } from '@studiometa/js-toolkit/utils/removeClass';
 import { viewTransition } from './scheduler.js';
 
 export interface ViewTransitionProps extends BaseProps {

--- a/packages/ui/decorators/withDeprecation.ts
+++ b/packages/ui/decorators/withDeprecation.ts
@@ -5,7 +5,7 @@ import type {
   BaseConfig,
   BaseInterface,
 } from '@studiometa/js-toolkit';
-import { isDev } from '@studiometa/js-toolkit/utils';
+import { isDev } from '@studiometa/js-toolkit/utils/isDev';
 
 export interface DeprecationProps extends BaseProps {}
 

--- a/packages/ui/decorators/withIndex.ts
+++ b/packages/ui/decorators/withIndex.ts
@@ -5,7 +5,11 @@ import type {
   BaseConfig,
   BaseInterface,
 } from '@studiometa/js-toolkit';
-import { clamp, fold, isString, randomInt, wrap } from '@studiometa/js-toolkit/utils';
+import { clamp } from '@studiometa/js-toolkit/utils/clamp';
+import { fold } from '@studiometa/js-toolkit/utils/fold';
+import { isString } from '@studiometa/js-toolkit/utils/isString';
+import { randomInt } from '@studiometa/js-toolkit/utils/randomInt';
+import { wrap } from '@studiometa/js-toolkit/utils/wrap';
 
 const INDEXABLE_BOUNDARIES = {
   CLAMP: 'clamp',

--- a/packages/ui/decorators/withTransition.ts
+++ b/packages/ui/decorators/withTransition.ts
@@ -1,5 +1,7 @@
-import { getInstances } from '@studiometa/js-toolkit';
-import { nextFrame, removeClass, transition } from '@studiometa/js-toolkit/utils';
+import { getInstances } from '@studiometa/js-toolkit/getInstances';
+import { nextFrame } from '@studiometa/js-toolkit/utils/nextFrame';
+import { removeClass } from '@studiometa/js-toolkit/utils/removeClass';
+import { transition } from '@studiometa/js-toolkit/utils/transition';
 import type {
   Base,
   BaseDecorator,


### PR DESCRIPTION
## Why

`@studiometa/ui` and `@studiometa/ui-mapbox` are meant to be usable directly from the [esm.sh](https://esm.sh) CDN with no bundler. esm.sh **does not tree-shake** and externalizes each dependency to its esm.sh URL. Because the source imported js-toolkit values from the package barrel (`@studiometa/js-toolkit` and `@studiometa/js-toolkit/utils`), esm.sh pulled the **entire** js-toolkit main barrel (~106 KB raw) **and** the entire `/utils` barrel (~42 KB raw) into *every* component — regardless of what that component actually used.

Example (before): loading `@studiometa/ui/Modal` from esm.sh downloaded ~112 KB raw across ~65 files, of which only ~4 KB was Modal's own code.

## What

Import each **value** from its dedicated per-symbol subpath:

```diff
-import { Base, withDrag } from '@studiometa/js-toolkit';
+import { Base } from '@studiometa/js-toolkit/Base';
+import { withDrag } from '@studiometa/js-toolkit/withDrag';
-import { clamp, damp, transform } from '@studiometa/js-toolkit/utils';
+import { clamp } from '@studiometa/js-toolkit/utils/clamp';
+import { damp } from '@studiometa/js-toolkit/utils/damp';
+import { transform } from '@studiometa/js-toolkit/utils/transform';
```

Type-only symbols are erased by esm.sh, so they **stay on the barrel** at no runtime cost:

```diff
-import { Base, KeyServiceProps } from '@studiometa/js-toolkit';
+import { Base } from '@studiometa/js-toolkit/Base';
+import type { KeyServiceProps } from '@studiometa/js-toolkit';
```

83 files, 113 import statements rewritten. No public API change.

## Evidence

Measured against the real esm.sh transitive graph, **js-toolkit pinned at `3.9.0-beta.1`, `target=es2022`** (pinning isolates this change from the in-flight js-toolkit internal-imports work):

| Package | Per-entry median Δ raw | Range | Highlights |
|---|--:|--:|---|
| `@studiometa/ui` (94 entries) | **−26%** | 0% … −96% | `withDeprecation` 45.9→1.7 KB (−96%), `autoload` 123.7→71.3 KB (−42%), `Modal` 112→82.6 KB (−26%) |
| `@studiometa/ui-mapbox` (18 entries) | **−27%** | −14% … −48% | `autoload` 109.8→57.5 KB (−48%); no entry gains requests |

The measurement methodology was pressure-tested before use (exact-version pinning to avoid a caret-range leak, forced build target, real ES parser with resolved-URL dedup, real brotli, static-imports-only).

### Caveats
- The per-entry figures are a **model** validated against real esm.sh subpath graphs (the source change swaps only static value imports; type imports are erased). Worth confirming with one canary publish before quoting the headline as measured.
- The win is **bytes, not requests** — some entries trade a few extra subpath facade requests for the byte savings; `ui-mapbox` never regresses on request count.
- `ui-mapbox` figures are static-only and **exclude** the ~1.2 MB `mapbox-gl` that loads dynamically on mount.
- Numbers are tied to the pinned js-toolkit version; once the js-toolkit internal-imports optimization lands, the two deltas should be re-measured separately, not summed.

## Verification
- `npm run lint:types` — pass
- `npm run lint:static` — 0 errors (pre-existing warnings only)
- `npm run test` — 806 passed, 3 skipped, 1 todo

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HKLcgvaDcjK9ohA3fg7Ssq
