### PR TITLE
Make the Dialog open and close events extendable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 
 - **DataBind:** sync late-mounted `immediate` keyed subscribers with the current scoped value ([#626](https://github.com/studiometa/ui/pull/626))
+- **Dialog:** make the `open` and `close` events extendable with `event.detail.waitUntil()` so any component can join the open and close choreography
 
 ## [v1.10.0](https://github.com/studiometa/ui/compare/1.9.0..1.10.0) (2026-08-11)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 
 - **DataBind:** sync late-mounted `immediate` keyed subscribers with the current scoped value ([#626](https://github.com/studiometa/ui/pull/626))
-- **Dialog:** make the `open` and `close` events extendable with `event.detail.waitUntil()` so any component can join the open and close choreography
+- **Dialog:** make the `open` and `close` events extendable with `event.detail.waitUntil()` so any component can join the open and close choreography ([#627](https://github.com/studiometa/ui/pull/627))
 
 ## [v1.10.0](https://github.com/studiometa/ui/compare/1.9.0..1.10.0) (2026-08-11)
 

--- a/packages/docs/reference/items/Dialog/js-api.md
+++ b/packages/docs/reference/items/Dialog/js-api.md
@@ -67,13 +67,13 @@ A getter returning every [`Transition`](/reference/items/Transition/) and [`View
 
 - Returns `Promise<void>`
 
-Open the dialog: call `showModal()` (or `show()` when `modal` is `false`), lock the scroll, emit `open`, then run every child's `enter()`. A no-op if the dialog is already open. Resolves once the enter transitions have finished.
+Open the dialog: call `showModal()` (or `show()` when `modal` is `false`), lock the scroll, emit `open`, then run every child's `enter()` alongside the [`waitUntil` extensions](#extending-the-choreography-with-waituntil). A no-op if the dialog is already open. Resolves once the enter choreography has finished.
 
 ### `close`
 
 - Returns `Promise<void>`
 
-Close the dialog: emit `close`, run every child's `leave()`, **then** call `dialog.close()`, release the focus-trap (non-modal path) and unlock the scroll. A no-op if the dialog is already closed. Resolves once closed.
+Close the dialog: emit `close`, run every child's `leave()` alongside the [`waitUntil` extensions](#extending-the-choreography-with-waituntil), **then** call `dialog.close()`, release the focus-trap (non-modal path) and unlock the scroll. A no-op if the dialog is already closed, and concurrent calls await the same run. Resolves once closed.
 
 ### `toggle`
 
@@ -85,8 +85,28 @@ Call `close()` if the dialog is open, `open()` otherwise.
 
 ### `open`
 
-Emitted when the dialog starts opening, before the enter transitions run.
+Emitted when the dialog starts opening, before the enter transitions run. The `detail` carries a [`waitUntil`](#extending-the-choreography-with-waituntil) function.
 
 ### `close`
 
-Emitted when the dialog starts closing, before the leave transitions run.
+Emitted when the dialog starts closing, before the leave transitions run. The `detail` carries a [`waitUntil`](#extending-the-choreography-with-waituntil) function.
+
+## Extending the choreography with `waitUntil`
+
+Both lifecycle events expose `event.detail.waitUntil(promise)`, modeled on the Service Worker [`ExtendableEvent`](https://developer.mozilla.org/en-US/docs/Web/API/ExtendableEvent/waitUntil). Any listener can register a promise while the event dispatches, and the dialog awaits it alongside its transition children — on `close`, the native dialog stays painted until every registered promise settles. This lets any component participate in the open and close choreography without being a declared child.
+
+For example, a `Motion` box (from `@studiometa/ui-motion`) can spring in and out with the dialog through two [`Action`](/reference/items/Action/) attributes:
+
+<!-- prettier-ignore-start -->
+```html {3,4}
+<dialog
+  data-component="Action Dialog"
+  data-on:open="Motion(#box)->event.detail.waitUntil(target.play())"
+  data-on:close="Motion(#box)->event.detail.waitUntil(target.reverse())"
+  data-on:cancel.prevent="Dialog.close()">
+  …
+</dialog>
+```
+<!-- prettier-ignore-end -->
+
+Registration is only valid synchronously, while the event dispatches; later calls warn and are ignored.

--- a/packages/docs/reference/items/Dialog/js-api.md
+++ b/packages/docs/reference/items/Dialog/js-api.md
@@ -109,4 +109,4 @@ For example, a `Motion` box (from `@studiometa/ui-motion`) can spring in and out
 ```
 <!-- prettier-ignore-end -->
 
-Registration is only valid synchronously, while the event dispatches; later calls warn and are ignored.
+Registration is only valid synchronously, while the event dispatches; later calls warn and are ignored. A rejected extension never blocks the choreography: the rejection is reported with a warning and the run completes.

--- a/packages/tests/Dialog/Dialog.spec.ts
+++ b/packages/tests/Dialog/Dialog.spec.ts
@@ -241,6 +241,25 @@ describe('The Dialog component', () => {
     expect(warn).toHaveBeenCalledTimes(1);
   });
 
+  it('should complete the closing choreography when an extension rejects', async () => {
+    const { dialog, el } = await createDialog();
+    const warn = vi.fn();
+    Object.defineProperty(dialog, '$warn', { configurable: true, get: () => warn });
+    dialog.$on('close', (event) => {
+      (event as CustomEvent<{ waitUntil(promise: Promise<unknown>): void }>).detail.waitUntil(
+        Promise.reject(new Error('extension failed')),
+      );
+    });
+
+    await dialog.open();
+    await dialog.close();
+
+    // The rejection is reported, and the dialog still hides and cleans up.
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(el.close).toHaveBeenCalledTimes(1);
+    expect(document.documentElement.style.overflow).toBe('');
+  });
+
   it('should let concurrent close calls await the same run', async () => {
     const { dialog, el } = await createDialog();
     const closeFn = vi.fn();

--- a/packages/tests/Dialog/Dialog.spec.ts
+++ b/packages/tests/Dialog/Dialog.spec.ts
@@ -171,4 +171,91 @@ describe('The Dialog component', () => {
     await dialog.close();
     expect(order).toEqual(['leave', 'close']);
   });
+
+  it('should await promises registered with `waitUntil` on the close event before hiding', async () => {
+    const { dialog, el } = await createDialog();
+    let release: () => void;
+    const extension = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    dialog.$on('close', (event) => {
+      (event as CustomEvent<{ waitUntil(promise: Promise<unknown>): void }>).detail.waitUntil(
+        extension,
+      );
+    });
+
+    await dialog.open();
+    const closing = dialog.close();
+    // The extension is pending: the native dialog must still be open.
+    await Promise.resolve();
+    expect(el.close).not.toHaveBeenCalled();
+
+    release();
+    await closing;
+    expect(el.close).toHaveBeenCalledTimes(1);
+  });
+
+  it('should await promises registered with `waitUntil` on the open event', async () => {
+    const { dialog } = await createDialog();
+    let release: () => void;
+    const extension = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    dialog.$on('open', (event) => {
+      (event as CustomEvent<{ waitUntil(promise: Promise<unknown>): void }>).detail.waitUntil(
+        extension,
+      );
+    });
+
+    let opened = false;
+    const opening = dialog.open().then(() => {
+      opened = true;
+    });
+    // The native dialog shows immediately; only the promise resolution waits.
+    expect(dialog.dialog.open).toBe(true);
+    await Promise.resolve();
+    expect(opened).toBe(false);
+
+    release();
+    await opening;
+    expect(opened).toBe(true);
+  });
+
+  it('should ignore and warn on `waitUntil` calls after the event dispatched', async () => {
+    const { dialog, el } = await createDialog();
+    // `$warn` is a prototype getter: shadow it on the instance to observe calls.
+    const warn = vi.fn();
+    Object.defineProperty(dialog, '$warn', { configurable: true, get: () => warn });
+    let waitUntil: (promise: Promise<unknown>) => void;
+    dialog.$on('close', (event) => {
+      ({ waitUntil } = (event as CustomEvent<{ waitUntil(promise: Promise<unknown>): void }>)
+        .detail);
+    });
+
+    await dialog.open();
+    await dialog.close();
+    expect(el.close).toHaveBeenCalledTimes(1);
+
+    // A late registration must not wedge anything and must warn.
+    waitUntil(new Promise(() => {}));
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  it('should let concurrent close calls await the same run', async () => {
+    const { dialog, el } = await createDialog();
+    const closeFn = vi.fn();
+    dialog.$on('close', (event) => {
+      closeFn();
+      (event as CustomEvent<{ waitUntil(promise: Promise<unknown>): void }>).detail.waitUntil(
+        Promise.resolve(),
+      );
+    });
+
+    await dialog.open();
+    await Promise.all([dialog.close(), dialog.close()]);
+
+    // One choreography: one close event, one native hide.
+    expect(closeFn).toHaveBeenCalledTimes(1);
+    expect(el.close).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/ui/src/Dialog/Dialog.ts
+++ b/packages/ui/src/Dialog/Dialog.ts
@@ -151,7 +151,10 @@ export class Dialog<T extends BaseProps = BaseProps> extends Base<T & DialogProp
    * `event.detail.waitUntil(promise)` — any component (or plain JavaScript)
    * can hold the dialog open (or its `open()` promise pending) without being
    * a declared child. Registration is only valid while the event dispatches;
-   * later calls warn and are ignored.
+   * later calls warn and are ignored. Every registered promise is wrapped so
+   * a rejection settles with a warning instead of propagating — a failing
+   * extension must never leave the choreography incomplete (native dialog
+   * open, scroll locked).
    * @private
    */
   __emitExtendable(name: 'open' | 'close'): Promise<unknown>[] {
@@ -164,7 +167,11 @@ export class Dialog<T extends BaseProps = BaseProps> extends Base<T & DialogProp
         );
         return;
       }
-      pending.push(promise);
+      pending.push(
+        Promise.resolve(promise).catch((error) => {
+          this.$warn(`An extension of the \`${name}\` event rejected.`, error);
+        }),
+      );
     };
     this.$emit(new CustomEvent(name, { detail: { waitUntil } }));
     dispatching = false;

--- a/packages/ui/src/Dialog/Dialog.ts
+++ b/packages/ui/src/Dialog/Dialog.ts
@@ -62,6 +62,13 @@ export class Dialog<T extends BaseProps = BaseProps> extends Base<T & DialogProp
   };
 
   /**
+   * The in-flight `close()` run, so concurrent calls await the same
+   * choreography instead of racing it.
+   * @private
+   */
+  __closing: Promise<void> | null = null;
+
+  /**
    * Get the native `<dialog>` element.
    */
   get dialog(): HTMLDialogElement {
@@ -98,8 +105,8 @@ export class Dialog<T extends BaseProps = BaseProps> extends Base<T & DialogProp
       document.documentElement.style.overflow = 'hidden';
     }
 
-    this.$emit('open');
-    await Promise.all(this.transitions.map((transition) => transition.enter()));
+    const pending = this.__emitExtendable('open');
+    await Promise.all([...this.transitions.map((transition) => transition.enter()), ...pending]);
   }
 
   /**
@@ -110,10 +117,24 @@ export class Dialog<T extends BaseProps = BaseProps> extends Base<T & DialogProp
       return;
     }
 
-    this.$emit('close');
-    // The leave transitions are awaited **before** the native hide so the
-    // dialog is still painted while its children animate out.
-    await Promise.all(this.transitions.map((transition) => transition.leave()));
+    if (!this.__closing) {
+      this.__closing = this.__close().finally(() => {
+        this.__closing = null;
+      });
+    }
+
+    return this.__closing;
+  }
+
+  /**
+   * Run the closing choreography: collect the `close` event extensions, await
+   * them alongside the leave transitions — the dialog is still painted while
+   * its children animate out — then hide the native dialog.
+   * @private
+   */
+  async __close(): Promise<void> {
+    const pending = this.__emitExtendable('close');
+    await Promise.all([...this.transitions.map((transition) => transition.leave()), ...pending]);
     this.dialog.close();
 
     if (!this.$options.modal && this.$options.trapFocus) {
@@ -123,6 +144,31 @@ export class Dialog<T extends BaseProps = BaseProps> extends Base<T & DialogProp
     if (this.$options.scrollLock) {
       document.documentElement.style.overflow = '';
     }
+  }
+
+  /**
+   * Emit a lifecycle event whose listeners can extend the choreography with
+   * `event.detail.waitUntil(promise)` — any component (or plain JavaScript)
+   * can hold the dialog open (or its `open()` promise pending) without being
+   * a declared child. Registration is only valid while the event dispatches;
+   * later calls warn and are ignored.
+   * @private
+   */
+  __emitExtendable(name: 'open' | 'close'): Promise<unknown>[] {
+    const pending: Promise<unknown>[] = [];
+    let dispatching = true;
+    const waitUntil = (promise: Promise<unknown>) => {
+      if (!dispatching) {
+        this.$warn(
+          `\`waitUntil\` must be called synchronously while the \`${name}\` event dispatches.`,
+        );
+        return;
+      }
+      pending.push(promise);
+    };
+    this.$emit(new CustomEvent(name, { detail: { waitUntil } }));
+    dispatching = false;
+    return pending;
   }
 
   /**


### PR DESCRIPTION
## What

The `Dialog` `open` and `close` events now expose `event.detail.waitUntil(promise)`, modeled on the Service Worker [`ExtendableEvent`](https://developer.mozilla.org/en-US/docs/Web/API/ExtendableEvent/waitUntil). Promises registered while the event dispatches are awaited alongside the `Transition`/`ViewTransition` children — on `close`, the native dialog stays painted until every registered promise settles.

## Why

Any component (or plain JavaScript) can now join the open and close choreography without being a declared child, and without any new option — the contract is convention. First consumer: the `Motion` component from the upcoming `@studiometa/ui-motion` package, which can spring a dialog box in and out through two `Action` attributes:

```html
<dialog
  data-component="Action Dialog"
  data-on:open="Motion(#box)->event.detail.waitUntil(target.play())"
  data-on:close="Motion(#box)->event.detail.waitUntil(target.reverse())"
  data-on:cancel.prevent="Dialog.close()">
  …
</dialog>
```

## Details

- `waitUntil` is only valid synchronously while the event dispatches; later calls warn and are ignored.
- Concurrent `close()` calls await the same memoized run: one `close` event, one native hide.
- Docs: new "Extending the choreography with `waitUntil`" section on the Dialog JS API page. (Its `Motion` link resolves once the `@studiometa/ui-motion` PR lands.)

## Test plan

- 5 new specs in `packages/tests/Dialog/Dialog.spec.ts`: close waits for the extension before hiding, open resolution waits, late `waitUntil` warns and is ignored, concurrent closes share one run.
- Full suite green: 98 files, 802 tests. Lint: 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FVXrJ8idMfvt667yJadvB8