### PR TITLE
Prepare 1.10.0-beta.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [v1.10.0-beta.6](https://github.com/studiometa/ui/compare/1.10.0-beta.5..1.10.0-beta.6) (2026-08-10)
+
 ### Added
 
 - **@studiometa/ui-mapbox:** expose each component at its own explicit subpath, e.g. `@studiometa/ui-mapbox/MapboxMap` ([#620](https://github.com/studiometa/ui/pull/620))

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "studiometa/ui",
   "type": "composer-plugin",
-  "version": "1.10.0-beta.5",
+  "version": "1.10.0-beta.6",
   "description": "Accessible and composable JavaScript behaviors and Twig templates.",
   "license": "MIT",
   "require": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@studiometa/ui-workspace",
-  "version": "1.10.0-beta.5",
+  "version": "1.10.0-beta.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@studiometa/ui-workspace",
-      "version": "1.10.0-beta.5",
+      "version": "1.10.0-beta.6",
       "hasInstallScript": true,
       "workspaces": [
         "packages/*"
@@ -22343,11 +22343,11 @@
     },
     "packages/api": {
       "name": "@studiometa/ui-api",
-      "version": "1.10.0-beta.5"
+      "version": "1.10.0-beta.6"
     },
     "packages/docs": {
       "name": "@studiometa/ui-docs",
-      "version": "1.10.0-beta.5",
+      "version": "1.10.0-beta.6",
       "dependencies": {
         "@studiometa/js-toolkit": "3.9.0-beta.2"
       },
@@ -22473,7 +22473,7 @@
     },
     "packages/eslint-plugin-ui": {
       "name": "@studiometa/eslint-plugin-ui",
-      "version": "1.10.0-beta.5",
+      "version": "1.10.0-beta.6",
       "license": "MIT",
       "dependencies": {
         "@oxlint/plugins": "1.63.0"
@@ -22488,7 +22488,7 @@
     },
     "packages/playground": {
       "name": "@studiometa/ui-playground",
-      "version": "1.10.0-beta.5",
+      "version": "1.10.0-beta.6",
       "dependencies": {
         "@studiometa/playground": "^0.3.13"
       },
@@ -22504,7 +22504,7 @@
     },
     "packages/tests": {
       "name": "@studiometa/ui-tests",
-      "version": "1.10.0-beta.5",
+      "version": "1.10.0-beta.6",
       "license": "MIT",
       "dependencies": {
         "@happy-dom/global-registrator": "^20.8.8",
@@ -22734,7 +22734,7 @@
     },
     "packages/ui": {
       "name": "@studiometa/ui",
-      "version": "1.10.0-beta.5",
+      "version": "1.10.0-beta.6",
       "license": "MIT",
       "dependencies": {
         "alien-signals": "^3.2.1",
@@ -22757,7 +22757,7 @@
     },
     "packages/ui-mapbox": {
       "name": "@studiometa/ui-mapbox",
-      "version": "1.10.0-beta.5",
+      "version": "1.10.0-beta.6",
       "license": "MIT",
       "devDependencies": {
         "@mapbox/mapbox-gl-geocoder": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-workspace",
-  "version": "1.10.0-beta.5",
+  "version": "1.10.0-beta.6",
   "type": "module",
   "private": true,
   "workspaces": [

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-api",
-  "version": "1.10.0-beta.5",
+  "version": "1.10.0-beta.6",
   "private": true,
   "type": "commonjs"
 }

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-docs",
-  "version": "1.10.0-beta.5",
+  "version": "1.10.0-beta.6",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/eslint-plugin-ui/package.json
+++ b/packages/eslint-plugin-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/eslint-plugin-ui",
-  "version": "1.10.0-beta.5",
+  "version": "1.10.0-beta.6",
   "description": "ESLint plugin to help developers discover and use @studiometa/ui components",
   "publishConfig": {
     "access": "public"

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-playground",
-  "version": "1.10.0-beta.5",
+  "version": "1.10.0-beta.6",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-tests",
-  "version": "1.10.0-beta.5",
+  "version": "1.10.0-beta.6",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/ui-mapbox/package.json
+++ b/packages/ui-mapbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-mapbox",
-  "version": "1.10.0-beta.5",
+  "version": "1.10.0-beta.6",
   "description": "Vanilla js-toolkit components to build Mapbox GL maps declaratively",
   "publishConfig": {
     "access": "public"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui",
-  "version": "1.10.0-beta.5",
+  "version": "1.10.0-beta.6",
   "description": "Accessible and composable JavaScript behaviors and templates",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Prepares the `1.10.0-beta.6` release.

- Promote the `[Unreleased]` changelog entries to `[v1.10.0-beta.6]`.
- Bump all package versions (root, workspaces, and `composer.json`) to `1.10.0-beta.6`.

The release ships the `src/`+`dist/` restructure of `@studiometa/ui` and `@studiometa/ui-mapbox`, the `.js`-subpath-export cleanup, the ui-mapbox per-component subpaths, and the `typescript` in-repo export condition (see #620).

Once merged, push the `1.10.0-beta.6` tag to trigger the npm publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)