### PR TITLE
Add the MotionView component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - **@studiometa/ui-motion:** add a new `@studiometa/ui-motion` package with `Motion` and `MotionScrollTimeline` components to animate elements declaratively with [Motion](https://motion.dev) ([#628](https://github.com/studiometa/ui/pull/628))
 - **@studiometa/ui-motion:** add the `hover`, `press` and `inView` gesture options to `Motion` ([#629](https://github.com/studiometa/ui/pull/629))
 - **@studiometa/ui-motion:** add the `MotionSequence` component to orchestrate `Motion` children as one staggered timeline ([#630](https://github.com/studiometa/ui/pull/630))
-- **@studiometa/ui-motion:** add the `MotionView` component to animate DOM updates with Motion's `animateView()`
+- **@studiometa/ui-motion:** add the `MotionView` component to animate DOM updates with Motion's `animateView()` ([#633](https://github.com/studiometa/ui/pull/633))
 - **DataBind:** add the `data-bind:if` virtual binding to render `<template>` content conditionally ([#626](https://github.com/studiometa/ui/pull/626))
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - **@studiometa/ui-motion:** add a new `@studiometa/ui-motion` package with `Motion` and `MotionScrollTimeline` components to animate elements declaratively with [Motion](https://motion.dev) ([#628](https://github.com/studiometa/ui/pull/628))
 - **@studiometa/ui-motion:** add the `hover`, `press` and `inView` gesture options to `Motion` ([#629](https://github.com/studiometa/ui/pull/629))
 - **@studiometa/ui-motion:** add the `MotionSequence` component to orchestrate `Motion` children as one staggered timeline ([#630](https://github.com/studiometa/ui/pull/630))
+- **@studiometa/ui-motion:** add the `MotionView` component to animate DOM updates with Motion's `animateView()`
 - **DataBind:** add the `data-bind:if` virtual binding to render `<template>` content conditionally ([#626](https://github.com/studiometa/ui/pull/626))
 
 ### Changed

--- a/packages/docs/.vitepress/reference/catalog.ts
+++ b/packages/docs/.vitepress/reference/catalog.ts
@@ -998,6 +998,7 @@ export const referenceCatalog = [
         '/reference/items/Motion/js-api#motionscrolltimeline',
       ),
       motionSymbol('MotionSequence', '/reference/items/Motion/js-api#motionsequence'),
+      motionSymbol('MotionView', '/reference/items/Motion/js-api#motionview'),
       motionSymbol(
         'provideMotion',
         '/reference/items/Motion/js-api#providing-the-motion-dependency',

--- a/packages/docs/.vitepress/reference/public-contracts.ts
+++ b/packages/docs/.vitepress/reference/public-contracts.ts
@@ -918,4 +918,12 @@ export const publicContractSymbols = [
     href: '/reference/items/Motion/js-api',
     status: 'stable',
   },
+  {
+    name: 'MotionViewProps',
+    kind: 'type',
+    package: 'npm:@studiometa/ui-motion',
+    importPath: '@studiometa/ui-motion',
+    href: '/reference/items/Motion/js-api',
+    status: 'stable',
+  },
 ] satisfies ReferenceSymbol[];

--- a/packages/docs/reference/items/Motion/examples.md
+++ b/packages/docs/reference/items/Motion/examples.md
@@ -151,6 +151,27 @@ A single element carries `Action`, `Motion` and [`TimerProgress`](/reference/ite
 
 </llm-only>
 
+## Animated state change with `MotionView`
+
+[`MotionView`](./js-api#motionview) wraps DOM updates in Motion's `animateView()`, as a drop-in alternative to [`ViewTransition`](/reference/items/ViewTransition/): toggling swaps the `enterTo`/`leaveTo` classes inside a view transition, and the spring `transition` with the `layout` morph animates the card between its two states — no `::view-transition-*` CSS needed. Where view transitions are unavailable, the classes still swap, only without animation.
+
+<llm-exclude>
+  <PreviewPlayground
+    :html="() => import('./stories/view/app.twig')"
+    :script="() => import('./stories/view/app.js?raw')"
+    />
+</llm-exclude>
+<llm-only>
+
+:::code-group
+
+<<< ./stories/view/app.twig
+<<< ./stories/view/app.js
+
+:::
+
+</llm-only>
+
 ## Scroll-driven timeline
 
 [`MotionScrollTimeline`](./js-api#motionscrolltimeline) separates the timeline from the animations, like the `ScrollAnimation` family: the tall section defines the scroll range, and every `Motion` inside it is driven by that progress through Motion's `scroll()` — hardware-accelerated where the browser supports `ScrollTimeline`. Keyframe arrays give each child a multi-step track across the same range, and registering the timeline is enough: it mounts its `Motion` children itself.

--- a/packages/docs/reference/items/Motion/js-api.md
+++ b/packages/docs/reference/items/Motion/js-api.md
@@ -344,6 +344,13 @@ Per-layer keyframes applied to each subject, mapping to the builder's [`new()`/`
 
 Enable the layout morph on each subject (the builder's `layout()`), so position and size changes animate smoothly.
 
+#### `auto`
+
+- Type: `boolean`
+- Default: `true`
+
+Enable [ambient wiring](#ambient-wiring): the component wraps any `dom-update` announced inside its subtree and joins the lifecycle of a containing `Dialog`. Opt out with `data-option-no-auto`.
+
 ### Events
 
 The same events as [`ViewTransition`](/reference/items/ViewTransition/js-api#events), in the same order: `enter`, `enter-start`, `enter-end` around the enter transition and `leave`, `leave-start`, `leave-end` around the leave transition.
@@ -356,6 +363,43 @@ The same events as [`ViewTransition`](/reference/items/ViewTransition/js-api#eve
 | `leave()`        | Swap `enterTo` for `leaveTo` inside a view transition. Resolves once the animation settles.                   |
 | `toggle()`       | Toggle between enter and leave, entering first.                                                               |
 | `update(mutate)` | The underlying primitive: run any DOM mutation as a view transition configured by the options. Never rejects. |
+
+### Ambient wiring
+
+Containment is the wiring: with the `auto` option (on by default), a mounted `MotionView` listens for the bubbling `dom-update` event that mutating components — [`Fetch`](/reference/items/Fetch/), [`DataBind`](/reference/items/DataBind/)'s `data-bind:if` — announce before changing the DOM, and runs the announced change through `update()` so it plays as a view transition. Nesting the mutators inside the component is enough, with zero wiring attributes on either side:
+
+<!-- prettier-ignore-start -->
+```html {1}
+<div data-component="MotionView" data-option-transition='{ "type": "spring", "bounce": 0.2 }'>
+  <form action="/search" data-component="Fetch">
+    <input type="search" name="q" />
+  </form>
+
+  <template data-component="DataBind" data-option-key="expanded" data-bind:if>
+    <p>…</p>
+  </template>
+</div>
+```
+<!-- prettier-ignore-end -->
+
+A `MotionView` placed inside a [`Dialog`](/reference/items/Dialog/) also joins its lifecycle: the dialog's extendable `open` and `close` events bubble past the component, which hands itself to `detail.waitUntil()` — the dialog then awaits `enter()` on open and `leave()` on close.
+
+Opt out with `data-option-no-auto`. Explicit wiring through [`Action`](/reference/items/Action/) remains for cross-subtree topologies, where the mutator and the animated subtree are not nested:
+
+<!-- prettier-ignore-start -->
+```html {4}
+<form
+  action="/search"
+  data-component="Fetch Action"
+  data-on:dom-update="MotionView(#list)->event.detail.wrap(target)">
+  <input type="search" name="q" />
+</form>
+
+<ul id="list" data-component="MotionView">
+  …
+</ul>
+```
+<!-- prettier-ignore-end -->
 
 ### Notes
 

--- a/packages/docs/reference/items/Motion/js-api.md
+++ b/packages/docs/reference/items/Motion/js-api.md
@@ -274,6 +274,94 @@ A child's explicit position in the sequence, taking precedence over `stagger`: a
 - Children without `animate` keyframes are skipped.
 - Sequences need the full `motion` entry: `motion/mini`'s `animate()` does not support them.
 
+## `MotionView`
+
+Wrap DOM updates in Motion's [`animateView()`](https://motion.dev/docs/animate-view) so the change plays as a view transition. A drop-in alternative to the [`ViewTransition`](/reference/items/ViewTransition/) component — same `enter()`/`leave()`/`toggle()` methods, `state` property, events and `viewTransitionName`/`enterTo`/`leaveTo` options — but the animation is declared with Motion keyframes and transitions (including springs) instead of the `::view-transition-*` CSS pseudo-elements.
+
+<!-- prettier-ignore-start -->
+```html {2,3}
+<div
+  data-component="MotionView"
+  data-option-enter-to="is-open"
+  data-option-transition='{ "type": "spring", "bounce": 0.3 }'>
+  …
+</div>
+
+<button data-component="Action" data-on:click="MotionView->target.toggle()">Toggle</button>
+```
+<!-- prettier-ignore-end -->
+
+### Options
+
+Object options are parsed as JSON: quote the keys (`data-option-new='{ "opacity": [0, 1] }'`).
+
+#### `viewTransitionName`
+
+- Type: `string`
+- Default: `''`
+
+Assigned as the element's [`view-transition-name`](https://developer.mozilla.org/en-US/docs/Web/CSS/view-transition-name) on mount, exactly like `ViewTransition`. Optional with `MotionView`: `animateView()` names the subjects it animates automatically.
+
+#### `enterTo`
+
+- Type: `string`
+- Default: `''`
+
+Classes describing the shown state. Added on `enter`, removed on `leave`.
+
+#### `leaveTo`
+
+- Type: `string`
+- Default: `''`
+
+Classes describing the hidden state. Added on `leave`, removed on `enter`. Usually also the element's initial class so it starts hidden.
+
+#### `transition`
+
+- Type: `ViewTransitionOptions`
+- Default: `{}`
+
+The root [`animateView()` options](https://motion.dev/docs/animate-view): a default transition (`duration`, `ease`, `type: "spring"`, …) for every layer of the view transition.
+
+#### `add`
+
+- Type: `string`
+- Default: `''`
+
+A selector resolved within the component's element: every matched element becomes an animated subject of the transition. When empty, the element itself is the subject.
+
+#### `new`, `old`, `enter`, `exit`
+
+- Type: `DOMKeyframesDefinition`
+- Default: `{}`
+
+Per-layer keyframes applied to each subject, mapping to the builder's [`new()`/`old()`/`enter()`/`exit()` methods](https://motion.dev/docs/animate-view): `new` and `old` animate the new and old views whether the element persists or not, while `enter` and `exit` only fire for a pure newcomer or leaver.
+
+#### `layout`
+
+- Type: `boolean`
+- Default: `false`
+
+Enable the layout morph on each subject (the builder's `layout()`), so position and size changes animate smoothly.
+
+### Events
+
+The same events as [`ViewTransition`](/reference/items/ViewTransition/js-api#events), in the same order: `enter`, `enter-start`, `enter-end` around the enter transition and `leave`, `leave-start`, `leave-end` around the leave transition.
+
+### Methods
+
+| Method           | Description                                                                                                   |
+| ---------------- | ------------------------------------------------------------------------------------------------------------- |
+| `enter()`        | Swap `leaveTo` for `enterTo` inside a view transition. Resolves once the animation settles.                   |
+| `leave()`        | Swap `enterTo` for `leaveTo` inside a view transition. Resolves once the animation settles.                   |
+| `toggle()`       | Toggle between enter and leave, entering first.                                                               |
+| `update(mutate)` | The underlying primitive: run any DOM mutation as a view transition configured by the options. Never rejects. |
+
+### Notes
+
+- The mutation is never lost: in browsers without the View Transitions API — or when the animation rejects — the update still applies, only without animation.
+- `animateView()` is not part of `motion/mini`: when the [provided module](#providing-the-motion-dependency) lacks it, the component warns and applies updates directly.
+
 ## Providing the Motion dependency
 
 By default the component resolves `motion` with a lazy `import()` the first time an animation is built. To control which build is used — a specific version, the smaller `motion/mini` entry, or a module served from an import map or a CDN — inject it once with `provideMotion()` before the components mount:

--- a/packages/docs/reference/items/Motion/stories/view/app.js
+++ b/packages/docs/reference/items/Motion/stories/view/app.js
@@ -1,0 +1,5 @@
+import { registerComponents } from '@studiometa/js-toolkit';
+import { Action } from '@studiometa/ui';
+import { MotionView } from '@studiometa/ui-motion';
+
+registerComponents(Action, MotionView);

--- a/packages/docs/reference/items/Motion/stories/view/app.twig
+++ b/packages/docs/reference/items/Motion/stories/view/app.twig
@@ -1,0 +1,19 @@
+<div class="grid gap-4 justify-items-start">
+  <div
+    data-component="MotionView"
+    data-option-enter-to="w-72 p-8 rounded-3xl bg-emerald-400 dark:bg-emerald-600"
+    data-option-leave-to="w-40 p-4 rounded bg-blue-400 dark:bg-blue-600"
+    data-option-transition='{ "type": "spring", "bounce": 0.3 }'
+    data-option-layout
+    class="w-40 p-4 rounded bg-blue-400 dark:bg-blue-600 text-white font-bold">
+    One card, two states
+  </div>
+
+  <button
+    type="button"
+    data-component="Action"
+    data-on:click="MotionView->target.toggle()"
+    class="px-4 py-2 rounded bg-zinc-200 dark:bg-zinc-800">
+    Toggle
+  </button>
+</div>

--- a/packages/tests/Motion/MotionView.spec.ts
+++ b/packages/tests/Motion/MotionView.spec.ts
@@ -12,10 +12,7 @@ import { MotionView } from '@studiometa/ui-motion';
 import { ViewTransition } from '@studiometa/ui';
 import { h } from '#test-utils';
 
-async function mountView(
-  attributes: Record<string, string> = {},
-  children: HTMLElement[] = [],
-) {
+async function mountView(attributes: Record<string, string> = {}, children: HTMLElement[] = []) {
   const el = h('div', { dataComponent: 'MotionView', ...attributes }, children);
   const instance = new MotionView(el);
   await instance.$mount();
@@ -149,5 +146,74 @@ describe('MotionView component', () => {
 
     await expect(instance.update(mutate)).resolves.toBeUndefined();
     expect(mutate).toHaveBeenCalledTimes(1);
+  });
+
+  it('should wrap a `dom-update` announced inside its subtree', async () => {
+    const child = h('div');
+    const { instance } = await mountView({}, [child]);
+    const wrap = vi.fn();
+
+    child.dispatchEvent(new CustomEvent('dom-update', { bubbles: true, detail: { wrap } }));
+
+    expect(wrap).toHaveBeenCalledTimes(1);
+    expect(wrap).toHaveBeenCalledWith(instance);
+
+    await instance.$destroy();
+  });
+
+  it('should not wrap a `dom-update` with the `auto` option disabled', async () => {
+    const child = h('div');
+    const { instance } = await mountView({ dataOptionNoAuto: '' }, [child]);
+    const wrap = vi.fn();
+
+    child.dispatchEvent(new CustomEvent('dom-update', { bubbles: true, detail: { wrap } }));
+
+    expect(wrap).not.toHaveBeenCalled();
+
+    await instance.$destroy();
+  });
+
+  it('should join the lifecycle of a containing dialog only', async () => {
+    const { el, instance } = await mountView();
+    const ancestor = h('div', {}, [el]);
+    document.body.append(ancestor);
+    const sibling = h('div');
+    document.body.append(sibling);
+    const waitUntil = vi.fn();
+
+    for (const event of ['open', 'close']) {
+      ancestor.dispatchEvent(new CustomEvent(event, { bubbles: true, detail: { waitUntil } }));
+    }
+    expect(waitUntil).toHaveBeenCalledTimes(2);
+    expect(waitUntil).toHaveBeenCalledWith(instance);
+
+    waitUntil.mockClear();
+    sibling.dispatchEvent(new CustomEvent('open', { bubbles: true, detail: { waitUntil } }));
+    el.dispatchEvent(new CustomEvent('open', { bubbles: true, detail: { waitUntil } }));
+    expect(waitUntil).not.toHaveBeenCalled();
+
+    await instance.$destroy();
+    ancestor.remove();
+    sibling.remove();
+  });
+
+  it('should stop listening once destroyed', async () => {
+    const child = h('div');
+    const { el, instance } = await mountView({}, [child]);
+    const ancestor = h('div', {}, [el]);
+    document.body.append(ancestor);
+    const wrap = vi.fn();
+    const waitUntil = vi.fn();
+
+    await instance.$destroy();
+
+    child.dispatchEvent(new CustomEvent('dom-update', { bubbles: true, detail: { wrap } }));
+    ancestor.dispatchEvent(new CustomEvent('open', { bubbles: true, detail: { waitUntil } }));
+    ancestor.dispatchEvent(new CustomEvent('close', { bubbles: true, detail: { waitUntil } }));
+
+    expect(wrap).not.toHaveBeenCalled();
+    expect(waitUntil).not.toHaveBeenCalled();
+
+    ancestor.remove();
   });
 });

--- a/packages/tests/Motion/MotionView.spec.ts
+++ b/packages/tests/Motion/MotionView.spec.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+// Importing the mock injects the `motion` module double through `provideMotion`
+// before the components resolve it below.
+import {
+  viewBuilders,
+  mockAnimateView,
+  mockAnimateViewState,
+  mockMotionModule,
+  resetMockMotion,
+} from './mock-motion.js';
+import { MotionView } from '@studiometa/ui-motion';
+import { ViewTransition } from '@studiometa/ui';
+import { h } from '#test-utils';
+
+async function mountView(
+  attributes: Record<string, string> = {},
+  children: HTMLElement[] = [],
+) {
+  const el = h('div', { dataComponent: 'MotionView', ...attributes }, children);
+  const instance = new MotionView(el);
+  await instance.$mount();
+
+  return { el, instance };
+}
+
+describe('MotionView component', () => {
+  beforeEach(() => {
+    resetMockMotion();
+  });
+
+  it('should have the correct config, mirroring ViewTransition', () => {
+    expect(MotionView.config.name).toBe('MotionView');
+    expect(MotionView.config.emits).toEqual(ViewTransition.config.emits);
+  });
+
+  it('should apply the `view-transition-name` on mount', async () => {
+    const { el } = await mountView({ dataOptionViewTransitionName: 'panel' });
+    expect(el.style.getPropertyValue('view-transition-name')).toBe('panel');
+  });
+
+  it('should run the mutation through a builder targeting its own element', async () => {
+    const { el, instance } = await mountView({
+      dataOptionTransition: '{ "duration": 0.3 }',
+      dataOptionNew: '{ "opacity": [0, 1] }',
+      dataOptionOld: '{ "opacity": [1, 0] }',
+      dataOptionEnter: '{ "y": [16, 0] }',
+      dataOptionExit: '{ "y": [0, -16] }',
+      dataOptionLayout: '',
+    });
+    const mutate = vi.fn();
+
+    await instance.update(mutate);
+
+    expect(mutate).toHaveBeenCalledTimes(1);
+    expect(mockAnimateView).toHaveBeenCalledTimes(1);
+    expect(mockAnimateView).toHaveBeenCalledWith(mutate, { duration: 0.3 });
+    expect(viewBuilders[0].calls).toEqual([
+      ['add', el],
+      ['new', { opacity: [0, 1] }],
+      ['old', { opacity: [1, 0] }],
+      ['enter', { y: [16, 0] }],
+      ['exit', { y: [0, -16] }],
+      ['layout'],
+    ]);
+  });
+
+  it('should resolve the `add` selector within its subtree and skip empty options', async () => {
+    const cards = [h('div', { class: 'card' }), h('div', { class: 'card' })];
+    const { instance } = await mountView({ dataOptionAdd: '.card' }, [
+      ...cards,
+      h('div', { class: 'not-a-card' }),
+    ]);
+
+    await instance.update(() => {});
+
+    // No transition option: the builder receives no root options.
+    expect(mockAnimateView.mock.calls[0][1]).toBeUndefined();
+    // One `add` per matched element, no layer calls for empty keyframe options.
+    expect(viewBuilders[0].calls).toEqual([
+      ['add', cards[0]],
+      ['add', cards[1]],
+    ]);
+  });
+
+  it('should warn and still run the mutation without animateView support', async () => {
+    // Simulate a `motion/mini` build: the injected module has no `animateView`.
+    mockMotionModule.animateView = undefined as never;
+
+    const el = h('div', { dataComponent: 'MotionView' });
+    const instance = new MotionView(el);
+    const warn = vi.fn();
+    Object.defineProperty(instance, '$warn', { configurable: true, get: () => warn });
+    await instance.$mount();
+
+    const mutate = vi.fn();
+    await instance.update(mutate);
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(mutate).toHaveBeenCalledTimes(1);
+    expect(mockAnimateView).not.toHaveBeenCalled();
+  });
+
+  it('should swap classes through the builder on enter and leave, emitting in order', async () => {
+    const { el, instance } = await mountView({
+      class: 'hidden',
+      dataOptionLeaveTo: 'hidden',
+      dataOptionEnterTo: 'shown',
+    });
+    const events: string[] = [];
+    for (const event of MotionView.config.emits as string[]) {
+      el.addEventListener(event, () => events.push(event));
+    }
+
+    await instance.enter();
+    expect(events).toEqual(['enter', 'enter-start', 'enter-end']);
+    expect(instance.state).toBe('entering');
+    expect(el.classList.contains('hidden')).toBe(false);
+    expect(el.classList.contains('shown')).toBe(true);
+    // The class swap ran inside the builder update callback.
+    expect(mockAnimateView).toHaveBeenCalledTimes(1);
+
+    events.length = 0;
+    await instance.leave();
+    expect(events).toEqual(['leave', 'leave-start', 'leave-end']);
+    expect(instance.state).toBe('leaving');
+    expect(el.classList.contains('shown')).toBe(false);
+    expect(el.classList.contains('hidden')).toBe(true);
+    expect(mockAnimateView).toHaveBeenCalledTimes(2);
+  });
+
+  it('should toggle between enter and leave, entering first', async () => {
+    const { instance } = await mountView({ dataOptionEnterTo: 'shown' });
+
+    expect(instance.state).toBe(null);
+    await instance.toggle();
+    expect(instance.state).toBe('entering');
+    await instance.toggle();
+    expect(instance.state).toBe('leaving');
+    await instance.toggle();
+    expect(instance.state).toBe('entering');
+  });
+
+  it('should resolve even when the builder rejects, keeping the mutation', async () => {
+    // Simulate a graceful-degradation browser: the view animation rejects.
+    mockAnimateViewState.reject = true;
+
+    const { instance } = await mountView();
+    const mutate = vi.fn();
+
+    await expect(instance.update(mutate)).resolves.toBeUndefined();
+    expect(mutate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/tests/Motion/exports.spec.ts
+++ b/packages/tests/Motion/exports.spec.ts
@@ -7,6 +7,7 @@ test('@studiometa/ui-motion exports', () => {
       "Motion",
       "MotionScrollTimeline",
       "MotionSequence",
+      "MotionView",
       "provideMotion",
       "resolveMotion",
     ]

--- a/packages/tests/Motion/mock-motion.ts
+++ b/packages/tests/Motion/mock-motion.ts
@@ -130,6 +130,80 @@ export const mockScroll = vi.fn(
   },
 );
 
+/**
+ * Chainable double for the builder `animateView()` returns: it records every
+ * subject and layer call in order, runs the update callback when awaited, and
+ * settles like the real builder — resolving to an animation exposing a
+ * `finished` promise, or rejecting when {@link MockViewBuilder.rejects} is set.
+ */
+export class MockViewBuilder {
+  update: () => void | Promise<void>;
+  options: Record<string, unknown> | undefined;
+  /** Every builder method call, in order, as `[method, ...args]`. */
+  calls: [string, ...unknown[]][] = [];
+  /** When `true`, the thenable rejects after running the update. */
+  rejects = false;
+
+  constructor(update: () => void | Promise<void>, options?: Record<string, unknown>) {
+    this.update = update;
+    this.options = options;
+  }
+
+  add(...args: unknown[]) {
+    return this.__record('add', args);
+  }
+
+  new(...args: unknown[]) {
+    return this.__record('new', args);
+  }
+
+  old(...args: unknown[]) {
+    return this.__record('old', args);
+  }
+
+  enter(...args: unknown[]) {
+    return this.__record('enter', args);
+  }
+
+  exit(...args: unknown[]) {
+    return this.__record('exit', args);
+  }
+
+  layout(...args: unknown[]) {
+    return this.__record('layout', args);
+  }
+
+  then(resolve: (value: { finished: Promise<void> }) => void, reject?: (reason?: unknown) => void) {
+    Promise.resolve(this.update()).then(() => {
+      if (this.rejects) {
+        reject?.(new Error('view transition rejected'));
+        return;
+      }
+      resolve({ finished: Promise.resolve() });
+    });
+  }
+
+  __record(method: string, args: unknown[]) {
+    this.calls.push([method, ...args]);
+    return this;
+  }
+}
+
+/** Every view builder created since the last {@link resetMockMotion} call. */
+export const viewBuilders: MockViewBuilder[] = [];
+
+/** Shared flag copied onto every new {@link MockViewBuilder} as `rejects`. */
+export const mockAnimateViewState = { reject: false };
+
+export const mockAnimateView = vi.fn(
+  (update: () => void | Promise<void>, options?: Record<string, unknown>) => {
+    const builder = new MockViewBuilder(update, options);
+    builder.rejects = mockAnimateViewState.reject;
+    viewBuilders.push(builder);
+    return builder;
+  },
+);
+
 type GestureStart = (element: Element, info?: unknown) => void | (() => void);
 
 /**
@@ -167,6 +241,7 @@ export const mockInView = createGestureMock();
  */
 export const mockMotionModule = {
   animate: mockAnimate,
+  animateView: mockAnimateView,
   scroll: mockScroll,
   hover: mockHover.fn,
   press: mockPress.fn,
@@ -178,11 +253,15 @@ provideMotion(mockMotionModule as unknown as MotionModule);
 export function resetMockMotion() {
   animations.length = 0;
   scrollLinks.length = 0;
+  viewBuilders.length = 0;
+  mockAnimateViewState.reject = false;
   mockAnimate.mockClear();
+  mockAnimateView.mockClear();
   mockScroll.mockClear();
   mockHover.reset();
   mockPress.reset();
   mockInView.reset();
+  mockMotionModule.animateView = mockAnimateView;
   mockMotionModule.scroll = mockScroll;
   mockMotionModule.hover = mockHover.fn;
   mockMotionModule.press = mockPress.fn;

--- a/packages/tests/Motion/subpath-exports.spec.ts
+++ b/packages/tests/Motion/subpath-exports.spec.ts
@@ -7,6 +7,7 @@ import MotionScrollTimelineDefault, {
 import MotionSequenceDefault, {
   MotionSequence as MotionSequenceNamed,
 } from '@studiometa/ui-motion/MotionSequence';
+import MotionViewDefault, { MotionView as MotionViewNamed } from '@studiometa/ui-motion/MotionView';
 
 test.each([
   ['Motion', MotionDefault, MotionNamed, barrel.Motion],
@@ -17,6 +18,7 @@ test.each([
     barrel.MotionScrollTimeline,
   ],
   ['MotionSequence', MotionSequenceDefault, MotionSequenceNamed, barrel.MotionSequence],
+  ['MotionView', MotionViewDefault, MotionViewNamed, barrel.MotionView],
 ])('%s is available at its own subpath as default and named export', (_name, def, named, fromBarrel) => {
   // The default export is a js-toolkit `Base` subclass.
   expect('$isBase' in def).toBe(true);

--- a/packages/tests/barrel-exports/barrel-exports.spec.ts
+++ b/packages/tests/barrel-exports/barrel-exports.spec.ts
@@ -310,6 +310,8 @@ test('@studiometa/ui-motion barrel export surface', () => {
       "MotionScrollTimelineProps [type]",
       "MotionSequence [value]",
       "MotionSequenceProps [type]",
+      "MotionView [value]",
+      "MotionViewProps [type]",
       "provideMotion [value]",
       "resolveMotion [value]",
     ]

--- a/packages/ui-motion/README.md
+++ b/packages/ui-motion/README.md
@@ -54,7 +54,7 @@ The `hover`, `press` and `inView` options apply keyframes while their state hold
 <div data-component="Motion" data-option-hover='{ "scale": 1.1 }'>Hover me</div>
 ```
 
-`MotionSequence` composes its `Motion` children into one timeline (with per-child `at` positions or an automatic `stagger`), and the whole playback surface drives the sequence. For scroll-driven animations, wrap `Motion` components in a `MotionScrollTimeline`: the wrapper's traversal of the viewport defines the timeline and every child is bound to that progress with Motion's `scroll()`, hardware-accelerated where the browser supports `ScrollTimeline`:
+`MotionView` wraps DOM updates (its `enter()`/`leave()`/`toggle()` class swaps, or any mutation through `update()`) in Motion's `animateView()`, as a drop-in alternative to the `ViewTransition` component powered by Motion keyframes and springs instead of CSS pseudo-elements. `MotionSequence` composes its `Motion` children into one timeline (with per-child `at` positions or an automatic `stagger`), and the whole playback surface drives the sequence. For scroll-driven animations, wrap `Motion` components in a `MotionScrollTimeline`: the wrapper's traversal of the viewport defines the timeline and every child is bound to that progress with Motion's `scroll()`, hardware-accelerated where the browser supports `ScrollTimeline`:
 
 ```html
 <section data-component="MotionScrollTimeline" class="h-[300vh]">

--- a/packages/ui-motion/package.json
+++ b/packages/ui-motion/package.json
@@ -42,6 +42,11 @@
       "types": "./dist/MotionSequence.d.ts",
       "import": "./dist/MotionSequence.js"
     },
+    "./MotionView": {
+      "typescript": "./src/MotionView.ts",
+      "types": "./dist/MotionView.d.ts",
+      "import": "./dist/MotionView.js"
+    },
     "./dependencies": {
       "typescript": "./src/dependencies.ts",
       "types": "./dist/dependencies.d.ts",

--- a/packages/ui-motion/src/MotionView.ts
+++ b/packages/ui-motion/src/MotionView.ts
@@ -19,6 +19,7 @@ export interface MotionViewProps extends BaseProps {
     enter: DOMKeyframesDefinition;
     exit: DOMKeyframesDefinition;
     layout: boolean;
+    auto: boolean;
   };
 }
 
@@ -36,6 +37,12 @@ export interface MotionViewProps extends BaseProps {
  * The mutation is never lost: without browser support the update applies
  * without animation, and `animateView()` is not part of `motion/mini` — the
  * component then warns and applies updates directly.
+ *
+ * Containment is the wiring: with the `auto` option (on by default), the
+ * component wraps any `dom-update` announced by a mutating component inside
+ * its subtree, and joins the open/close lifecycle of a containing `Dialog`
+ * through the extendable events' `waitUntil()`. Explicit `Action` wiring
+ * (`event.detail.wrap(target)`) remains for cross-subtree topologies.
  *
  * @example
  * ```html
@@ -65,6 +72,10 @@ export class MotionView<T extends BaseProps = BaseProps> extends Base<MotionView
       enter: Object,
       exit: Object,
       layout: Boolean,
+      auto: {
+        type: Boolean,
+        default: true,
+      },
     },
   };
 
@@ -74,6 +85,39 @@ export class MotionView<T extends BaseProps = BaseProps> extends Base<MotionView
   state: 'entering' | 'leaving' | null = null;
 
   /**
+   * Wrap a `dom-update` announced by a mutating component inside the subtree:
+   * the bubbling event reaches the root element, and passing the instance to
+   * `detail.wrap()` lets the emitter run its mutation through `update()`.
+   * @private
+   */
+  __onDomUpdate = (event: Event) => {
+    const { wrap } = (event as CustomEvent).detail ?? {};
+    if (typeof wrap === 'function') {
+      wrap(this);
+    }
+  };
+
+  /**
+   * Join the open/close lifecycle of a containing `Dialog`: its extendable
+   * events bubble up past the root element to the document, and handing the
+   * instance to `detail.waitUntil()` lets the dialog call `enter()` on open
+   * and `leave()` on close.
+   * @private
+   */
+  __onDialogPhase = (event: Event) => {
+    const { target } = event;
+    const { waitUntil } = (event as CustomEvent).detail ?? {};
+    if (
+      target instanceof Element &&
+      target !== this.$el &&
+      target.contains(this.$el) &&
+      typeof waitUntil === 'function'
+    ) {
+      waitUntil(this);
+    }
+  };
+
+  /**
    * Get the transition target.
    */
   get target(): HTMLElement {
@@ -81,13 +125,31 @@ export class MotionView<T extends BaseProps = BaseProps> extends Base<MotionView
   }
 
   /**
-   * Assign the configured `view-transition-name` to the target element.
+   * Assign the configured `view-transition-name` to the target element and,
+   * with the `auto` option, listen for ambient wiring events: `dom-update`
+   * from descendant mutators on the root element, and the extendable
+   * `open`/`close` events of a containing `Dialog` on the document.
    */
   mounted() {
-    const { viewTransitionName } = this.$options;
+    const { viewTransitionName, auto } = this.$options;
     if (viewTransitionName) {
       this.target.style.setProperty('view-transition-name', viewTransitionName);
     }
+
+    if (auto) {
+      this.$el.addEventListener('dom-update', this.__onDomUpdate);
+      document.addEventListener('open', this.__onDialogPhase);
+      document.addEventListener('close', this.__onDialogPhase);
+    }
+  }
+
+  /**
+   * Remove the ambient wiring listeners.
+   */
+  destroyed() {
+    this.$el.removeEventListener('dom-update', this.__onDomUpdate);
+    document.removeEventListener('open', this.__onDialogPhase);
+    document.removeEventListener('close', this.__onDialogPhase);
   }
 
   /**

--- a/packages/ui-motion/src/MotionView.ts
+++ b/packages/ui-motion/src/MotionView.ts
@@ -1,0 +1,194 @@
+import { Base } from '@studiometa/js-toolkit/Base';
+import type { BaseProps, BaseConfig } from '@studiometa/js-toolkit';
+import { addClass } from '@studiometa/js-toolkit/utils/addClass';
+import { removeClass } from '@studiometa/js-toolkit/utils/removeClass';
+import type { animateView, DOMKeyframesDefinition } from 'motion';
+import { resolveMotion } from './dependencies.js';
+
+type ViewTransitionOptions = NonNullable<Parameters<typeof animateView>[1]>;
+
+export interface MotionViewProps extends BaseProps {
+  $options: {
+    viewTransitionName: string;
+    enterTo: string;
+    leaveTo: string;
+    transition: ViewTransitionOptions;
+    add: string;
+    new: DOMKeyframesDefinition;
+    old: DOMKeyframesDefinition;
+    enter: DOMKeyframesDefinition;
+    exit: DOMKeyframesDefinition;
+    layout: boolean;
+  };
+}
+
+/**
+ * MotionView class.
+ *
+ * Wrap DOM updates in Motion's [`animateView()`](https://motion.dev/docs/animate-view)
+ * so the mutation plays as a view transition. A drop-in alternative to the
+ * `ViewTransition` component — same `enter()`/`leave()`/`toggle()` surface,
+ * `state` property and options — but the animation is declared with Motion
+ * keyframes and transitions (including springs) instead of CSS
+ * pseudo-elements. The `update()` method is the underlying primitive: hand it
+ * any mutation and it animates.
+ *
+ * The mutation is never lost: without browser support the update applies
+ * without animation, and `animateView()` is not part of `motion/mini` — the
+ * component then warns and applies updates directly.
+ *
+ * @example
+ * ```html
+ * <div data-component="MotionView" data-option-enter-to="is-open" data-option-transition='{ "type": "spring", "bounce": 0.3 }'>
+ *   Content
+ * </div>
+ * <button data-component="Action" data-on:click="MotionView->target.toggle()">Toggle</button>
+ * ```
+ *
+ * @link https://ui.studiometa.dev/reference/items/Motion/js-api#motionview
+ */
+export class MotionView<T extends BaseProps = BaseProps> extends Base<MotionViewProps & T> {
+  /**
+   * Config.
+   */
+  static config: BaseConfig = {
+    name: 'MotionView',
+    emits: ['enter', 'enter-start', 'enter-end', 'leave', 'leave-start', 'leave-end', 'toggle'],
+    options: {
+      viewTransitionName: String,
+      enterTo: String,
+      leaveTo: String,
+      transition: Object,
+      add: String,
+      new: Object,
+      old: Object,
+      enter: Object,
+      exit: Object,
+      layout: Boolean,
+    },
+  };
+
+  /**
+   * Current state.
+   */
+  state: 'entering' | 'leaving' | null = null;
+
+  /**
+   * Get the transition target.
+   */
+  get target(): HTMLElement {
+    return this.$el;
+  }
+
+  /**
+   * Assign the configured `view-transition-name` to the target element.
+   */
+  mounted() {
+    const { viewTransitionName } = this.$options;
+    if (viewTransitionName) {
+      this.target.style.setProperty('view-transition-name', viewTransitionName);
+    }
+  }
+
+  /**
+   * Run the given mutation as a view transition built from the options: the
+   * `add` selector picks the animated subjects within the root element (the
+   * element itself by default), the `new`, `old`, `enter` and `exit` keyframes
+   * apply to each subject's layers, and `layout` enables the morph transition.
+   * The returned promise resolves when the animation settles and never
+   * rejects; when the animation cannot run, the mutation still applies.
+   */
+  async update(mutate: () => void | Promise<void>): Promise<void> {
+    const motion = await resolveMotion();
+
+    if (!motion.animateView) {
+      this.$warn(
+        'The resolved motion module has no `animateView()` (e.g. `motion/mini`). Provide the full `motion` entry to animate updates with MotionView.',
+      );
+      await mutate();
+      return;
+    }
+
+    const {
+      transition,
+      add,
+      new: newKeyframes,
+      old: oldKeyframes,
+      enter: enterKeyframes,
+      exit: exitKeyframes,
+      layout,
+    } = this.$options;
+
+    const builder = motion.animateView(
+      mutate,
+      Object.keys(transition).length > 0 ? transition : undefined,
+    );
+
+    const targets: Element[] = add ? Array.from(this.$el.querySelectorAll(add)) : [this.$el];
+    for (const target of targets) {
+      builder.add(target);
+      if (Object.keys(newKeyframes).length > 0) {
+        builder.new(newKeyframes);
+      }
+      if (Object.keys(oldKeyframes).length > 0) {
+        builder.old(oldKeyframes);
+      }
+      if (Object.keys(enterKeyframes).length > 0) {
+        builder.enter(enterKeyframes);
+      }
+      if (Object.keys(exitKeyframes).length > 0) {
+        builder.exit(exitKeyframes);
+      }
+      if (layout) {
+        builder.layout();
+      }
+    }
+
+    // Browsers without the View Transitions API may reject or settle early:
+    // the mutation has already run, so degrade silently instead of throwing.
+    try {
+      const animation = (await builder) as { finished: Promise<unknown> };
+      await animation.finished;
+    } catch {
+      // Graceful degradation: the update ran, only the animation could not.
+    }
+  }
+
+  /**
+   * Trigger the enter transition.
+   */
+  async enter(): Promise<void> {
+    this.state = 'entering';
+    this.$emit('enter');
+    this.$emit('enter-start');
+    await this.update(() => {
+      removeClass(this.target, this.$options.leaveTo);
+      addClass(this.target, this.$options.enterTo);
+    });
+    this.$emit('enter-end');
+  }
+
+  /**
+   * Trigger the leave transition.
+   */
+  async leave(): Promise<void> {
+    this.state = 'leaving';
+    this.$emit('leave');
+    this.$emit('leave-start');
+    await this.update(() => {
+      removeClass(this.target, this.$options.enterTo);
+      addClass(this.target, this.$options.leaveTo);
+    });
+    this.$emit('leave-end');
+  }
+
+  /**
+   * Toggle between the enter and leave transitions.
+   * Defaults to the enter transition if no transition has been triggered yet.
+   */
+  toggle(): Promise<void> {
+    return this.state === 'entering' ? this.leave() : this.enter();
+  }
+}
+
+export default MotionView;

--- a/packages/ui-motion/src/catalog.ts
+++ b/packages/ui-motion/src/catalog.ts
@@ -7,6 +7,7 @@ const components: readonly CuratedComponentMetadata[] = [
   { token: 'Motion', group: 'motion' },
   { token: 'MotionScrollTimeline', group: 'motion', children: ['Motion'] },
   { token: 'MotionSequence', group: 'motion', children: ['Motion'] },
+  { token: 'MotionView', group: 'motion' },
 ];
 
 /** The autoload catalog for every declarative `@studiometa/ui-motion` component. */

--- a/packages/ui-motion/src/dependencies.ts
+++ b/packages/ui-motion/src/dependencies.ts
@@ -1,15 +1,17 @@
-import type { animate, scroll, hover, press, inView } from 'motion';
+import type { animate, animateView, scroll, hover, press, inView } from 'motion';
 
 /**
  * The subset of the `motion` module the components consume. Declared
  * structurally so a host can inject the full `motion` entry, the smaller
  * `motion/mini` entry or any compatible build — only the members listed here
  * are ever read. Everything but `animate` is optional because `motion/mini`
- * does not ship it: `scroll` powers `MotionScrollTimeline`, and `hover`,
- * `press` and `inView` power the matching `Motion` gesture options.
+ * does not ship it: `animateView` powers `MotionView`, `scroll` powers
+ * `MotionScrollTimeline`, and `hover`, `press` and `inView` power the
+ * matching `Motion` gesture options.
  */
 export interface MotionModule {
   animate: typeof animate;
+  animateView?: typeof animateView;
   scroll?: typeof scroll;
   hover?: typeof hover;
   press?: typeof press;

--- a/packages/ui-motion/src/index.ts
+++ b/packages/ui-motion/src/index.ts
@@ -6,3 +6,4 @@ export {
 export { Motion, type MotionProps } from './Motion.js';
 export { MotionScrollTimeline, type MotionScrollTimelineProps } from './MotionScrollTimeline.js';
 export { MotionSequence, type MotionSequenceProps } from './MotionSequence.js';
+export { MotionView, type MotionViewProps } from './MotionView.js';

--- a/packages/ui-motion/src/manifest.ts
+++ b/packages/ui-motion/src/manifest.ts
@@ -32,4 +32,13 @@ export const manifest: ComponentManifest = {
     children: ['Motion'],
     load: () => import('./MotionSequence.js').then(({ MotionSequence }) => MotionSequence),
   },
+  MotionView: {
+    token: 'MotionView',
+    packageName: '@studiometa/ui-motion',
+    subpath: 'MotionView',
+    exportName: 'MotionView',
+    strategy: 'visible',
+    group: 'motion',
+    load: () => import('./MotionView.js').then(({ MotionView }) => MotionView),
+  },
 };


### PR DESCRIPTION
> Stacked on #630 (chain: #628 ← #629 ← #630) — this PR's base is `feature/ui-motion-sequence`.

## What

`MotionView` wraps DOM updates in Motion's [`animateView()`](https://motion.dev/docs/animate-view) so mutations play as view transitions:

```html
<div
  data-component="MotionView"
  data-option-enter-to="w-72 p-8 rounded-3xl bg-emerald-400"
  data-option-leave-to="w-40 p-4 rounded bg-blue-400"
  data-option-transition='{ "type": "spring", "bounce": 0.3 }'
  data-option-layout
  class="w-40 p-4 rounded bg-blue-400">
  One card, two states
</div>

<button data-component="Action" data-on:click="MotionView->target.toggle()">Toggle</button>
```

- **Drop-in for `ViewTransition`**: same `enter()`/`leave()`/`toggle()` methods, `state` property, events and `viewTransitionName`/`enterTo`/`leaveTo` options — but the animation is declared with Motion keyframes and transitions (including springs) instead of the `::view-transition-*` CSS pseudo-elements.
- **`update(mutate)` primitive**: run any DOM mutation as a view transition configured by the options — `add` picks the animated subjects within the subtree (the element itself by default), `new`/`old`/`enter`/`exit` keyframes apply per layer, and `layout` enables the morph.
- **Graceful degradation**: the mutation is never lost. Without browser support — or when the view animation rejects — the update still applies, only without animation, and `update()` never rejects.
- **`motion/mini` caveat**: `animateView()` is not part of `motion/mini`; the component then warns and applies updates directly. `MotionModule.animateView` is optional accordingly.

## Ambient wiring

Containment is the wiring: with the new `auto` option (on by default), a mounted `MotionView` picks up the ambient protocols by itself — no wiring attribute on either side.

- **`dom-update`**: mutating components (`Fetch`, `DataBind`'s `data-bind:if`) announce an imminent DOM change with a bubbling `dom-update` event whose `detail.wrap()` lets a listener run the change. `MotionView` listens on its own element, so any announcement from inside its subtree is wrapped in a view transition through `update()`.
- **Dialog lifecycle**: a `MotionView` inside a `Dialog` hands itself to the extendable `open`/`close` events' `detail.waitUntil()` — the dialog awaits `enter()` on open and `leave()` on close.

```html
<div data-component="MotionView" data-option-transition='{ "type": "spring", "bounce": 0.2 }'>
  <form action="/search" data-component="Fetch">
    <input type="search" name="q" />
  </form>

  <template data-component="DataBind" data-option-key="expanded" data-bind:if>
    <p>…</p>
  </template>
</div>
```

Opt out with `data-option-no-auto`. Explicit `Action` wiring (`data-on:dom-update="MotionView(#list)->event.detail.wrap(target)"`) remains for cross-subtree topologies.

## Test plan

- New `packages/tests/Motion/MotionView.spec.ts` with 12 specs: config parity with `ViewTransition`, builder configuration (targets, keyframes, layout, transition), missing-`animateView` warning with the mutation preserved, enter/leave/toggle event sequences and class swaps, and settlement despite a rejecting builder.
- Ambient wiring specs use synthetic events: a descendant `dom-update` is wrapped with the instance, `data-option-no-auto` opts out, only a containing element's `open`/`close` joins the lifecycle (sibling and self are ignored), and all listeners are gone after `$destroy()`.
- `mock-motion.ts` gains a chainable `animateView()` builder double; the exports, subpath and barrel snapshots cover the new entry.
- Full suite: 106 test files, 858 passed (3 skipped, 1 todo). `npm run lint`: 0 errors, 20 warnings (pre-existing baseline). Docs reference validation passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FVXrJ8idMfvt667yJadvB8
