### PR TITLE
Measure export size per named barrel export

### DIFF
--- a/scripts/export-size-comment.mjs
+++ b/scripts/export-size-comment.mjs
@@ -37,8 +37,14 @@ function index(path) {
 const base = index(basePath);
 const head = index(headPath);
 
+// Human-readable size, matching the previous action's `pretty-bytes` output:
+// bytes under 1 kB (so small diffs stay precise instead of rounding to
+// `0.00 kB`), kB above with trailing zeros trimmed (`446 B`, `1.11 kB`,
+// `3.4 kB`). The sign is preserved for deltas.
 function kib(bytes) {
-  return `${(bytes / 1024).toFixed(2)} kB`;
+  const abs = Math.abs(bytes);
+  const value = abs < 1024 ? `${abs} B` : `${parseFloat((abs / 1024).toFixed(2))} kB`;
+  return bytes < 0 ? `-${value}` : value;
 }
 
 const HEADER = ['| Export | Size (gzip) | Diff |', '| :-- | --: | :-: |'];

--- a/scripts/export-size-comment.mjs
+++ b/scripts/export-size-comment.mjs
@@ -12,8 +12,14 @@ if (!basePath || !headPath) {
   process.exit(1);
 }
 
+// Normalize an entry key so an older subpath-based report (`./Modal`) lines up
+// with a named-export report (`Modal`) in the diff.
+function key(entry) {
+  return entry === '.' ? '.' : entry.replace(/^\.\//, '');
+}
+
 /**
- * Index a report as `{ [package]: { [subpath]: { raw, gzip, brotli } } }`.
+ * Index a report as `{ [package]: { [name]: { raw, gzip, brotli } } }`.
  *
  * @param   {string} path
  * @returns {Record<string, Record<string, { raw: number, gzip: number, brotli: number }>>}
@@ -23,7 +29,7 @@ function index(path) {
   const map = {};
   for (const { name, entries } of report) {
     map[name] = {};
-    for (const entry of entries) map[name][entry.subpath] = entry;
+    for (const entry of entries) map[name][key(entry.subpath)] = entry;
   }
   return map;
 }
@@ -37,8 +43,8 @@ function kib(bytes) {
 
 const HEADER = ['| Export | Size (gzip) | Diff |', '| :-- | --: | :-: |'];
 
-function name(subpath) {
-  return subpath === '.' ? '(index)' : subpath.replace(/^\.\//, '');
+function name(entry) {
+  return entry === '.' ? '(barrel)' : entry;
 }
 
 // A signed gzip delta with percentage. Added exports read as +100%, removed

--- a/scripts/export-size.mjs
+++ b/scripts/export-size.mjs
@@ -1,9 +1,15 @@
 // Measure the published export sizes of the workspace packages, replacing the
 // third-party export-size GitHub Action with a local check built on esbuild (the
-// same toolchain family as our tsdown builder). Each public subpath is bundled
-// from its built `dist` entry with all bare dependencies (peers such as
-// `@studiometa/js-toolkit`) left external, minified, then measured raw, gzipped
-// and brotli-compressed. Requires the packages to be built first.
+// same toolchain family as our tsdown builder).
+//
+// Each named export of a package barrel is measured as it is actually consumed —
+// `import { Name } from '@studiometa/ui'` — by tree-shaking that single symbol
+// out of the built barrel, with every bare dependency (peers such as
+// `@studiometa/js-toolkit`) left external and the output minified, then measured
+// raw, gzipped and brotli-compressed. The whole barrel (`.`) and any side-effect
+// or non-barrel entry (`autoload`, `manifest`) are measured from their own entry.
+// A symbol reachable from several places (the barrel and its own subpath) has one
+// size, so results are keyed by name and measured once. Requires a prior build.
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -26,14 +32,50 @@ function brotliSize(contents) {
   }).length;
 }
 
+// Bundle with esbuild and measure the combined output (dynamic-import chunks are
+// summed) raw, gzipped and brotli-compressed.
+async function sizeOf(options) {
+  const result = await build({
+    bundle: true,
+    minify: true,
+    format: 'esm',
+    platform: 'neutral',
+    // Leave every bare import (peers, third-party) external so the measurement
+    // reflects the package's own shipped code, not its dependencies.
+    packages: 'external',
+    write: false,
+    logLevel: 'silent',
+    ...options,
+  });
+  const contents = Buffer.concat(result.outputFiles.map((file) => file.contents));
+  return { raw: contents.length, gzip: gzipSync(contents).length, brotli: brotliSize(contents) };
+}
+
+// The value exports of a built barrel, via esbuild's metafile (type-only exports
+// are erased in the emitted JavaScript and carry no size, so they are excluded).
+async function barrelExports(entry) {
+  const { metafile } = await build({
+    entryPoints: [entry],
+    bundle: true,
+    metafile: true,
+    write: false,
+    format: 'esm',
+    packages: 'external',
+    logLevel: 'silent',
+  });
+  const output = Object.values(metafile.outputs).find((out) => out.entryPoint);
+  return (output?.exports ?? []).filter((exported) => exported !== 'default').sort();
+}
+
 /**
- * List a package's public subpaths and the built `dist` entry each resolves to.
+ * List a package's explicit (non-pattern) subpath exports and the built entry
+ * each resolves to.
  *
  * @param   {Record<string, unknown>} exports
- * @param   {string} pkgDir
+ * @param   {string} manifestDir
  * @returns {{ subpath: string, entry: string }[]}
  */
-function publicEntries(exports, manifestDir) {
+function publicSubpaths(exports, manifestDir) {
   return Object.entries(exports)
     .filter(([key]) => key === '.' || (key.startsWith('./') && !key.includes('*') && key !== './package.json'))
     .filter(([, value]) => value && typeof value === 'object' && 'import' in value)
@@ -50,29 +92,35 @@ async function measure(pkg) {
   const manifestPath = existsSync(distManifest) ? distManifest : resolve(pkgDir, 'package.json');
   const manifestDir = dirname(manifestPath);
   const { exports } = JSON.parse(readFileSync(manifestPath, 'utf8'));
-  const entries = [];
-  for (const { subpath, entry } of publicEntries(exports, manifestDir)) {
-    const result = await build({
-      entryPoints: [entry],
-      bundle: true,
-      minify: true,
-      format: 'esm',
-      platform: 'neutral',
-      // Leave every bare import (peers, third-party) external so the measurement
-      // reflects the package's own shipped code, not its dependencies.
-      packages: 'external',
-      write: false,
-      logLevel: 'silent',
-    });
-    const { contents } = result.outputFiles[0];
-    entries.push({
-      subpath,
-      raw: contents.length,
-      gzip: gzipSync(contents).length,
-      brotli: brotliSize(contents),
+
+  const barrelEntry = resolve(manifestDir, exports['.'].import);
+  const resolveDir = dirname(barrelEntry);
+  const names = await barrelExports(barrelEntry);
+
+  // One row per unique export name; a name seen again (e.g. a barrel export that
+  // also has its own subpath) is skipped since it is the same code, same size.
+  const byName = new Map();
+  async function record(exportName, options) {
+    if (!byName.has(exportName)) byName.set(exportName, { subpath: exportName, ...(await sizeOf(options)) });
+  }
+
+  // The whole barrel, then every named export tree-shaken out of it.
+  await record('.', { entryPoints: [barrelEntry] });
+  for (const name of names) {
+    await record(name, {
+      stdin: { contents: `export { ${name} } from ${JSON.stringify(barrelEntry)}`, resolveDir, loader: 'js' },
     });
   }
-  entries.sort((a, b) => b.gzip - a.gzip);
+
+  // Explicit subpaths that are not barrel exports — side-effect and non-barrel
+  // entries such as `autoload` and `manifest` — measured from their own entry.
+  for (const { subpath, entry } of publicSubpaths(exports, manifestDir)) {
+    const name = subpath === '.' ? '.' : subpath.replace(/^\.\//, '');
+    if (byName.has(name)) continue;
+    await record(name, { entryPoints: [entry] });
+  }
+
+  const entries = [...byName.values()].sort((a, b) => b.gzip - a.gzip);
   return { name: pkg.name, entries };
 }
 

--- a/scripts/export-size.mjs
+++ b/scripts/export-size.mjs
@@ -124,8 +124,9 @@ async function measure(pkg) {
   return { name: pkg.name, entries };
 }
 
+// Bytes under 1 kB, kB above with trailing zeros trimmed (matching the comment).
 function kib(bytes) {
-  return `${(bytes / 1024).toFixed(2)} kB`;
+  return bytes < 1024 ? `${bytes} B` : `${parseFloat((bytes / 1024).toFixed(2))} kB`;
 }
 
 const report = [];


### PR DESCRIPTION
Improves the local export-size check to measure **each named export as it is consumed from the barrel** — `import { X } from '@studiometa/ui'` — by tree-shaking the single symbol out of the built barrel, rather than measuring one flat subpath entry per module.

## Changes

- `scripts/export-size.mjs` — enumerate a package barrel's value exports (via esbuild's metafile), then measure each one tree-shaken from the barrel. The whole barrel (`.`) and non-barrel entries (`autoload`, `manifest`) are still measured from their own entry. Results are keyed by export name and measured **once**, so a symbol reachable from both the barrel and its own subpath collapses to a single row (they are the same code, same size).
- `scripts/export-size-comment.mjs` — normalize entry keys (`./Modal` → `Modal`) so an older subpath-based baseline still lines up with the new named-export report in the diff.

## Notes

- Verified locally: tree-shaking `Modal` from the barrel yields the same size as the old `./Modal` subpath (~1.16 kB gzip), confirming the merge assumption.
- Because `main` still runs the subpath-based script, this PR's diff comment will show a small transition (a few B deltas from barrel-vs-subpath bundling, plus a handful of non-aligning add/remove rows). Subsequent PRs will diff cleanly per named export.

🤖 Generated with [Claude Code](https://claude.com/claude-code)