### PR TITLE
Prepare the 1.10.0 stable release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,10 @@ This release promotes the `1.10.0` beta line to stable. It bundles every change 
 
 ### Added
 
+- **@studiometa/ui-mapbox:** add the new `@studiometa/ui-mapbox` package — the `@studiometa/vue-mapbox-gl` components ported to js-toolkit (`MapboxMap`, `MapboxMarker`, `MapboxPopup`, `MapboxCluster`, `MapboxSource`, `MapboxLayer`, `MapboxImage`, the control components, `MapboxGeocoder` and `StoreLocator`), each exposed at its own subpath, e.g. `@studiometa/ui-mapbox/MapboxMap` ([#561](https://github.com/studiometa/ui/pull/561), [#620](https://github.com/studiometa/ui/pull/620))
+- **@studiometa/ui-mapbox:** resolve the `mapbox-gl` peer dependency (and the optional geocoder) with a lazy `import()` on first map build, or let a host supply its own instance with `provideMapboxGl` / `provideMapboxGeocoder` ([#575](https://github.com/studiometa/ui/pull/575))
 - **Autoloading:** add the `@studiometa/ui/autoload` and `@studiometa/ui-mapbox/autoload` side-effect entries, registering each package's manifest with the `@studiometa/js-toolkit` autoload runtime for declarative, no-build usage ([#598](https://github.com/studiometa/ui/pull/598), [#614](https://github.com/studiometa/ui/pull/614), [#617](https://github.com/studiometa/ui/pull/617))
 - **Toaster:** add the `Toaster` and `Toast` components — a headless notifications region built on two `aria-live` regions, each toast a `Timer`-based `Toast` with a pausable auto-dismiss countdown ([#572](https://github.com/studiometa/ui/pull/572))
-- **Mapbox:** add `provideMapboxGl` / `provideMapboxGeocoder` injection and their resolvers so a host can supply its own `mapbox-gl` instance, otherwise resolved with a lazy `import()` on first map build ([#575](https://github.com/studiometa/ui/pull/575))
-- **@studiometa/ui-mapbox:** expose each component at its own explicit subpath, e.g. `@studiometa/ui-mapbox/MapboxMap` ([#620](https://github.com/studiometa/ui/pull/620))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,27 +8,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [v1.10.0](https://github.com/studiometa/ui/compare/1.9.0..1.10.0) (2026-08-11)
 
-This release promotes the `1.10.0` beta line to stable. It bundles every change published across `1.10.0-beta.0` through `1.10.0-beta.6` — see the sections below for the per-beta breakdown and pull request references. The bespoke browser CDN and the `@studiometa/ui-autoload` package explored during the beta line were both superseded before stable: load the packages from an ESM CDN such as [esm.sh](https://esm.sh) with the built-in `/autoload` entries instead — see the [Autoloading guide](https://ui.studiometa.dev/guide/autoloading/).
+This release promotes the `1.10.0` beta line to stable. It bundles every change published across `1.10.0-beta.0` through `1.10.0-beta.6`, see the sections below for the per-beta breakdown and pull request references. The bespoke browser CDN and the `@studiometa/ui-autoload` package explored during the beta line were both superseded before stable: load the packages from an ESM CDN such as [esm.sh](https://esm.sh) with the built-in `/autoload` entries instead, see the [Autoloading guide](https://ui.studiometa.dev/guide/autoloading/).
 
 ### Added
 
-- **@studiometa/ui-mapbox:** add the new `@studiometa/ui-mapbox` package — the `@studiometa/vue-mapbox-gl` components ported to js-toolkit (`MapboxMap`, `MapboxMarker`, `MapboxPopup`, `MapboxCluster`, `MapboxSource`, `MapboxLayer`, `MapboxImage`, the control components, `MapboxGeocoder` and `StoreLocator`), each exposed at its own subpath, e.g. `@studiometa/ui-mapbox/MapboxMap` ([#561](https://github.com/studiometa/ui/pull/561), [#620](https://github.com/studiometa/ui/pull/620))
-- **@studiometa/ui-mapbox:** resolve the `mapbox-gl` peer dependency (and the optional geocoder) with a lazy `import()` on first map build, or let a host supply its own instance with `provideMapboxGl` / `provideMapboxGeocoder` ([#575](https://github.com/studiometa/ui/pull/575))
+- **@studiometa/ui-mapbox:** add a new `@studiometa/ui-mapbox` package with `MapboxMap`, `MapboxMarker`, `MapboxPopup`, `MapboxCluster`, `MapboxSource`, `MapboxLayer`, `MapboxImage`, the control components, `MapboxGeocoder` and `StoreLocator` components ([#561](https://github.com/studiometa/ui/pull/561), [#620](https://github.com/studiometa/ui/pull/620))
 - **Autoloading:** add the `@studiometa/ui/autoload` and `@studiometa/ui-mapbox/autoload` side-effect entries, registering each package's manifest with the `@studiometa/js-toolkit` autoload runtime for declarative, no-build usage ([#598](https://github.com/studiometa/ui/pull/598), [#614](https://github.com/studiometa/ui/pull/614), [#617](https://github.com/studiometa/ui/pull/617))
 - **Toaster:** add the `Toaster` and `Toast` components — a headless notifications region built on two `aria-live` regions, each toast a `Timer`-based `Toast` with a pausable auto-dismiss countdown ([#572](https://github.com/studiometa/ui/pull/572))
 
 ### Changed
 
 - Require `@studiometa/js-toolkit` `^3.9.0` as a peer dependency ([#617](https://github.com/studiometa/ui/pull/617))
-- **@studiometa/ui, @studiometa/ui-mapbox:** replace every `export *` barrel re-export with explicit named exports so the public surface is statically analyzable ([#611](https://github.com/studiometa/ui/pull/611))
-- **@studiometa/ui, @studiometa/ui-mapbox:** import js-toolkit values from their per-symbol subpaths instead of the package barrel, shrinking every component's esm.sh footprint ([#619](https://github.com/studiometa/ui/pull/619))
-- **@studiometa/ui, @studiometa/ui-mapbox:** move sources under `src/`, build to `dist/`, and publish the package folder with a single root `package.json` ([#620](https://github.com/studiometa/ui/pull/620))
+- Replace every `export *` barrel re-export with explicit named exports so the public surface is statically analyzable ([#611](https://github.com/studiometa/ui/pull/611))
+- Import js-toolkit values from their per-symbol subpaths instead of the package barrel, shrinking every component's esm.sh footprint ([#619](https://github.com/studiometa/ui/pull/619))
+- Move sources under `src/`, build to `dist/`, and publish the package folder with a single root `package.json` ([#620](https://github.com/studiometa/ui/pull/620))
 - **Build:** migrate the library builds from esbuild to tsdown ([#585](https://github.com/studiometa/ui/pull/585))
-- **Release:** publish the npm packages with tokenless trusted publishing (OIDC provenance) ([#586](https://github.com/studiometa/ui/pull/586))
-
-### Removed
-
-- **@studiometa/ui, @studiometa/ui-mapbox:** remove the redundant `.js` subpath exports; use the extensionless subpaths instead ([#620](https://github.com/studiometa/ui/pull/620))
 
 ## [v1.10.0-beta.6](https://github.com/studiometa/ui/compare/1.10.0-beta.5..1.10.0-beta.6) (2026-08-10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [v1.10.0](https://github.com/studiometa/ui/compare/1.9.0..1.10.0) (2026-08-11)
+
+This release promotes the `1.10.0` beta line to stable. It bundles every change published across `1.10.0-beta.0` through `1.10.0-beta.6` — see the sections below for the per-beta breakdown and pull request references. The bespoke browser CDN and the `@studiometa/ui-autoload` package explored during the beta line were both superseded before stable: load the packages from an ESM CDN such as [esm.sh](https://esm.sh) with the built-in `/autoload` entries instead — see the [Autoloading guide](https://ui.studiometa.dev/guide/autoloading/).
+
+### Added
+
+- **Autoloading:** add the `@studiometa/ui/autoload` and `@studiometa/ui-mapbox/autoload` side-effect entries, registering each package's manifest with the `@studiometa/js-toolkit` autoload runtime for declarative, no-build usage ([#598](https://github.com/studiometa/ui/pull/598), [#614](https://github.com/studiometa/ui/pull/614), [#617](https://github.com/studiometa/ui/pull/617))
+- **Toaster:** add the `Toaster` and `Toast` components — a headless notifications region built on two `aria-live` regions, each toast a `Timer`-based `Toast` with a pausable auto-dismiss countdown ([#572](https://github.com/studiometa/ui/pull/572))
+- **Mapbox:** add `provideMapboxGl` / `provideMapboxGeocoder` injection and their resolvers so a host can supply its own `mapbox-gl` instance, otherwise resolved with a lazy `import()` on first map build ([#575](https://github.com/studiometa/ui/pull/575))
+- **@studiometa/ui-mapbox:** expose each component at its own explicit subpath, e.g. `@studiometa/ui-mapbox/MapboxMap` ([#620](https://github.com/studiometa/ui/pull/620))
+
+### Changed
+
+- Require `@studiometa/js-toolkit` `^3.9.0` as a peer dependency ([#617](https://github.com/studiometa/ui/pull/617))
+- **@studiometa/ui, @studiometa/ui-mapbox:** replace every `export *` barrel re-export with explicit named exports so the public surface is statically analyzable ([#611](https://github.com/studiometa/ui/pull/611))
+- **@studiometa/ui, @studiometa/ui-mapbox:** import js-toolkit values from their per-symbol subpaths instead of the package barrel, shrinking every component's esm.sh footprint ([#619](https://github.com/studiometa/ui/pull/619))
+- **@studiometa/ui, @studiometa/ui-mapbox:** move sources under `src/`, build to `dist/`, and publish the package folder with a single root `package.json` ([#620](https://github.com/studiometa/ui/pull/620))
+- **Build:** migrate the library builds from esbuild to tsdown ([#585](https://github.com/studiometa/ui/pull/585))
+- **Release:** publish the npm packages with tokenless trusted publishing (OIDC provenance) ([#586](https://github.com/studiometa/ui/pull/586))
+
+### Removed
+
+- **@studiometa/ui, @studiometa/ui-mapbox:** remove the redundant `.js` subpath exports; use the extensionless subpaths instead ([#620](https://github.com/studiometa/ui/pull/620))
+
 ## [v1.10.0-beta.6](https://github.com/studiometa/ui/compare/1.10.0-beta.5..1.10.0-beta.6) (2026-08-10)
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "studiometa/ui",
   "type": "composer-plugin",
-  "version": "1.10.0-beta.6",
+  "version": "1.10.0",
   "description": "Accessible and composable JavaScript behaviors and Twig templates.",
   "license": "MIT",
   "require": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@studiometa/ui-workspace",
-  "version": "1.10.0-beta.6",
+  "version": "1.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@studiometa/ui-workspace",
-      "version": "1.10.0-beta.6",
+      "version": "1.10.0",
       "hasInstallScript": true,
       "workspaces": [
         "packages/*"
@@ -22343,11 +22343,11 @@
     },
     "packages/api": {
       "name": "@studiometa/ui-api",
-      "version": "1.10.0-beta.6"
+      "version": "1.10.0"
     },
     "packages/docs": {
       "name": "@studiometa/ui-docs",
-      "version": "1.10.0-beta.6",
+      "version": "1.10.0",
       "dependencies": {
         "@studiometa/js-toolkit": "3.9.0"
       },
@@ -22473,7 +22473,7 @@
     },
     "packages/eslint-plugin-ui": {
       "name": "@studiometa/eslint-plugin-ui",
-      "version": "1.10.0-beta.6",
+      "version": "1.10.0",
       "license": "MIT",
       "dependencies": {
         "@oxlint/plugins": "1.63.0"
@@ -22488,7 +22488,7 @@
     },
     "packages/playground": {
       "name": "@studiometa/ui-playground",
-      "version": "1.10.0-beta.6",
+      "version": "1.10.0",
       "dependencies": {
         "@studiometa/playground": "^0.3.13"
       },
@@ -22504,7 +22504,7 @@
     },
     "packages/tests": {
       "name": "@studiometa/ui-tests",
-      "version": "1.10.0-beta.6",
+      "version": "1.10.0",
       "license": "MIT",
       "dependencies": {
         "@happy-dom/global-registrator": "^20.8.8",
@@ -22734,7 +22734,7 @@
     },
     "packages/ui": {
       "name": "@studiometa/ui",
-      "version": "1.10.0-beta.6",
+      "version": "1.10.0",
       "license": "MIT",
       "dependencies": {
         "alien-signals": "^3.2.1",
@@ -22757,7 +22757,7 @@
     },
     "packages/ui-mapbox": {
       "name": "@studiometa/ui-mapbox",
-      "version": "1.10.0-beta.6",
+      "version": "1.10.0",
       "license": "MIT",
       "devDependencies": {
         "@mapbox/mapbox-gl-geocoder": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-workspace",
-  "version": "1.10.0-beta.6",
+  "version": "1.10.0",
   "type": "module",
   "private": true,
   "workspaces": [

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-api",
-  "version": "1.10.0-beta.6",
+  "version": "1.10.0",
   "private": true,
   "type": "commonjs"
 }

--- a/packages/docs/guide/autoloading/index.md
+++ b/packages/docs/guide/autoloading/index.md
@@ -12,7 +12,7 @@ Add a module script. Import the `@studiometa/ui/autoload` entry. The import regi
 
 ```html
 <script type="module">
-  import 'https://esm.sh/@studiometa/ui@next/autoload';
+  import 'https://esm.sh/@studiometa/ui@latest/autoload';
 </script>
 
 <button
@@ -25,7 +25,7 @@ Add a module script. Import the `@studiometa/ui/autoload` entry. The import regi
 
 The runtime scans the document for `data-component` tokens, imports the matching modules, and registers them with the [js-toolkit](https://js-toolkit.studiometa.dev) runtime. The declarative contract (`data-component`, `data-ref`, `data-option-*`) is the same one that [Declarative runtime](/guide/concepts/declarative-runtime) describes.
 
-Use `@next` or an exact version during the prerelease line. See [Version pinning](#version-pinning).
+Pin an exact version in production. See [Version pinning](#version-pinning).
 
 ## Activate a package
 
@@ -33,8 +33,8 @@ Import one side-effect entry for each component package you use. Each import reg
 
 ```html
 <script type="module">
-  import 'https://esm.sh/@studiometa/ui@next/autoload'; // @studiometa/ui components
-  import 'https://esm.sh/@studiometa/ui-mapbox@next/autoload'; // @studiometa/ui-mapbox components
+  import 'https://esm.sh/@studiometa/ui@latest/autoload'; // @studiometa/ui components
+  import 'https://esm.sh/@studiometa/ui-mapbox@latest/autoload'; // @studiometa/ui-mapbox components
 </script>
 ```
 
@@ -55,13 +55,13 @@ A version reference follows the package's npm tags and semver ranges:
 
 ```html
 <script type="module">
-  import 'https://esm.sh/@studiometa/ui@next/autoload'; // current prerelease
-  import 'https://esm.sh/@studiometa/ui@1.10.0-beta.5/autoload'; // exact version
+  import 'https://esm.sh/@studiometa/ui@latest/autoload'; // latest stable release
+  import 'https://esm.sh/@studiometa/ui@1.10.0/autoload'; // exact version
   import 'https://esm.sh/@studiometa/ui@^1/autoload'; // semver range
 </script>
 ```
 
-Pin an exact version in production. An exact-version URL is immutable and stays cached the longest, and it makes every entry on the page resolve to the same version. A versionless URL follows the `latest` stable tag, so use `@next` or an exact version until a stable `1.x` release exists.
+Pin an exact version in production. An exact-version URL is immutable and stays cached the longest, and it makes every entry on the page resolve to the same version. A versionless URL and `@latest` follow the latest stable release.
 
 ## Loading strategies
 
@@ -129,8 +129,8 @@ To autoload your own js-toolkit components, build a manifest from your component
 You can also import components directly from the CDN, without the autoloader. This suits a script that builds components itself.
 
 ```js
-import { Action, Modal } from 'https://esm.sh/@studiometa/ui@1.10.0-beta.5'; // the whole surface
-import { Action } from 'https://esm.sh/@studiometa/ui@1.10.0-beta.5/Action'; // one component
+import { Action, Modal } from 'https://esm.sh/@studiometa/ui@1.10.0'; // the whole surface
+import { Action } from 'https://esm.sh/@studiometa/ui@1.10.0/Action'; // one component
 ```
 
 Manual imports and the autoloader do not conflict, while every import on the page resolves to one js-toolkit runtime. Pin the same version everywhere.
@@ -151,8 +151,8 @@ Declare an [import map](https://developer.mozilla.org/en-US/docs/Web/HTML/Elemen
   }
 </script>
 <script type="module">
-  import 'https://esm.sh/@studiometa/ui@next/autoload';
-  import 'https://esm.sh/@studiometa/ui-mapbox@next/autoload';
+  import 'https://esm.sh/@studiometa/ui@latest/autoload';
+  import 'https://esm.sh/@studiometa/ui-mapbox@latest/autoload';
 </script>
 ```
 

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-docs",
-  "version": "1.10.0-beta.6",
+  "version": "1.10.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/eslint-plugin-ui/package.json
+++ b/packages/eslint-plugin-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/eslint-plugin-ui",
-  "version": "1.10.0-beta.6",
+  "version": "1.10.0",
   "description": "ESLint plugin to help developers discover and use @studiometa/ui components",
   "publishConfig": {
     "access": "public"

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-playground",
-  "version": "1.10.0-beta.6",
+  "version": "1.10.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-tests",
-  "version": "1.10.0-beta.6",
+  "version": "1.10.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/ui-mapbox/package.json
+++ b/packages/ui-mapbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-mapbox",
-  "version": "1.10.0-beta.6",
+  "version": "1.10.0",
   "description": "Vanilla js-toolkit components to build Mapbox GL maps declaratively",
   "publishConfig": {
     "access": "public"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui",
-  "version": "1.10.0-beta.6",
+  "version": "1.10.0",
   "description": "Accessible and composable JavaScript behaviors and templates",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary

Prepare the `1.10.0` stable release, promoting the `1.10.0-beta.x` line.

- **Update the autoloading guide** for the stable release: the esm.sh examples now use `@latest` instead of `@next`, the pinned examples use `1.10.0` instead of `1.10.0-beta.5`, and the prerelease-era version-pinning notes are gone.
- **Add the `1.10.0` changelog entry**, consolidating the changes from `beta.0` through `beta.6` like the `1.9.0` entry did. The entry describes the net changes against `1.9.0`, so the browser CDN and `@studiometa/ui-autoload` package — added and removed within the beta line — only appear in the intro note.
- **Prepare 1.10.0**: bump the version to `1.10.0` in `composer.json`, the root and workspace `package.json` files, and the lockfile.

## Release steps after merge

1. Tag the merge commit with `1.10.0` and push the tag.
2. The `release` workflow publishes `@studiometa/ui`, `@studiometa/eslint-plugin-ui` and `@studiometa/ui-mapbox` under the `latest` npm tag and creates the GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HKLcgvaDcjK9ohA3fg7Ssq