### PR TITLE
Add the MotionSequence component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - **@studiometa/ui-motion:** add a new `@studiometa/ui-motion` package with `Motion` and `MotionScrollTimeline` components to animate elements declaratively with [Motion](https://motion.dev) ([#628](https://github.com/studiometa/ui/pull/628))
 - **@studiometa/ui-motion:** add the `hover`, `press` and `inView` gesture options to `Motion` ([#629](https://github.com/studiometa/ui/pull/629))
-- **@studiometa/ui-motion:** add the `MotionSequence` component to orchestrate `Motion` children as one staggered timeline
+- **@studiometa/ui-motion:** add the `MotionSequence` component to orchestrate `Motion` children as one staggered timeline ([#630](https://github.com/studiometa/ui/pull/630))
 - **DataBind:** add the `data-bind:if` virtual binding to render `<template>` content conditionally ([#626](https://github.com/studiometa/ui/pull/626))
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - **@studiometa/ui-motion:** add a new `@studiometa/ui-motion` package with `Motion` and `MotionScrollTimeline` components to animate elements declaratively with [Motion](https://motion.dev) ([#628](https://github.com/studiometa/ui/pull/628))
 - **@studiometa/ui-motion:** add the `hover`, `press` and `inView` gesture options to `Motion` ([#629](https://github.com/studiometa/ui/pull/629))
+- **@studiometa/ui-motion:** add the `MotionSequence` component to orchestrate `Motion` children as one staggered timeline
 - **DataBind:** add the `data-bind:if` virtual binding to render `<template>` content conditionally ([#626](https://github.com/studiometa/ui/pull/626))
 
 ### Changed

--- a/packages/docs/.vitepress/reference/catalog.ts
+++ b/packages/docs/.vitepress/reference/catalog.ts
@@ -997,6 +997,7 @@ export const referenceCatalog = [
         'MotionScrollTimeline',
         '/reference/items/Motion/js-api#motionscrolltimeline',
       ),
+      motionSymbol('MotionSequence', '/reference/items/Motion/js-api#motionsequence'),
       motionSymbol(
         'provideMotion',
         '/reference/items/Motion/js-api#providing-the-motion-dependency',

--- a/packages/docs/.vitepress/reference/public-contracts.ts
+++ b/packages/docs/.vitepress/reference/public-contracts.ts
@@ -910,4 +910,12 @@ export const publicContractSymbols = [
     href: '/reference/items/Motion/js-api',
     status: 'stable',
   },
+  {
+    name: 'MotionSequenceProps',
+    kind: 'type',
+    package: 'npm:@studiometa/ui-motion',
+    importPath: '@studiometa/ui-motion',
+    href: '/reference/items/Motion/js-api',
+    status: 'stable',
+  },
 ] satisfies ReferenceSymbol[];

--- a/packages/docs/reference/items/Motion/examples.md
+++ b/packages/docs/reference/items/Motion/examples.md
@@ -130,6 +130,27 @@ A single element carries `Action`, `Motion` and [`TimerProgress`](/reference/ite
 
 </llm-only>
 
+## Staggered sequence
+
+[`MotionSequence`](./js-api#motionsequence) composes its `Motion` children into one timeline: the `stagger` option spreads the first three items, the finale positions itself with `data-option-at="+0.2"`, and one `Action` target plays or reverses the entire choreography — a single animation under the hood.
+
+<llm-exclude>
+  <PreviewPlayground
+    :html="() => import('./stories/sequence/app.twig')"
+    :script="() => import('./stories/sequence/app.js?raw')"
+    />
+</llm-exclude>
+<llm-only>
+
+:::code-group
+
+<<< ./stories/sequence/app.twig
+<<< ./stories/sequence/app.js
+
+:::
+
+</llm-only>
+
 ## Scroll-driven timeline
 
 [`MotionScrollTimeline`](./js-api#motionscrolltimeline) separates the timeline from the animations, like the `ScrollAnimation` family: the tall section defines the scroll range, and every `Motion` inside it is driven by that progress through Motion's `scroll()` — hardware-accelerated where the browser supports `ScrollTimeline`. Keyframe arrays give each child a multi-step track across the same range, and registering the timeline is enough: it mounts its `Motion` children itself.

--- a/packages/docs/reference/items/Motion/js-api.md
+++ b/packages/docs/reference/items/Motion/js-api.md
@@ -239,6 +239,41 @@ The scroll axis driving the timeline.
 - `scroll()` is not part of `motion/mini`: when the [provided module](#providing-the-motion-dependency) lacks it, the timeline warns and leaves its children untouched.
 - Each child gets its own `scroll()` link, released when the timeline is destroyed.
 
+## `MotionSequence`
+
+Orchestrate the `Motion` children as one animation sequence: each child declares its keyframes as usual, and the sequence composes them — in DOM order — into a single timeline with Motion's [sequencing](https://motion.dev/docs/animate#timeline-sequencing). The whole playback surface applies to the sequence: an [`Action`](/reference/items/Action/) can `play()`, `reverse()` or `seek()` the entire choreography, and a [`MotionScrollTimeline`](#motionscrolltimeline) can scrub it. Give the children `data-option-no-autoplay` — the sequence owns their playback.
+
+<!-- prettier-ignore-start -->
+```html {1}
+<ul data-component="MotionSequence" data-option-stagger="0.1">
+  <li data-component="Motion" data-option-initial='{ "opacity": 0, "y": 16 }' data-option-animate='{ "opacity": 1, "y": 0 }' data-option-no-autoplay>One</li>
+  <li data-component="Motion" data-option-initial='{ "opacity": 0, "y": 16 }' data-option-animate='{ "opacity": 1, "y": 0 }' data-option-no-autoplay>Two</li>
+</ul>
+```
+<!-- prettier-ignore-end -->
+
+### Options
+
+#### `stagger`
+
+- Type: `number`
+- Default: `0`
+
+Spreads the segments automatically: each child starts `stagger` seconds after the previous one. Without it, segments run one after another (Motion's default).
+
+#### `at` (on the children)
+
+- Type: `string`
+- Default: `''`
+
+A child's explicit position in the sequence, taking precedence over `stagger`: a time in seconds (`"2"`), a relative offset (`"-0.2"`), or `"<"` for "with the previous segment". See Motion's [sequencing options](https://motion.dev/docs/animate#timeline-sequencing).
+
+### Notes
+
+- The sequence element's own `transition` option is passed as the sequence-level options (e.g. a shared `duration` or `repeat`).
+- Children without `animate` keyframes are skipped.
+- Sequences need the full `motion` entry: `motion/mini`'s `animate()` does not support them.
+
 ## Providing the Motion dependency
 
 By default the component resolves `motion` with a lazy `import()` the first time an animation is built. To control which build is used — a specific version, the smaller `motion/mini` entry, or a module served from an import map or a CDN — inject it once with `provideMotion()` before the components mount:

--- a/packages/docs/reference/items/Motion/stories/sequence/app.js
+++ b/packages/docs/reference/items/Motion/stories/sequence/app.js
@@ -1,0 +1,5 @@
+import { registerComponents } from '@studiometa/js-toolkit';
+import { Action } from '@studiometa/ui';
+import { MotionSequence } from '@studiometa/ui-motion';
+
+registerComponents(Action, MotionSequence);

--- a/packages/docs/reference/items/Motion/stories/sequence/app.twig
+++ b/packages/docs/reference/items/Motion/stories/sequence/app.twig
@@ -1,0 +1,59 @@
+<div class="grid gap-4 justify-items-start">
+  <ul
+    data-component="MotionSequence"
+    data-option-stagger="0.15"
+    data-option-no-autoplay
+    class="grid gap-2 list-none p-0">
+    <li
+      data-component="Motion"
+      data-option-initial='{ "opacity": 0, "x": -32 }'
+      data-option-animate='{ "opacity": 1, "x": 0 }'
+      data-option-no-autoplay
+      class="px-4 py-2 rounded bg-blue-400 dark:bg-blue-600 text-white font-bold">
+      One
+    </li>
+    <li
+      data-component="Motion"
+      data-option-initial='{ "opacity": 0, "x": -32 }'
+      data-option-animate='{ "opacity": 1, "x": 0 }'
+      data-option-no-autoplay
+      class="px-4 py-2 rounded bg-blue-400 dark:bg-blue-600 text-white font-bold">
+      Two
+    </li>
+    <li
+      data-component="Motion"
+      data-option-initial='{ "opacity": 0, "x": -32 }'
+      data-option-animate='{ "opacity": 1, "x": 0 }'
+      data-option-no-autoplay
+      class="px-4 py-2 rounded bg-blue-400 dark:bg-blue-600 text-white font-bold">
+      Three
+    </li>
+    <li
+      data-component="Motion"
+      data-option-initial='{ "opacity": 0, "scale": 0 }'
+      data-option-animate='{ "opacity": 1, "scale": 1 }'
+      data-option-transition='{ "type": "spring", "bounce": 0.5 }'
+      data-option-at="+0.2"
+      data-option-no-autoplay
+      class="px-4 py-2 rounded bg-emerald-400 dark:bg-emerald-600 text-white font-bold">
+      Finale, 0.2s later
+    </li>
+  </ul>
+
+  <div class="flex gap-2">
+    <button
+      type="button"
+      data-component="Action"
+      data-on:click="MotionSequence->target.play()"
+      class="px-4 py-2 rounded bg-zinc-200 dark:bg-zinc-800">
+      Play
+    </button>
+    <button
+      type="button"
+      data-component="Action"
+      data-on:click="MotionSequence->target.reverse()"
+      class="px-4 py-2 rounded bg-zinc-200 dark:bg-zinc-800">
+      Reverse
+    </button>
+  </div>
+</div>

--- a/packages/tests/Motion/MotionSequence.spec.ts
+++ b/packages/tests/Motion/MotionSequence.spec.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+// Importing the mock injects the `motion` module double through `provideMotion`
+// before the components resolve it below.
+import { animations, mockAnimate, resetMockMotion } from './mock-motion.js';
+import { MotionSequence } from '@studiometa/ui-motion';
+import { h, wait } from '#test-utils';
+
+function motionChild(attributes: Record<string, string>) {
+  return h('div', { dataComponent: 'Motion', dataOptionNoAutoplay: '', ...attributes });
+}
+
+async function mountSequence(
+  attributes: Record<string, string> = {},
+  children: Array<Record<string, string>> = [
+    { dataOptionAnimate: '{ "x": 100 }' },
+    { dataOptionAnimate: '{ "y": 50 }', dataOptionTransition: '{ "duration": 1 }' },
+  ],
+) {
+  const kids = children.map(motionChild);
+  const el = h('div', { dataComponent: 'MotionSequence', ...attributes }, kids);
+  const instance = new MotionSequence(el);
+  await instance.$mount();
+  await wait(0);
+
+  return { el, instance, kids };
+}
+
+describe('MotionSequence component', () => {
+  beforeEach(() => {
+    resetMockMotion();
+  });
+
+  it('should have the correct config', () => {
+    expect(MotionSequence.config.name).toBe('MotionSequence');
+    expect(MotionSequence.config.components).toHaveProperty('Motion');
+  });
+
+  it('should autoplay one sequence built from the children in DOM order', async () => {
+    const { el, kids } = await mountSequence();
+    let played = 0;
+    el.addEventListener('motion-play', () => (played += 1));
+
+    expect(mockAnimate).toHaveBeenCalledTimes(1);
+    const [animation] = animations;
+    expect(animation.sequence).toEqual([
+      [kids[0], { x: 100 }, {}],
+      [kids[1], { y: 50 }, { duration: 1 }],
+    ]);
+    // No transition on the sequence element: no sequence-level options.
+    expect(animation.options).toBeUndefined();
+  });
+
+  it('should position segments with the at option, parsing numbers', async () => {
+    const { kids } = await mountSequence({}, [
+      { dataOptionAnimate: '{ "x": 100 }', dataOptionAt: '0.5' },
+      { dataOptionAnimate: '{ "y": 50 }', dataOptionAt: '<' },
+    ]);
+
+    expect(animations[0].sequence).toEqual([
+      [kids[0], { x: 100 }, { at: 0.5 }],
+      [kids[1], { y: 50 }, { at: '<' }],
+    ]);
+  });
+
+  it('should spread the segments with stagger, explicit at winning', async () => {
+    const { kids } = await mountSequence({ dataOptionStagger: '0.2' }, [
+      { dataOptionAnimate: '{ "x": 100 }' },
+      { dataOptionAnimate: '{ "y": 50 }' },
+      { dataOptionAnimate: '{ "rotate": 90 }', dataOptionAt: '2' },
+    ]);
+
+    expect(animations[0].sequence).toEqual([
+      [kids[0], { x: 100 }, { at: 0 }],
+      [kids[1], { y: 50 }, { at: 0.2 }],
+      [kids[2], { rotate: 90 }, { at: 2 }],
+    ]);
+  });
+
+  it('should pass its transition as the sequence options', async () => {
+    await mountSequence({ dataOptionTransition: '{ "duration": 3 }' });
+    expect(animations[0].options).toEqual({ duration: 3 });
+  });
+
+  it('should skip children without keyframes and not autoplay when none remain', async () => {
+    await mountSequence({}, [{}, {}]);
+    expect(mockAnimate).not.toHaveBeenCalled();
+  });
+
+  it('should drive the whole sequence with the inherited playback surface', async () => {
+    const { instance } = await mountSequence({ dataOptionNoAutoplay: '' });
+    expect(mockAnimate).not.toHaveBeenCalled();
+
+    instance.play();
+    await wait(0);
+    expect(mockAnimate).toHaveBeenCalledTimes(1);
+    expect(instance.controls).toBe(animations[0]);
+
+    instance.reverse();
+    await wait(0);
+    expect(animations[0].speed).toBe(-1);
+    expect(mockAnimate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/tests/Motion/exports.spec.ts
+++ b/packages/tests/Motion/exports.spec.ts
@@ -6,6 +6,7 @@ test('@studiometa/ui-motion exports', () => {
     [
       "Motion",
       "MotionScrollTimeline",
+      "MotionSequence",
       "provideMotion",
       "resolveMotion",
     ]

--- a/packages/tests/Motion/mock-motion.ts
+++ b/packages/tests/Motion/mock-motion.ts
@@ -7,7 +7,9 @@ import { provideMotion, type MotionModule } from '@studiometa/ui-motion';
  * through {@link MockAnimation.finish}.
  */
 export class MockAnimation {
-  element: Element;
+  element: Element | null;
+  /** The segments array when built from `animate(sequence, options)`. */
+  sequence: unknown[] | null;
   keyframes: Record<string, unknown>;
   options: Record<string, unknown> | undefined;
   speed = 1;
@@ -26,13 +28,22 @@ export class MockAnimation {
   __callbacks: [() => void, () => void][] = [];
 
   constructor(
-    element: Element,
-    keyframes: Record<string, unknown>,
+    target: Element | unknown[],
+    keyframes?: Record<string, unknown>,
     options?: Record<string, unknown>,
   ) {
-    this.element = element;
-    this.keyframes = keyframes;
-    this.options = options;
+    if (Array.isArray(target)) {
+      // Sequence overload: `animate(sequence, sequenceOptions)`.
+      this.element = null;
+      this.sequence = target;
+      this.keyframes = {};
+      this.options = keyframes;
+    } else {
+      this.element = target;
+      this.sequence = null;
+      this.keyframes = keyframes ?? {};
+      this.options = options;
+    }
   }
 
   play() {
@@ -89,8 +100,12 @@ export class MockAnimation {
 export const animations: MockAnimation[] = [];
 
 export const mockAnimate = vi.fn(
-  (element: Element, keyframes: Record<string, unknown>, options?: Record<string, unknown>) => {
-    const animation = new MockAnimation(element, keyframes, options);
+  (
+    target: Element | unknown[],
+    keyframes?: Record<string, unknown>,
+    options?: Record<string, unknown>,
+  ) => {
+    const animation = new MockAnimation(target, keyframes, options);
     animations.push(animation);
     return animation;
   },

--- a/packages/tests/Motion/subpath-exports.spec.ts
+++ b/packages/tests/Motion/subpath-exports.spec.ts
@@ -4,6 +4,9 @@ import MotionDefault, { Motion as MotionNamed } from '@studiometa/ui-motion/Moti
 import MotionScrollTimelineDefault, {
   MotionScrollTimeline as MotionScrollTimelineNamed,
 } from '@studiometa/ui-motion/MotionScrollTimeline';
+import MotionSequenceDefault, {
+  MotionSequence as MotionSequenceNamed,
+} from '@studiometa/ui-motion/MotionSequence';
 
 test.each([
   ['Motion', MotionDefault, MotionNamed, barrel.Motion],
@@ -13,6 +16,7 @@ test.each([
     MotionScrollTimelineNamed,
     barrel.MotionScrollTimeline,
   ],
+  ['MotionSequence', MotionSequenceDefault, MotionSequenceNamed, barrel.MotionSequence],
 ])('%s is available at its own subpath as default and named export', (_name, def, named, fromBarrel) => {
   // The default export is a js-toolkit `Base` subclass.
   expect('$isBase' in def).toBe(true);

--- a/packages/tests/barrel-exports/barrel-exports.spec.ts
+++ b/packages/tests/barrel-exports/barrel-exports.spec.ts
@@ -308,6 +308,8 @@ test('@studiometa/ui-motion barrel export surface', () => {
       "MotionProps [type]",
       "MotionScrollTimeline [value]",
       "MotionScrollTimelineProps [type]",
+      "MotionSequence [value]",
+      "MotionSequenceProps [type]",
       "provideMotion [value]",
       "resolveMotion [value]",
     ]

--- a/packages/ui-motion/README.md
+++ b/packages/ui-motion/README.md
@@ -54,7 +54,7 @@ The `hover`, `press` and `inView` options apply keyframes while their state hold
 <div data-component="Motion" data-option-hover='{ "scale": 1.1 }'>Hover me</div>
 ```
 
-For scroll-driven animations, wrap `Motion` components in a `MotionScrollTimeline`: the wrapper's traversal of the viewport defines the timeline and every child is bound to that progress with Motion's `scroll()`, hardware-accelerated where the browser supports `ScrollTimeline`:
+`MotionSequence` composes its `Motion` children into one timeline (with per-child `at` positions or an automatic `stagger`), and the whole playback surface drives the sequence. For scroll-driven animations, wrap `Motion` components in a `MotionScrollTimeline`: the wrapper's traversal of the viewport defines the timeline and every child is bound to that progress with Motion's `scroll()`, hardware-accelerated where the browser supports `ScrollTimeline`:
 
 ```html
 <section data-component="MotionScrollTimeline" class="h-[300vh]">

--- a/packages/ui-motion/package.json
+++ b/packages/ui-motion/package.json
@@ -37,6 +37,11 @@
       "types": "./dist/MotionScrollTimeline.d.ts",
       "import": "./dist/MotionScrollTimeline.js"
     },
+    "./MotionSequence": {
+      "typescript": "./src/MotionSequence.ts",
+      "types": "./dist/MotionSequence.d.ts",
+      "import": "./dist/MotionSequence.js"
+    },
     "./dependencies": {
       "typescript": "./src/dependencies.ts",
       "types": "./dist/dependencies.d.ts",

--- a/packages/ui-motion/src/Motion.ts
+++ b/packages/ui-motion/src/Motion.ts
@@ -14,6 +14,7 @@ export interface MotionProps extends BaseProps {
     animate: DOMKeyframesDefinition;
     transition: AnimationOptions;
     autoplay: boolean;
+    at: string;
     hover: DOMKeyframesDefinition;
     press: DOMKeyframesDefinition;
     inView: DOMKeyframesDefinition;
@@ -55,6 +56,7 @@ export class Motion<T extends BaseProps = BaseProps> extends Base<MotionProps & 
       animate: Object,
       transition: Object,
       autoplay: { type: Boolean, default: true },
+      at: String,
       hover: Object,
       press: Object,
       inView: Object,
@@ -125,7 +127,7 @@ export class Motion<T extends BaseProps = BaseProps> extends Base<MotionProps & 
    * the gesture options.
    */
   async mounted() {
-    const { initial, animate, autoplay } = this.$options;
+    const { initial, autoplay } = this.$options;
     const motion = await resolveMotion();
 
     if (!this.$isMounted) {
@@ -136,11 +138,21 @@ export class Motion<T extends BaseProps = BaseProps> extends Base<MotionProps & 
       motion.animate(this.$el, initial, { duration: 0 });
     }
 
-    if (autoplay && Object.keys(animate).length > 0) {
+    if (autoplay && this.__hasDeclaredAnimation) {
       this.play();
     }
 
     this.__bindGestures(motion);
+  }
+
+  /**
+   * Whether the options declare an animation to play — the gate for
+   * `autoplay`. Subclasses building their animation from another source
+   * (e.g. `MotionSequence` from its children) override this.
+   * @protected
+   */
+  get __hasDeclaredAnimation(): boolean {
+    return Object.keys(this.$options.animate).length > 0;
   }
 
   /**
@@ -385,8 +397,9 @@ export class Motion<T extends BaseProps = BaseProps> extends Base<MotionProps & 
 
   /**
    * Create the animation from the `animate` and `transition` options and make
-   * it the current one.
-   * @private
+   * it the current one. Subclasses override this to build the current
+   * animation from another source.
+   * @protected
    */
   __createControls(): AnimationPlaybackControlsWithThen {
     const { animate, transition } = this.$options;

--- a/packages/ui-motion/src/MotionSequence.ts
+++ b/packages/ui-motion/src/MotionSequence.ts
@@ -1,0 +1,111 @@
+import type { BaseProps, BaseConfig } from '@studiometa/js-toolkit';
+import type { AnimationPlaybackControlsWithThen, AnimationSequence, SequenceOptions } from 'motion';
+import { Motion } from './Motion.js';
+import { getMotion } from './dependencies.js';
+
+export interface MotionSequenceProps extends BaseProps {
+  $children: {
+    Motion: Motion[];
+  };
+  $options: {
+    stagger: number;
+  };
+}
+
+/**
+ * MotionSequence class.
+ *
+ * Orchestrate the `Motion` children as one animation sequence: each child
+ * declares its keyframes as usual, and the sequence composes them — in DOM
+ * order — into a single timeline with Motion's [sequence support](https://motion.dev/docs/animate#timeline-sequencing).
+ * The whole `Motion` playback surface applies to the sequence: an `Action`
+ * can `play()`, `reverse()` or `seek()` the entire choreography, and a
+ * `MotionScrollTimeline` can scrub it.
+ *
+ * By default segments run one after another; a child's `at` option positions
+ * its segment explicitly (a time in seconds, a relative offset like `"-0.2"`,
+ * or `"<"` for "with the previous"), and the `stagger` option spreads the
+ * children automatically. Give the children `data-option-no-autoplay` — the
+ * sequence owns their playback.
+ *
+ * Sequences need the full `motion` entry: `motion/mini`'s `animate()` does
+ * not support them.
+ *
+ * @example
+ * ```html
+ * <ul data-component="MotionSequence" data-option-stagger="0.1">
+ *   <li data-component="Motion" data-option-animate='{ "opacity": 1, "y": 0 }' data-option-initial='{ "opacity": 0, "y": 16 }' data-option-no-autoplay>…</li>
+ *   <li data-component="Motion" data-option-animate='{ "opacity": 1, "y": 0 }' data-option-initial='{ "opacity": 0, "y": 16 }' data-option-no-autoplay>…</li>
+ * </ul>
+ * ```
+ *
+ * @link https://ui.studiometa.dev/reference/items/Motion/js-api#motionsequence
+ */
+export class MotionSequence<T extends BaseProps = BaseProps> extends Motion<
+  MotionSequenceProps & T
+> {
+  /**
+   * Config.
+   */
+  static config: BaseConfig = {
+    name: 'MotionSequence',
+    components: { Motion },
+    options: {
+      stagger: Number,
+    },
+  };
+
+  /**
+   * The sequence has an animation to autoplay as soon as it has children
+   * declaring keyframes.
+   * @protected
+   */
+  get __hasDeclaredAnimation(): boolean {
+    return this.__sequencedChildren.length > 0;
+  }
+
+  /**
+   * The `Motion` children carrying keyframes, in DOM order.
+   * @private
+   */
+  get __sequencedChildren(): Motion[] {
+    const { Motion: children = [] } = this.$children;
+    return children.filter((child) => Object.keys(child.$options.animate).length > 0);
+  }
+
+  /**
+   * Build the sequence from the children declarations and make it the
+   * current animation. Each segment merges the child's `transition` and its
+   * `at` position; without an explicit `at`, the `stagger` option spreads the
+   * segments, and with neither they run one after another (Motion's default).
+   * @protected
+   */
+  __createControls(): AnimationPlaybackControlsWithThen {
+    const motion = getMotion();
+    const { stagger, transition } = this.$options;
+
+    const sequence = this.__sequencedChildren.map((child, index) => {
+      const { animate, transition: childTransition, at } = child.$options;
+      const options: Record<string, unknown> = { ...childTransition };
+
+      if (at !== '') {
+        const numeric = Number(at);
+        options.at = Number.isNaN(numeric) ? at : numeric;
+      } else if (stagger > 0) {
+        options.at = index * stagger;
+      }
+
+      return [child.$el, animate, options];
+    });
+
+    const controls = motion.animate(
+      sequence as AnimationSequence,
+      Object.keys(transition).length > 0 ? (transition as SequenceOptions) : undefined,
+    );
+    this.__controls = controls;
+    this.__fromOptions = true;
+    return controls;
+  }
+}
+
+export default MotionSequence;

--- a/packages/ui-motion/src/catalog.ts
+++ b/packages/ui-motion/src/catalog.ts
@@ -6,6 +6,7 @@ import type { ComponentCatalog, CuratedComponentMetadata } from '../../../script
 const components: readonly CuratedComponentMetadata[] = [
   { token: 'Motion', group: 'motion' },
   { token: 'MotionScrollTimeline', group: 'motion', children: ['Motion'] },
+  { token: 'MotionSequence', group: 'motion', children: ['Motion'] },
 ];
 
 /** The autoload catalog for every declarative `@studiometa/ui-motion` component. */

--- a/packages/ui-motion/src/index.ts
+++ b/packages/ui-motion/src/index.ts
@@ -4,7 +4,5 @@ export {
   type MotionModule,
 } from './dependencies.js';
 export { Motion, type MotionProps } from './Motion.js';
-export {
-  MotionScrollTimeline,
-  type MotionScrollTimelineProps,
-} from './MotionScrollTimeline.js';
+export { MotionScrollTimeline, type MotionScrollTimelineProps } from './MotionScrollTimeline.js';
+export { MotionSequence, type MotionSequenceProps } from './MotionSequence.js';

--- a/packages/ui-motion/src/manifest.ts
+++ b/packages/ui-motion/src/manifest.ts
@@ -22,4 +22,14 @@ export const manifest: ComponentManifest = {
     load: () =>
       import('./MotionScrollTimeline.js').then(({ MotionScrollTimeline }) => MotionScrollTimeline),
   },
+  MotionSequence: {
+    token: 'MotionSequence',
+    packageName: '@studiometa/ui-motion',
+    subpath: 'MotionSequence',
+    exportName: 'MotionSequence',
+    strategy: 'visible',
+    group: 'motion',
+    children: ['Motion'],
+    load: () => import('./MotionSequence.js').then(({ MotionSequence }) => MotionSequence),
+  },
 };


### PR DESCRIPTION
> Stacked on #629 (itself on #628) — merge those first; this PR's base is `feature/ui-motion-gestures`.

## What

`MotionSequence` orchestrates its `Motion` children as **one** animation sequence, through Motion's [timeline sequencing](https://motion.dev/docs/animate#timeline-sequencing): each child declares its keyframes as usual, and the sequence composes them in DOM order into a single controls object.

```html
<ul data-component="MotionSequence" data-option-stagger="0.1">
  <li data-component="Motion" data-option-initial='{ "opacity": 0, "y": 16 }' data-option-animate='{ "opacity": 1, "y": 0 }' data-option-no-autoplay>One</li>
  <li data-component="Motion" data-option-animate='{ "opacity": 1, "y": 0 }' data-option-at="+0.2" data-option-no-autoplay>Two, 0.2s later</li>
</ul>

<button data-component="Action" data-on:click="MotionSequence->target.reverse()">Reverse all</button>
```

- Because the sequence **is** a `Motion` (it extends it and overrides only the `__createControls` seam), the whole playback surface drives the entire choreography: `Action` can `play()`/`reverse()`/`seek()` it, the `motion-*` events fire for it, and a `MotionScrollTimeline` can scrub it.
- Positioning: Motion's default is one segment after another; the sequence's `stagger` option spreads them automatically; a child's new `at` option (seconds, relative `"-0.2"`, or `"<"`) wins over both.
- The sequence element's own `transition` is passed as the sequence-level options (shared `duration`, `repeat`, ...).
- Children without `animate` keyframes are skipped; autoplay is gated by a new protected `__hasDeclaredAnimation` seam (children instead of own keyframes).
- Sequences need the full `motion` entry — `motion/mini`'s `animate()` has no sequence overload (documented).

## Test plan

- 7 new specs (`MotionSequence.spec.ts`): sequence composition in DOM order, `at` parsing (numbers vs `"<"`), stagger with explicit-`at` precedence, sequence-level options, keyframe-less children skipped, inherited playback surface.
- Full suite green: 105 files, 849 tests. Lint: 0 errors. Docs validator: 268 symbols; new "Staggered sequence" live story.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FVXrJ8idMfvt667yJadvB8