### PR TITLE
Let Dialog waitUntil accept a transitioner and make its lifecycle events bubble

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - **DataBind:** sync late-mounted `immediate` keyed subscribers with the current scoped value ([#626](https://github.com/studiometa/ui/pull/626))
 - **DataBind:** announce the `data-bind:if` DOM change with the bubbling `dom-update` protocol event whose `wrap()` lets a listener or transitioner run it ([#634](https://github.com/studiometa/ui/pull/634))
 - **Dialog:** make the `open` and `close` events extendable with `event.detail.waitUntil()` so any component can join the open and close choreography ([#627](https://github.com/studiometa/ui/pull/627))
-- **Dialog:** make the `open` and `close` events bubble and let `waitUntil()` accept a transitioner whose `enter()`/`leave()` follows the dialog lifecycle
+- **Dialog:** make the `open` and `close` events bubble and let `waitUntil()` accept a transitioner whose `enter()`/`leave()` follows the dialog lifecycle ([#635](https://github.com/studiometa/ui/pull/635))
 - **Fetch:** announce content updates with the bubbling `dom-update` protocol event whose `wrap()` lets a listener or transitioner run the swap ([#632](https://github.com/studiometa/ui/pull/632))
 - **Fetch:** route the default view transition through the shared `viewTransition` scheduler so it batches and serializes with every other view transition ([#632](https://github.com/studiometa/ui/pull/632))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - **DataBind:** sync late-mounted `immediate` keyed subscribers with the current scoped value ([#626](https://github.com/studiometa/ui/pull/626))
 - **DataBind:** announce the `data-bind:if` DOM change with the bubbling `dom-update` protocol event whose `wrap()` lets a listener or transitioner run it ([#634](https://github.com/studiometa/ui/pull/634))
 - **Dialog:** make the `open` and `close` events extendable with `event.detail.waitUntil()` so any component can join the open and close choreography ([#627](https://github.com/studiometa/ui/pull/627))
+- **Dialog:** make the `open` and `close` events bubble and let `waitUntil()` accept a transitioner whose `enter()`/`leave()` follows the dialog lifecycle
 - **Fetch:** announce content updates with the bubbling `dom-update` protocol event whose `wrap()` lets a listener or transitioner run the swap ([#632](https://github.com/studiometa/ui/pull/632))
 - **Fetch:** route the default view transition through the shared `viewTransition` scheduler so it batches and serializes with every other view transition ([#632](https://github.com/studiometa/ui/pull/632))
 

--- a/packages/docs/reference/items/Dialog/js-api.md
+++ b/packages/docs/reference/items/Dialog/js-api.md
@@ -83,6 +83,8 @@ Call `close()` if the dialog is open, `open()` otherwise.
 
 ## Events
 
+Both lifecycle events bubble up the DOM tree, so ancestors can route them and any listener up the tree can join the choreography.
+
 ### `open`
 
 Emitted when the dialog starts opening, before the enter transitions run. The `detail` carries a [`waitUntil`](#extending-the-choreography-with-waituntil) function.
@@ -93,7 +95,12 @@ Emitted when the dialog starts closing, before the leave transitions run. The `d
 
 ## Extending the choreography with `waitUntil`
 
-Both lifecycle events expose `event.detail.waitUntil(promise)`, modeled on the Service Worker [`ExtendableEvent`](https://developer.mozilla.org/en-US/docs/Web/API/ExtendableEvent/waitUntil). Any listener can register a promise while the event dispatches, and the dialog awaits it alongside its transition children — on `close`, the native dialog stays painted until every registered promise settles. This lets any component participate in the open and close choreography without being a declared child.
+Both lifecycle events expose `event.detail.waitUntil(x)`, modeled on the Service Worker [`ExtendableEvent`](https://developer.mozilla.org/en-US/docs/Web/API/ExtendableEvent/waitUntil). Any listener can register an extension while the event dispatches, and the dialog awaits it alongside its transition children — on `close`, the native dialog stays painted until every registered extension settles. This lets any component participate in the open and close choreography without being a declared child.
+
+`waitUntil()` accepts either form:
+
+- a **promise** (any thenable), awaited as is
+- a **transitioner**: a duck-typed object with `enter()` and `leave()` methods, e.g. `MotionView` from `@studiometa/ui-motion` — the dialog follows its lifecycle by awaiting `enter()` on `open` and `leave()` on `close`
 
 For example, a `Motion` box (from `@studiometa/ui-motion`) can spring in and out with the dialog through two [`Action`](/reference/items/Action/) attributes:
 
@@ -105,6 +112,19 @@ For example, a `Motion` box (from `@studiometa/ui-motion`) can spring in and out
   data-on:close="Motion(#box)->event.detail.waitUntil(target.reverse())"
   data-on:cancel.prevent="Dialog.close()">
   …
+</dialog>
+```
+<!-- prettier-ignore-end -->
+
+With the transitioner form, a single handler is enough — pass the transitioner itself and the dialog picks the right phase, like a `MotionView` navigation panel animating out before the dialog hides:
+
+<!-- prettier-ignore-start -->
+```html {3}
+<dialog
+  data-component="Action Dialog"
+  data-on:close="MotionView(#nav)->event.detail.waitUntil(target)"
+  data-on:cancel.prevent="Dialog.close()">
+  <nav id="nav">…</nav>
 </dialog>
 ```
 <!-- prettier-ignore-end -->

--- a/packages/tests/Dialog/Dialog.spec.ts
+++ b/packages/tests/Dialog/Dialog.spec.ts
@@ -221,6 +221,96 @@ describe('The Dialog component', () => {
     expect(opened).toBe(true);
   });
 
+  it('should bubble the `open` and `close` events up the DOM tree', async () => {
+    // The dialog is a child of `document.body`: an ancestor listener receives
+    // the bubbling lifecycle events.
+    const { dialog } = await createDialog();
+    const openFn = vi.fn();
+    const closeFn = vi.fn();
+    document.body.addEventListener('open', openFn);
+    document.body.addEventListener('close', closeFn);
+
+    await dialog.open();
+    expect(openFn).toHaveBeenCalledTimes(1);
+    await dialog.close();
+    expect(closeFn).toHaveBeenCalledTimes(1);
+
+    document.body.removeEventListener('open', openFn);
+    document.body.removeEventListener('close', closeFn);
+  });
+
+  it('should follow the lifecycle of a transitioner given to `waitUntil`', async () => {
+    const { dialog, el } = await createDialog();
+    let releaseEnter: () => void;
+    let releaseLeave: () => void;
+    const transitioner = {
+      enter: vi.fn(
+        () =>
+          new Promise<void>((resolve) => {
+            releaseEnter = resolve;
+          }),
+      ),
+      leave: vi.fn(
+        () =>
+          new Promise<void>((resolve) => {
+            releaseLeave = resolve;
+          }),
+      ),
+    };
+    dialog.$on('open', (event) => {
+      (event as CustomEvent<{ waitUntil(x: unknown): void }>).detail.waitUntil(transitioner);
+    });
+    dialog.$on('close', (event) => {
+      (event as CustomEvent<{ waitUntil(x: unknown): void }>).detail.waitUntil(transitioner);
+    });
+
+    let opened = false;
+    const opening = dialog.open().then(() => {
+      opened = true;
+    });
+    // `enter()` was called on open and its pending promise holds `open()`.
+    expect(transitioner.enter).toHaveBeenCalledTimes(1);
+    expect(transitioner.leave).not.toHaveBeenCalled();
+    await Promise.resolve();
+    expect(opened).toBe(false);
+
+    releaseEnter();
+    await opening;
+    expect(opened).toBe(true);
+
+    const closing = dialog.close();
+    // `leave()` was called on close and the native dialog is still open.
+    expect(transitioner.leave).toHaveBeenCalledTimes(1);
+    await Promise.resolve();
+    expect(el.close).not.toHaveBeenCalled();
+
+    releaseLeave();
+    await closing;
+    expect(el.close).toHaveBeenCalledTimes(1);
+  });
+
+  it('should complete the choreography when a transitioner method rejects', async () => {
+    const { dialog, el } = await createDialog();
+    const warn = vi.fn();
+    Object.defineProperty(dialog, '$warn', { configurable: true, get: () => warn });
+    const error = new Error('transitioner failed');
+    const transitioner = {
+      enter: () => Promise.resolve(),
+      leave: () => Promise.reject(error),
+    };
+    dialog.$on('close', (event) => {
+      (event as CustomEvent<{ waitUntil(x: unknown): void }>).detail.waitUntil(transitioner);
+    });
+
+    await dialog.open();
+    await dialog.close();
+
+    // The rejection is reported, and the dialog still hides and cleans up.
+    expect(warn).toHaveBeenCalledWith('An extension of the `close` event rejected.', error);
+    expect(el.close).toHaveBeenCalledTimes(1);
+    expect(document.documentElement.style.overflow).toBe('');
+  });
+
   it('should ignore and warn on `waitUntil` calls after the event dispatched', async () => {
     const { dialog, el } = await createDialog();
     // `$warn` is a prototype getter: shadow it on the instance to observe calls.
@@ -228,8 +318,9 @@ describe('The Dialog component', () => {
     Object.defineProperty(dialog, '$warn', { configurable: true, get: () => warn });
     let waitUntil: (promise: Promise<unknown>) => void;
     dialog.$on('close', (event) => {
-      ({ waitUntil } = (event as CustomEvent<{ waitUntil(promise: Promise<unknown>): void }>)
-        .detail);
+      ({ waitUntil } = (
+        event as CustomEvent<{ waitUntil(promise: Promise<unknown>): void }>
+      ).detail);
     });
 
     await dialog.open();

--- a/packages/ui/src/Dialog/Dialog.ts
+++ b/packages/ui/src/Dialog/Dialog.ts
@@ -32,6 +32,16 @@ export interface DialogProps extends BaseProps {
 }
 
 /**
+ * A transitioner following the dialog lifecycle — the duck-typed object form
+ * accepted by `waitUntil()`: `enter()` is awaited on `open`, `leave()` on
+ * `close`.
+ */
+interface DialogTransitioner {
+  enter(): unknown;
+  leave(): unknown;
+}
+
+/**
  * Dialog class.
  *
  * A headless wrapper around the native `<dialog>` element. It owns only what
@@ -147,33 +157,42 @@ export class Dialog<T extends BaseProps = BaseProps> extends Base<T & DialogProp
   }
 
   /**
-   * Emit a lifecycle event whose listeners can extend the choreography with
-   * `event.detail.waitUntil(promise)` — any component (or plain JavaScript)
-   * can hold the dialog open (or its `open()` promise pending) without being
-   * a declared child. Registration is only valid while the event dispatches;
-   * later calls warn and are ignored. Every registered promise is wrapped so
-   * a rejection settles with a warning instead of propagating — a failing
-   * extension must never leave the choreography incomplete (native dialog
-   * open, scroll locked).
+   * Emit a bubbling lifecycle event whose listeners can extend the
+   * choreography with `event.detail.waitUntil(x)` — any component (or plain
+   * JavaScript) can hold the dialog open (or its `open()` promise pending)
+   * without being a declared child, and ancestors can route the event since
+   * it bubbles. `waitUntil()` accepts a thenable, or a transitioner: a
+   * duck-typed object with `enter()` and `leave()` methods following the
+   * dialog lifecycle — `enter()` is awaited on `open`, `leave()` on `close`.
+   * Registration is only valid while the event dispatches; later calls warn
+   * and are ignored. Every registered promise is wrapped so a rejection
+   * settles with a warning instead of propagating — a failing extension must
+   * never leave the choreography incomplete (native dialog open, scroll
+   * locked).
    * @private
    */
   __emitExtendable(name: 'open' | 'close'): Promise<unknown>[] {
     const pending: Promise<unknown>[] = [];
+    const method = name === 'open' ? 'enter' : 'leave';
     let dispatching = true;
-    const waitUntil = (promise: Promise<unknown>) => {
+    const waitUntil = (extension: Promise<unknown> | DialogTransitioner) => {
       if (!dispatching) {
         this.$warn(
           `\`waitUntil\` must be called synchronously while the \`${name}\` event dispatches.`,
         );
         return;
       }
+      const value =
+        typeof (extension as DialogTransitioner)?.[method] === 'function'
+          ? (extension as DialogTransitioner)[method]()
+          : extension;
       pending.push(
-        Promise.resolve(promise).catch((error) => {
+        Promise.resolve(value).catch((error) => {
           this.$warn(`An extension of the \`${name}\` event rejected.`, error);
         }),
       );
     };
-    this.$emit(new CustomEvent(name, { detail: { waitUntil } }));
+    this.$emit(new CustomEvent(name, { detail: { waitUntil }, bubbles: true }));
     dispatching = false;
     return pending;
   }


### PR DESCRIPTION
## What

Two additions to the extendable `open`/`close` lifecycle events introduced in #627:

- **The events now bubble** (`bubbles: true`): ancestors can route them declaratively (e.g. through an `Action` higher up the tree), and descendants listening at the document level can join the choreography without being a declared child.
- **`waitUntil()` now also accepts a transitioner**: a duck-typed object with `enter()` and `leave()` methods. `__emitExtendable()` knows which phase is dispatching, so it awaits `enter()` on `open` and `leave()` on `close` — a single handler passing the object itself is enough, no phase-specific expression required. A thenable keeps today's behavior, and the sync-only registration guard and rejection handling (warn + settle, choreography always completes) are unchanged.

```html
<dialog
  data-component="Action Dialog"
  data-on:close="MotionView(#nav)->event.detail.waitUntil(target)"
  data-on:cancel.prevent="Dialog.close()">
  <nav id="nav">…</nav>
</dialog>
```

## Why

This is the duck-typed handshake the upcoming ambient `MotionView` from `@studiometa/ui-motion` builds on: a transitioner exposing `enter()`/`leave()` can follow the dialog lifecycle without knowing anything about `Dialog`, and `Dialog` needs to know nothing about Motion. With bubbling events, the ambient `MotionView` can pick up a dialog's lifecycle from the tree by itself — the common case becomes pure nesting with no attributes, and the `Action` expression above stays as the explicit escape hatch.

## Test plan

- [x] New specs: the `open`/`close` events reach an ancestor listener (`document.body`); a transitioner given to `waitUntil()` gets `enter()` called on open and `leave()` on close, with the dialog's promises held pending until each phase's promise resolves (same ordering assertions as the existing `waitUntil` specs); a transitioner whose method rejects behaves like a rejected promise — warned and settled, the dialog still hides and cleans up.
- [x] All existing Dialog specs pass unchanged.
- [x] `npm run test` — 98 files, 806 tests passed.
- [x] `npm run lint` — 0 errors, 19 warnings (baseline).
- [x] `cd packages/docs && node scripts/validate-reference.ts` — "Documentation validation passed".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FVXrJ8idMfvt667yJadvB8
