### PR TITLE
Add the hover, press and inView gesture options to Motion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 
 - **@studiometa/ui-motion:** add a new `@studiometa/ui-motion` package with `Motion` and `MotionScrollTimeline` components to animate elements declaratively with [Motion](https://motion.dev) ([#628](https://github.com/studiometa/ui/pull/628))
+- **@studiometa/ui-motion:** add the `hover`, `press` and `inView` gesture options to `Motion`
 - **DataBind:** add the `data-bind:if` virtual binding to render `<template>` content conditionally ([#626](https://github.com/studiometa/ui/pull/626))
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 
 - **@studiometa/ui-motion:** add a new `@studiometa/ui-motion` package with `Motion` and `MotionScrollTimeline` components to animate elements declaratively with [Motion](https://motion.dev) ([#628](https://github.com/studiometa/ui/pull/628))
-- **@studiometa/ui-motion:** add the `hover`, `press` and `inView` gesture options to `Motion`
+- **@studiometa/ui-motion:** add the `hover`, `press` and `inView` gesture options to `Motion` ([#629](https://github.com/studiometa/ui/pull/629))
 - **DataBind:** add the `data-bind:if` virtual binding to render `<template>` content conditionally ([#626](https://github.com/studiometa/ui/pull/626))
 
 ### Changed

--- a/packages/docs/reference/items/Motion/examples.md
+++ b/packages/docs/reference/items/Motion/examples.md
@@ -67,6 +67,27 @@ The `motion-*` events bubble, so a single routing [`Action`](/reference/items/Ac
 
 </llm-only>
 
+## Gestures
+
+The `hover`, `press` and `inView` options apply keyframes while their state holds, through Motion's own gesture functions: hover filters out touch emulation, press responds to pointer and keyboard alike, and in-view uses a real `IntersectionObserver`. When the state ends, the gesture animation plays backward — no base values to declare.
+
+<llm-exclude>
+  <PreviewPlayground
+    :html="() => import('./stories/gestures/app.twig')"
+    :script="() => import('./stories/gestures/app.js?raw')"
+    />
+</llm-exclude>
+<llm-only>
+
+:::code-group
+
+<<< ./stories/gestures/app.twig
+<<< ./stories/gestures/app.js
+
+:::
+
+</llm-only>
+
 ## Spring entrance and exit for a `Dialog`
 
 The [`Dialog`](/reference/items/Dialog/) component handles the top layer, focus and scroll lock, and its lifecycle events are [extendable](/reference/items/Dialog/js-api#extending-the-choreography-with-waituntil): registering a promise with `event.detail.waitUntil()` makes the dialog wait for it. The `open` event plays a spring entrance on the `Motion` box, the `close` event plays it in reverse, and the dialog stays painted until the exit settles — physics a CSS transition cannot express. Every closing interaction (button, backdrop, <kbd>Esc</kbd>) just calls `Dialog.close()`.

--- a/packages/docs/reference/items/Motion/js-api.md
+++ b/packages/docs/reference/items/Motion/js-api.md
@@ -73,6 +73,74 @@ Whether the `animate` keyframes play automatically on mount. Since the default i
 ```
 <!-- prettier-ignore-end -->
 
+#### `hover`
+
+- Type: `DOMKeyframesDefinition`
+- Default: `{}`
+
+Keyframes applied while the element is hovered, through Motion's [`hover()`](https://motion.dev/docs/hover) — real hover only, touch emulation is filtered out. When the hover ends, the gesture animation plays backward, returning the element to the styles it had when the gesture began.
+
+<!-- prettier-ignore-start -->
+```html {3}
+<div
+  data-component="Motion"
+  data-option-hover='{ "scale": 1.1 }'>
+  …
+</div>
+```
+<!-- prettier-ignore-end -->
+
+#### `press`
+
+- Type: `DOMKeyframesDefinition`
+- Default: `{}`
+
+Keyframes applied while the element is pressed, through Motion's [`press()`](https://motion.dev/docs/press) — pointer and keyboard alike, so the state is accessible for free. Reverts like `hover` when the press ends.
+
+#### `inView`
+
+- Type: `DOMKeyframesDefinition`
+- Default: `{}`
+
+Keyframes applied when the element enters the viewport, through Motion's [`inView()`](https://motion.dev/docs/inview). Reverts when the element leaves, unless [`once`](#once) is set.
+
+<!-- prettier-ignore-start -->
+```html {3,4}
+<div
+  data-component="Motion"
+  data-option-initial='{ "opacity": 0, "y": 24 }'
+  data-option-in-view='{ "opacity": 1, "y": 0 }'
+  data-option-once>
+  …
+</div>
+```
+<!-- prettier-ignore-end -->
+
+#### `inViewMargin`
+
+- Type: `string`
+- Default: `''`
+
+The viewport margin for the `inView` detection, in CSS margin syntax (e.g. `"-100px"` to trigger 100px inside the viewport).
+
+#### `inViewAmount`
+
+- Type: `'some' | 'all' | number`
+- Default: `'some'`
+
+How much of the element must be visible to trigger `inView`: `"some"`, `"all"`, or a `0`–`1` proportion.
+
+#### `once`
+
+- Type: `boolean`
+- Default: `false`
+
+When set, the `inView` keyframes play once and the reached styles persist — the element is no longer watched.
+
+::: info Gesture animations are transient
+The gesture options animate alongside the declared animation: they never become the [current animation](#methods) and emit no lifecycle events. Like `scroll()`, the gesture functions are not part of `motion/mini` — a gesture option warns and is skipped when the [provided module](#providing-the-motion-dependency) lacks its function.
+:::
+
 ### Events
 
 All events are dispatched as bubbling `CustomEvent`s on the component's element, so they can be listened to with [`Action`](/reference/items/Action/)'s `data-on:<event>` attribute — either on the same element or on an ancestor. Use the `.stop` modifier to contain them.

--- a/packages/docs/reference/items/Motion/stories/gestures/app.js
+++ b/packages/docs/reference/items/Motion/stories/gestures/app.js
@@ -1,0 +1,4 @@
+import { registerComponents } from '@studiometa/js-toolkit';
+import { Motion } from '@studiometa/ui-motion';
+
+registerComponents(Motion);

--- a/packages/docs/reference/items/Motion/stories/gestures/app.twig
+++ b/packages/docs/reference/items/Motion/stories/gestures/app.twig
@@ -1,0 +1,34 @@
+<div class="grid gap-4 justify-items-start">
+  <div
+    data-component="Motion"
+    data-option-hover='{ "scale": 1.1, "rotate": -2 }'
+    data-option-transition='{ "type": "spring", "bounce": 0.5 }'
+    class="px-6 py-4 rounded-lg bg-blue-400 dark:bg-blue-600 text-white font-bold">
+    Hover me
+  </div>
+
+  <button
+    type="button"
+    data-component="Motion"
+    data-option-press='{ "scale": 0.9 }'
+    data-option-transition='{ "type": "spring", "bounce": 0.5 }'
+    class="px-6 py-4 rounded-lg bg-zinc-200 dark:bg-zinc-800 font-bold">
+    Press me (pointer or keyboard)
+  </button>
+
+  <p class="pt-[80vh] text-current/60">
+    Scroll down for the in-view reveal ↓
+  </p>
+
+  <div
+    data-component="Motion"
+    data-option-initial='{ "opacity": 0, "y": 32 }'
+    data-option-in-view='{ "opacity": 1, "y": 0 }'
+    data-option-in-view-amount="0.5"
+    data-option-transition='{ "type": "spring", "bounce": 0.3 }'
+    class="px-6 py-4 rounded-lg bg-emerald-400 dark:bg-emerald-600 text-white font-bold">
+    I reveal in view, and revert when I leave
+  </div>
+
+  <div class="h-[40vh]"></div>
+</div>

--- a/packages/tests/Motion/Motion.gestures.spec.ts
+++ b/packages/tests/Motion/Motion.gestures.spec.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+// Importing the mock injects the `motion` module double through `provideMotion`
+// before the component resolves it below.
+import {
+  animations,
+  mockAnimate,
+  mockHover,
+  mockPress,
+  mockInView,
+  mockMotionModule,
+  resetMockMotion,
+} from './mock-motion.js';
+import { Motion } from '@studiometa/ui-motion';
+import { h, wait } from '#test-utils';
+
+async function mountMotion(attributes: Record<string, string> = {}) {
+  const el = h('div', { dataComponent: 'Motion', ...attributes });
+  const instance = new Motion(el);
+  await instance.$mount();
+  await wait(0);
+
+  return { el, instance };
+}
+
+describe('Motion gesture options', () => {
+  beforeEach(() => {
+    resetMockMotion();
+  });
+
+  it('should bind nothing without gesture options', async () => {
+    await mountMotion({ dataOptionAnimate: '{ "x": 100 }', dataOptionNoAutoplay: '' });
+
+    expect(mockHover.fn).not.toHaveBeenCalled();
+    expect(mockPress.fn).not.toHaveBeenCalled();
+    expect(mockInView.fn).not.toHaveBeenCalled();
+  });
+
+  it('should animate to the hover state and revert by reversing', async () => {
+    const { el, instance } = await mountMotion({
+      dataOptionHover: '{ "scale": 1.1 }',
+      dataOptionTransition: '{ "duration": 0.2 }',
+    });
+
+    expect(mockHover.fn).toHaveBeenCalledTimes(1);
+    expect(mockHover.fn.mock.calls[0][0]).toBe(el);
+
+    // Simulate the gesture start: a transient animation to the hover state.
+    const end = mockHover.handlers[0](el);
+    expect(mockAnimate).toHaveBeenCalledWith(el, { scale: 1.1 }, { duration: 0.2 });
+    // The gesture never becomes the current animation.
+    expect(instance.controls).toBeNull();
+
+    // Simulate the gesture end: the same animation plays backward.
+    const gesture = animations.at(-1);
+    (end as () => void)();
+    expect(gesture.speed).toBe(-1);
+    expect(gesture.playCount).toBe(1);
+  });
+
+  it('should animate to the press state and revert by reversing', async () => {
+    const { el } = await mountMotion({ dataOptionPress: '{ "scale": 0.95 }' });
+
+    expect(mockPress.fn).toHaveBeenCalledTimes(1);
+    const end = mockPress.handlers[0](el);
+    expect(mockAnimate).toHaveBeenCalledWith(el, { scale: 0.95 }, {});
+
+    (end as () => void)();
+    expect(animations.at(-1).speed).toBe(-1);
+  });
+
+  it('should forward the inView options and revert on leave', async () => {
+    const { el } = await mountMotion({
+      dataOptionInView: '{ "opacity": 1 }',
+      dataOptionInViewMargin: '-100px',
+      dataOptionInViewAmount: '0.5',
+    });
+
+    expect(mockInView.fn).toHaveBeenCalledTimes(1);
+    expect(mockInView.optionsCalls[0]).toEqual({ margin: '-100px', amount: 0.5 });
+
+    const leave = mockInView.handlers[0](el);
+    expect(mockAnimate).toHaveBeenCalledWith(el, { opacity: 1 }, {});
+    expect(typeof leave).toBe('function');
+
+    (leave as () => void)();
+    expect(animations.at(-1).speed).toBe(-1);
+  });
+
+  it('should keep the reached state and stop watching with once', async () => {
+    const { el } = await mountMotion({
+      dataOptionInView: '{ "opacity": 1 }',
+      dataOptionInViewAmount: 'all',
+      dataOptionOnce: '',
+    });
+
+    expect(mockInView.optionsCalls[0]).toEqual({ amount: 'all' });
+
+    // No leave handler returned: `inView()` fires once, styles persist.
+    const leave = mockInView.handlers[0](el);
+    expect(leave).toBeUndefined();
+  });
+
+  it('should release the gesture bindings on destroy', async () => {
+    const { instance } = await mountMotion({
+      dataOptionHover: '{ "scale": 1.1 }',
+      dataOptionPress: '{ "scale": 0.95 }',
+    });
+
+    await instance.$destroy();
+    expect(mockHover.stops[0]).toHaveBeenCalledTimes(1);
+    expect(mockPress.stops[0]).toHaveBeenCalledTimes(1);
+  });
+
+  it('should warn per gesture option the module cannot honor', async () => {
+    // Simulate a `motion/mini` build: no gesture functions.
+    mockMotionModule.hover = undefined as never;
+    mockMotionModule.press = undefined as never;
+    mockMotionModule.inView = undefined as never;
+
+    const el = h('div', {
+      dataComponent: 'Motion',
+      dataOptionHover: '{ "scale": 1.1 }',
+      dataOptionInView: '{ "opacity": 1 }',
+    });
+    const instance = new Motion(el);
+    const warn = vi.fn();
+    Object.defineProperty(instance, '$warn', { configurable: true, get: () => warn });
+
+    await instance.$mount();
+    await wait(0);
+
+    expect(warn).toHaveBeenCalledTimes(2);
+    expect(mockAnimate).not.toHaveBeenCalled();
+  });
+});

--- a/packages/tests/Motion/mock-motion.ts
+++ b/packages/tests/Motion/mock-motion.ts
@@ -115,11 +115,48 @@ export const mockScroll = vi.fn(
   },
 );
 
+type GestureStart = (element: Element, info?: unknown) => void | (() => void);
+
 /**
- * The injected module double. Mutable on purpose: specs can delete `scroll`
- * to simulate a `motion/mini` build, then restore it.
+ * A registry per gesture function: the registered start callbacks, so specs
+ * can simulate a gesture (`start()` returns the end handler), plus the stop
+ * spies returned to the component.
  */
-export const mockMotionModule = { animate: mockAnimate, scroll: mockScroll };
+function createGestureMock() {
+  const handlers: GestureStart[] = [];
+  const stops: ReturnType<typeof vi.fn>[] = [];
+  const optionsCalls: unknown[] = [];
+  const fn = vi.fn((element: Element, onStart: GestureStart, options?: unknown) => {
+    handlers.push(onStart);
+    optionsCalls.push(options);
+    const stop = vi.fn();
+    stops.push(stop);
+    return stop;
+  });
+  function reset() {
+    handlers.length = 0;
+    stops.length = 0;
+    optionsCalls.length = 0;
+    fn.mockClear();
+  }
+  return { fn, handlers, stops, optionsCalls, reset };
+}
+
+export const mockHover = createGestureMock();
+export const mockPress = createGestureMock();
+export const mockInView = createGestureMock();
+
+/**
+ * The injected module double. Mutable on purpose: specs can delete members
+ * to simulate a `motion/mini` build, then restore them.
+ */
+export const mockMotionModule = {
+  animate: mockAnimate,
+  scroll: mockScroll,
+  hover: mockHover.fn,
+  press: mockPress.fn,
+  inView: mockInView.fn,
+};
 
 provideMotion(mockMotionModule as unknown as MotionModule);
 
@@ -128,5 +165,11 @@ export function resetMockMotion() {
   scrollLinks.length = 0;
   mockAnimate.mockClear();
   mockScroll.mockClear();
+  mockHover.reset();
+  mockPress.reset();
+  mockInView.reset();
   mockMotionModule.scroll = mockScroll;
+  mockMotionModule.hover = mockHover.fn;
+  mockMotionModule.press = mockPress.fn;
+  mockMotionModule.inView = mockInView.fn;
 }

--- a/packages/ui-motion/README.md
+++ b/packages/ui-motion/README.md
@@ -48,6 +48,12 @@ The `initial` styles are applied on mount, then the `animate` keyframes play aut
 
 The playback API is `play()`, `pause()`, `reverse()`, `seek(progress)`, `stop()`, `cancel()`, `complete()` and `animate(keyframes, options)`. The component emits bubbling `motion-play`, `motion-pause`, `motion-complete`, `motion-cancel` and `motion-stop` events an ancestor `Action` can catch and route.
 
+The `hover`, `press` and `inView` options apply keyframes while their state holds (through Motion's touch-filtered, keyboard-accessible gesture functions) and revert when it ends:
+
+```html
+<div data-component="Motion" data-option-hover='{ "scale": 1.1 }'>Hover me</div>
+```
+
 For scroll-driven animations, wrap `Motion` components in a `MotionScrollTimeline`: the wrapper's traversal of the viewport defines the timeline and every child is bound to that progress with Motion's `scroll()`, hardware-accelerated where the browser supports `ScrollTimeline`:
 
 ```html

--- a/packages/ui-motion/src/Motion.ts
+++ b/packages/ui-motion/src/Motion.ts
@@ -6,6 +6,7 @@ import type {
   DOMKeyframesDefinition,
 } from 'motion';
 import { getMotion, resolveMotion } from './dependencies.js';
+import type { MotionModule } from './dependencies.js';
 
 export interface MotionProps extends BaseProps {
   $options: {
@@ -13,6 +14,12 @@ export interface MotionProps extends BaseProps {
     animate: DOMKeyframesDefinition;
     transition: AnimationOptions;
     autoplay: boolean;
+    hover: DOMKeyframesDefinition;
+    press: DOMKeyframesDefinition;
+    inView: DOMKeyframesDefinition;
+    inViewMargin: string;
+    inViewAmount: string;
+    once: boolean;
   };
 }
 
@@ -48,6 +55,12 @@ export class Motion<T extends BaseProps = BaseProps> extends Base<MotionProps & 
       animate: Object,
       transition: Object,
       autoplay: { type: Boolean, default: true },
+      hover: Object,
+      press: Object,
+      inView: Object,
+      inViewMargin: String,
+      inViewAmount: String,
+      once: Boolean,
     },
   };
 
@@ -63,6 +76,12 @@ export class Motion<T extends BaseProps = BaseProps> extends Base<MotionProps & 
    * @private
    */
   __completionToken = 0;
+
+  /**
+   * The stop function of each gesture binding, released on destroy.
+   * @private
+   */
+  __gestureStops: VoidFunction[] = [];
 
   /**
    * Whether the current animation was built from the `animate` and
@@ -102,7 +121,8 @@ export class Motion<T extends BaseProps = BaseProps> extends Base<MotionProps & 
   }
 
   /**
-   * Apply the `initial` styles, then autoplay the `animate` keyframes.
+   * Apply the `initial` styles, autoplay the `animate` keyframes, then bind
+   * the gesture options.
    */
   async mounted() {
     const { initial, animate, autoplay } = this.$options;
@@ -119,15 +139,23 @@ export class Motion<T extends BaseProps = BaseProps> extends Base<MotionProps & 
     if (autoplay && Object.keys(animate).length > 0) {
       this.play();
     }
+
+    this.__bindGestures(motion);
   }
 
   /**
-   * Stop the current animation on destroy, keeping the styles it reached.
+   * Stop the current animation and release the gesture bindings on destroy,
+   * keeping the styles the animation reached.
    */
   destroyed() {
     this.__completionToken += 1;
     this.__controls?.stop();
     this.__controls = null;
+
+    for (const stop of this.__gestureStops) {
+      stop();
+    }
+    this.__gestureStops = [];
   }
 
   /**
@@ -255,6 +283,104 @@ export class Motion<T extends BaseProps = BaseProps> extends Base<MotionProps & 
    */
   complete() {
     this.__controls?.complete();
+  }
+
+  /**
+   * Bind the `hover`, `press` and `inView` gesture options with Motion's own
+   * gesture functions (touch-filtered, keyboard-accessible press, real
+   * IntersectionObserver). Nothing binds when an option is empty, so idle
+   * elements pay nothing. Gesture animations are transient: they never become
+   * the current animation and emit no lifecycle events.
+   * @private
+   */
+  __bindGestures(motion: MotionModule) {
+    const { hover, press, inView, inViewMargin, inViewAmount, once } = this.$options;
+
+    if (Object.keys(hover).length > 0) {
+      if (motion.hover) {
+        this.__gestureStops.push(
+          motion.hover(this.$el, () => {
+            const controls = this.__startGesture(hover);
+            return () => this.__revertGesture(controls);
+          }),
+        );
+      } else {
+        this.__warnMissingGesture('hover');
+      }
+    }
+
+    if (Object.keys(press).length > 0) {
+      if (motion.press) {
+        this.__gestureStops.push(
+          motion.press(this.$el, () => {
+            const controls = this.__startGesture(press);
+            return () => this.__revertGesture(controls);
+          }),
+        );
+      } else {
+        this.__warnMissingGesture('press');
+      }
+    }
+
+    if (Object.keys(inView).length > 0) {
+      if (motion.inView) {
+        const options: { margin?: string; amount?: 'some' | 'all' | number } = {};
+        if (inViewMargin) {
+          options.margin = inViewMargin;
+        }
+        if (inViewAmount) {
+          const numeric = Number(inViewAmount);
+          options.amount = Number.isNaN(numeric) ? (inViewAmount as 'some' | 'all') : numeric;
+        }
+        this.__gestureStops.push(
+          motion.inView(
+            this.$el,
+            () => {
+              const controls = this.__startGesture(inView);
+              // With no leave handler returned, `inView()` fires once and the
+              // reached styles persist.
+              if (once) {
+                return undefined;
+              }
+              return () => this.__revertGesture(controls);
+            },
+            options as Parameters<NonNullable<MotionModule['inView']>>[2],
+          ),
+        );
+      } else {
+        this.__warnMissingGesture('inView');
+      }
+    }
+  }
+
+  /**
+   * Animate to a gesture state, alongside — not replacing — the current
+   * animation.
+   * @private
+   */
+  __startGesture(keyframes: DOMKeyframesDefinition): AnimationPlaybackControlsWithThen {
+    return getMotion().animate(this.$el, keyframes, this.$options.transition);
+  }
+
+  /**
+   * Revert a gesture by playing its animation backward: the element returns
+   * to the exact styles captured when the gesture started, with no knowledge
+   * of base values needed.
+   * @private
+   */
+  __revertGesture(controls: AnimationPlaybackControlsWithThen) {
+    controls.speed = -Math.abs(controls.speed || 1);
+    controls.play();
+  }
+
+  /**
+   * Warn about a gesture option the resolved motion module cannot honor.
+   * @private
+   */
+  __warnMissingGesture(name: string) {
+    this.$warn(
+      `The resolved motion module has no \`${name}()\` (e.g. \`motion/mini\`). Provide the full \`motion\` entry to use the \`${name}\` option.`,
+    );
   }
 
   /**

--- a/packages/ui-motion/src/dependencies.ts
+++ b/packages/ui-motion/src/dependencies.ts
@@ -1,15 +1,19 @@
-import type { animate, scroll } from 'motion';
+import type { animate, scroll, hover, press, inView } from 'motion';
 
 /**
  * The subset of the `motion` module the components consume. Declared
  * structurally so a host can inject the full `motion` entry, the smaller
  * `motion/mini` entry or any compatible build — only the members listed here
- * are ever read. `scroll` is optional because `motion/mini` does not ship it;
- * only `MotionScrollTimeline` needs it.
+ * are ever read. Everything but `animate` is optional because `motion/mini`
+ * does not ship it: `scroll` powers `MotionScrollTimeline`, and `hover`,
+ * `press` and `inView` power the matching `Motion` gesture options.
  */
 export interface MotionModule {
   animate: typeof animate;
   scroll?: typeof scroll;
+  hover?: typeof hover;
+  press?: typeof press;
+  inView?: typeof inView;
 }
 
 let motionInstance: MotionModule | undefined;


### PR DESCRIPTION
> Stacked on #628 — merge that one first; this PR's base is `feature/ui-motion`.

## What

The motion-v `whileHover` / `whilePress` / `whileInView` story, as three `Motion` options with short names:

```html
<div data-component="Motion" data-option-hover='{ "scale": 1.1 }'>Hover me</div>
<button data-component="Motion" data-option-press='{ "scale": 0.9 }'>Press me</button>
<div
  data-component="Motion"
  data-option-initial='{ "opacity": 0, "y": 24 }'
  data-option-in-view='{ "opacity": 1, "y": 0 }'
  data-option-once>
  …
</div>
```

- Bound through Motion's own gesture functions: `hover()` filters out touch emulation, `press()` responds to pointer **and keyboard** (accessible for free), `inView()` uses a real `IntersectionObserver` with `inViewMargin` / `inViewAmount` / `once` options.
- **Revert by reversing**: when the state ends, the gesture animation plays backward, returning the element to the exact styles captured at gesture start — no base values to declare.
- Gesture animations are transient: they never become the current animation (the `play()`/`reverse()` surface is untouched) and emit no lifecycle events. Empty options bind nothing, so idle elements pay nothing.
- `MotionModule` grows optional `hover`/`press`/`inView` members — `motion/mini` has none of them, so a set option warns and is skipped, same policy as `scroll()`.

## Test plan

- 7 new specs (`Motion.gestures.spec.ts`): zero-cost when unset, start/revert per gesture, `inView` option forwarding and `once` persistence, stop-on-destroy, per-option missing-function warnings.
- Full suite green: 104 files, 841 tests. Lint: 0 errors. Docs validator passing; new "Gestures" live story.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FVXrJ8idMfvt667yJadvB8