### PR TITLE
Follow Motion React for gesture returns and expose trackContentSize

### DIFF
--- a/packages/docs/reference/items/Motion/examples.md
+++ b/packages/docs/reference/items/Motion/examples.md
@@ -69,7 +69,7 @@ The `motion-*` events bubble, so a single routing [`Action`](/reference/items/Ac
 
 ## Gestures
 
-The `hover`, `press` and `inView` options apply keyframes while their state holds, through Motion's own gesture functions: hover filters out touch emulation, press responds to pointer and keyboard alike, and in-view uses a real `IntersectionObserver`. When the state ends, the gesture animation plays backward — no base values to declare.
+The `hover`, `press` and `inView` options apply keyframes while their state holds, through Motion's own gesture functions: hover filters out touch emulation, press responds to pointer and keyboard alike, and in-view uses a real `IntersectionObserver`. When the state ends, a new animation plays forward to the base values of the properties the gesture touched — the base values are read from the element itself, so there is nothing to declare.
 
 <llm-exclude>
   <PreviewPlayground

--- a/packages/docs/reference/items/Motion/js-api.md
+++ b/packages/docs/reference/items/Motion/js-api.md
@@ -92,7 +92,7 @@ Whether the `animate` keyframes play automatically on mount. Enable it with the 
 - Type: `DOMKeyframesDefinition`
 - Default: `{}`
 
-Keyframes applied while the element is hovered, through Motion's [`hover()`](https://motion.dev/docs/hover) — real hover only, touch emulation is filtered out. When the hover ends, the gesture animation plays backward, returning the element to the styles it had when the gesture began.
+Keyframes applied while the element is hovered, through Motion's [`hover()`](https://motion.dev/docs/hover) — real hover only, touch emulation is filtered out. When the hover ends, a new animation plays **forward** to the base values of the properties the gesture touched, with the same [`transition`](#transition) — the same return Motion for React performs when it deactivates a `whileHover` variant. The base value of each property is read from the element once, the first time a gesture touches it, so the return never plays the easing or spring curve backward and never depends on a gesture animation still being around.
 
 <!-- prettier-ignore-start -->
 ```html {3}
@@ -109,14 +109,14 @@ Keyframes applied while the element is hovered, through Motion's [`hover()`](htt
 - Type: `DOMKeyframesDefinition`
 - Default: `{}`
 
-Keyframes applied while the element is pressed, through Motion's [`press()`](https://motion.dev/docs/press) — pointer and keyboard alike, so the state is accessible for free. Reverts like `hover` when the press ends.
+Keyframes applied while the element is pressed, through Motion's [`press()`](https://motion.dev/docs/press) — pointer and keyboard alike, so the state is accessible for free. Returns to the base values like `hover` when the press ends.
 
 ### `inView`
 
 - Type: `DOMKeyframesDefinition`
 - Default: `{}`
 
-Keyframes applied when the element enters the viewport, through Motion's [`inView()`](https://motion.dev/docs/inview). Reverts when the element leaves, unless [`once`](#once) is set.
+Keyframes applied when the element enters the viewport, through Motion's [`inView()`](https://motion.dev/docs/inview). Returns to the base values when the element leaves, unless [`once`](#once) is set. Declaring [`initial`](#initial) is the way to choose those base values: it is applied on mount, so it is what the element holds when the first reveal reads it.
 
 <!-- prettier-ignore-start -->
 ```html {3,4}
@@ -152,7 +152,7 @@ How much of the element must be visible to trigger `inView`: `"some"`, `"all"`, 
 When set, the `inView` keyframes play once and the reached styles persist — the element is no longer watched.
 
 ::: info Gesture animations are transient
-The gesture options animate alongside the declared animation: they never become the [current animation](#methods) and emit no lifecycle events. Like `scroll()`, the gesture functions are not part of `motion/mini` — a gesture option warns and is skipped when the [provided module](#providing-the-motion-dependency) lacks its function.
+The gesture options animate alongside the declared animation: they never become the [current animation](#methods) and emit no lifecycle events — and neither does the animation returning to the base values. Like `scroll()`, the gesture functions are not part of `motion/mini` — a gesture option warns and is skipped when the [provided module](#providing-the-motion-dependency) lacks its function.
 :::
 
 ## Events

--- a/packages/docs/reference/items/Motion/stories/gestures/app.twig
+++ b/packages/docs/reference/items/Motion/stories/gestures/app.twig
@@ -27,7 +27,7 @@
     data-option-in-view-amount="0.5"
     data-option-transition='{ "type": "spring", "bounce": 0.3 }'
     class="px-6 py-4 rounded-lg bg-emerald-400 dark:bg-emerald-600 text-white font-bold">
-    I reveal in view, and revert when I leave
+    I reveal in view, and return when I leave
   </div>
 
   <div class="h-[40vh]"></div>

--- a/packages/docs/reference/items/MotionScrollTimeline/js-api.md
+++ b/packages/docs/reference/items/MotionScrollTimeline/js-api.md
@@ -36,7 +36,27 @@ The scroll range, in Motion's [offset syntax](https://motion.dev/docs/scroll#off
 
 The scroll axis driving the timeline.
 
+### `trackContentSize`
+
+- Type: `boolean`
+- Default: `false`
+
+Watch the scroll container for content size changes, through Motion's own [`trackContentSize`](https://motion.dev/docs/scroll) option. The scroll range is measured once and re-measured on resize, so content that grows or shrinks **after** mount without resizing anything — lazy-loaded images landing, a filtered list dropping rows, an accordion opening — leaves the timeline mapped to a range the page no longer has. Turn this on there.
+
+It is not free: Motion compares the container's `scrollWidth` and `scrollHeight` on **every frame** for as long as the timeline lives, and each change costs a re-measure. Leave it off when the content settles before the first scroll.
+
+<!-- prettier-ignore-start -->
+```html {3}
+<section
+  data-component="MotionScrollTimeline"
+  data-option-track-content-size>
+  …
+</section>
+```
+<!-- prettier-ignore-end -->
+
 ## Notes
 
 - `scroll()` is not part of `motion/mini`: when the [provided module](/reference/items/Motion/js-api#providing-the-motion-dependency) lacks it, the timeline warns and leaves its children untouched.
 - Each child gets its own `scroll()` link, released when the timeline is destroyed.
+- `trackContentSize` only changes the JavaScript path: where the browser drives the timeline natively with `ScrollTimeline` or `ViewTimeline`, it reads the live scroll range on its own.

--- a/packages/tests/Motion/Motion.gestures.spec.ts
+++ b/packages/tests/Motion/Motion.gestures.spec.ts
@@ -15,6 +15,9 @@ import { h, wait } from '#test-utils';
 
 async function mountMotion(attributes: Record<string, string> = {}) {
   const el = h('div', { dataComponent: 'Motion', ...attributes });
+  // Connected on purpose: reading a base value goes through the computed
+  // style, which happy-dom only resolves for elements in the document.
+  document.body.append(el);
   const instance = new Motion(el);
   await instance.$mount();
   await wait(0);
@@ -25,6 +28,7 @@ async function mountMotion(attributes: Record<string, string> = {}) {
 describe('Motion gesture options', () => {
   beforeEach(() => {
     resetMockMotion();
+    document.body.innerHTML = '';
   });
 
   it('should bind nothing without gesture options', async () => {
@@ -35,7 +39,7 @@ describe('Motion gesture options', () => {
     expect(mockInView.fn).not.toHaveBeenCalled();
   });
 
-  it('should animate to the hover state and revert by reversing', async () => {
+  it('should animate to the hover state and return forward to the base values', async () => {
     const { el, instance } = await mountMotion({
       dataOptionHover: '{ "scale": 1.1 }',
       dataOptionTransition: '{ "duration": 0.2 }',
@@ -50,29 +54,55 @@ describe('Motion gesture options', () => {
     // The gesture never becomes the current animation.
     expect(instance.controls).toBeNull();
 
-    // Simulate the gesture end: the same animation plays backward.
+    // Simulate the gesture end: a NEW animation forward to the base value —
+    // with no declared `animate`, `scale` returns to Motion's own base of 1.
     const gesture = animations.at(-1);
     (end as () => void)();
-    expect(gesture.speed).toBe(-1);
-    expect(gesture.playCount).toBe(1);
+    expect(mockAnimate).toHaveBeenLastCalledWith(el, { scale: 1 }, { duration: 0.2 });
+    expect(animations).toHaveLength(2);
+    // The gesture animation itself is left alone: never rewound, never replayed.
+    expect(gesture.speed).toBe(1);
+    expect(gesture.playCount).toBe(0);
+    // The return stays transient too.
+    expect(instance.controls).toBeNull();
   });
 
-  it('should animate to the press state and revert by reversing', async () => {
+  it('should capture the base values once, before the gesture moves the element', async () => {
+    const { el } = await mountMotion({ dataOptionHover: '{ "scale": 1.1 }' });
+
+    const firstEnd = mockHover.handlers[0](el) as () => void;
+    firstEnd();
+
+    // Hover again while the element sits at the gesture state: the base value
+    // is still the one captured on the first gesture, never re-read from an
+    // element the gesture already moved.
+    el.style.transform = 'matrix(1.1, 0, 0, 1.1, 0, 0)';
+    const secondEnd = mockHover.handlers[0](el) as () => void;
+    secondEnd();
+
+    expect(animations.at(-1).keyframes).toEqual({ scale: 1 });
+  });
+
+  it('should animate to the press state and return forward to the base values', async () => {
     const { el } = await mountMotion({ dataOptionPress: '{ "scale": 0.95 }' });
 
     expect(mockPress.fn).toHaveBeenCalledTimes(1);
     const end = mockPress.handlers[0](el);
     expect(mockAnimate).toHaveBeenCalledWith(el, { scale: 0.95 }, {});
 
+    const gesture = animations.at(-1);
     (end as () => void)();
-    expect(animations.at(-1).speed).toBe(-1);
+    expect(mockAnimate).toHaveBeenLastCalledWith(el, { scale: 1 }, {});
+    expect(gesture.speed).toBe(1);
   });
 
-  it('should forward the inView options and revert on leave', async () => {
+  it('should forward the inView options and return on leave', async () => {
     const { el } = await mountMotion({
       dataOptionInView: '{ "opacity": 1 }',
       dataOptionInViewMargin: '-100px',
       dataOptionInViewAmount: '0.5',
+      // The base of a style property is read from the computed style.
+      style: 'opacity: 0',
     });
 
     expect(mockInView.fn).toHaveBeenCalledTimes(1);
@@ -83,7 +113,7 @@ describe('Motion gesture options', () => {
     expect(typeof leave).toBe('function');
 
     (leave as () => void)();
-    expect(animations.at(-1).speed).toBe(-1);
+    expect(mockAnimate).toHaveBeenLastCalledWith(el, { opacity: 0 }, {});
   });
 
   it('should keep the reached state and stop watching with once', async () => {

--- a/packages/tests/Motion/MotionScrollTimeline.spec.ts
+++ b/packages/tests/Motion/MotionScrollTimeline.spec.ts
@@ -67,6 +67,20 @@ describe('MotionScrollTimeline component', () => {
     expect(scrollLinks[0].options.axis).toBe('x');
   });
 
+  it('should not track the content size by default', async () => {
+    await mountTimeline();
+
+    expect(scrollLinks[0].options).not.toHaveProperty('trackContentSize');
+  });
+
+  it('should forward the trackContentSize option', async () => {
+    await mountTimeline({ dataOptionTrackContentSize: '' });
+
+    for (const link of scrollLinks) {
+      expect(link.options.trackContentSize).toBe(true);
+    }
+  });
+
   it('should release every scroll link on destroy', async () => {
     const { instance } = await mountTimeline();
 

--- a/packages/tests/Motion/mock-motion.ts
+++ b/packages/tests/Motion/mock-motion.ts
@@ -1,4 +1,7 @@
 import { vi } from 'vitest';
+// The value readers are pure DOM readers, not animation drivers: the double
+// uses the real ones so the captured base values follow Motion's semantics.
+import { transformProps, readTransformValue, getComputedStyle } from 'motion';
 import { provideMotion, type MotionModule } from '@studiometa/ui-motion';
 
 /**
@@ -246,6 +249,9 @@ export const mockMotionModule = {
   hover: mockHover.fn,
   press: mockPress.fn,
   inView: mockInView.fn,
+  transformProps,
+  readTransformValue,
+  getComputedStyle,
 };
 
 provideMotion(mockMotionModule as unknown as MotionModule);

--- a/packages/ui-motion/src/Motion.ts
+++ b/packages/ui-motion/src/Motion.ts
@@ -86,6 +86,13 @@ export class Motion<T extends BaseProps = BaseProps> extends Base<MotionProps & 
   __gestureStops: VoidFunction[] = [];
 
   /**
+   * The base value of every property a gesture animated, captured the first
+   * time a gesture touched it — the values a gesture returns to when it ends.
+   * @private
+   */
+  __baseValues: Record<string, string | number> = {};
+
+  /**
    * Whether the current animation was built from the `animate` and
    * `transition` options, as opposed to an imperative `animate()` call.
    * @private
@@ -312,8 +319,8 @@ export class Motion<T extends BaseProps = BaseProps> extends Base<MotionProps & 
       if (motion.hover) {
         this.__gestureStops.push(
           motion.hover(this.$el, () => {
-            const controls = this.__startGesture(hover);
-            return () => this.__revertGesture(controls);
+            this.__startGesture(hover);
+            return () => this.__revertGesture(hover);
           }),
         );
       } else {
@@ -325,8 +332,8 @@ export class Motion<T extends BaseProps = BaseProps> extends Base<MotionProps & 
       if (motion.press) {
         this.__gestureStops.push(
           motion.press(this.$el, () => {
-            const controls = this.__startGesture(press);
-            return () => this.__revertGesture(controls);
+            this.__startGesture(press);
+            return () => this.__revertGesture(press);
           }),
         );
       } else {
@@ -348,13 +355,13 @@ export class Motion<T extends BaseProps = BaseProps> extends Base<MotionProps & 
           motion.inView(
             this.$el,
             () => {
-              const controls = this.__startGesture(inView);
+              this.__startGesture(inView);
               // With no leave handler returned, `inView()` fires once and the
               // reached styles persist.
               if (once) {
                 return undefined;
               }
-              return () => this.__revertGesture(controls);
+              return () => this.__revertGesture(inView);
             },
             options as Parameters<NonNullable<MotionModule['inView']>>[2],
           ),
@@ -367,22 +374,79 @@ export class Motion<T extends BaseProps = BaseProps> extends Base<MotionProps & 
 
   /**
    * Animate to a gesture state, alongside — not replacing — the current
-   * animation.
+   * animation, capturing the base value of every property it touches first.
    * @private
    */
   __startGesture(keyframes: DOMKeyframesDefinition): AnimationPlaybackControlsWithThen {
+    this.__captureBaseValues(keyframes);
     return getMotion().animate(this.$el, keyframes, this.$options.transition);
   }
 
   /**
-   * Revert a gesture by playing its animation backward: the element returns
-   * to the exact styles captured when the gesture started, with no knowledge
-   * of base values needed.
+   * Capture the element's current value for every property a gesture is about
+   * to animate, once per property and never refreshed afterwards.
+   *
+   * The read mirrors Motion's own `VisualElement.readValueFromInstance()`: the
+   * parsed transform matrix for a transform property, the computed style
+   * otherwise — both through Motion's own readers, so the values come back in
+   * the shape its animations expect. Motion React hydrates the same snapshot
+   * (its `baseTarget`) the first time it reads a value and keeps it, which is
+   * what makes a return immune to a second gesture starting while the previous
+   * one is still returning.
+   *
+   * A property the readers cannot resolve is left out, so nothing is invented:
+   * the return animation simply does not touch it.
    * @private
    */
-  __revertGesture(controls: AnimationPlaybackControlsWithThen) {
-    controls.speed = -Math.abs(controls.speed || 1);
-    controls.play();
+  __captureBaseValues(keyframes: DOMKeyframesDefinition) {
+    const { transformProps, readTransformValue, getComputedStyle } = getMotion();
+
+    for (const property of Object.keys(keyframes)) {
+      if (property in this.__baseValues) {
+        continue;
+      }
+
+      if (readTransformValue && transformProps?.has(property)) {
+        this.__baseValues[property] = readTransformValue(this.$el, property);
+        continue;
+      }
+
+      const computed = getComputedStyle?.(this.$el, property);
+
+      if (typeof computed === 'string' && computed !== '') {
+        const numeric = Number(computed);
+        this.__baseValues[property] = Number.isNaN(numeric) ? computed : numeric;
+      }
+    }
+  }
+
+  /**
+   * Return the element to its base values when a gesture ends, animating
+   * forward with the `transition` option — the gesture animation is never
+   * rewound.
+   *
+   * This is what Motion React does: ending a gesture deactivates its variant
+   * (`node.animationState.setActive("whileHover", false)`), which recomputes
+   * the target of every property the variant owned and animates to it. Playing
+   * the gesture animation backward instead would run its easing or spring
+   * curve in reverse — a different feel — and could never reach a base value
+   * the element did not hold when the gesture started.
+   * @private
+   */
+  __revertGesture(keyframes: DOMKeyframesDefinition) {
+    const base: Record<string, string | number> = {};
+
+    for (const property of Object.keys(keyframes)) {
+      if (property in this.__baseValues) {
+        base[property] = this.__baseValues[property];
+      }
+    }
+
+    if (Object.keys(base).length === 0) {
+      return;
+    }
+
+    getMotion().animate(this.$el, base as DOMKeyframesDefinition, this.$options.transition);
   }
 
   /**

--- a/packages/ui-motion/src/MotionScrollTimeline.ts
+++ b/packages/ui-motion/src/MotionScrollTimeline.ts
@@ -4,7 +4,16 @@ import type { scroll } from 'motion';
 import { Motion } from './Motion.js';
 import { resolveMotion } from './dependencies.js';
 
-type ScrollOptions = NonNullable<Parameters<typeof scroll>[1]>;
+/**
+ * The options `scroll()` accepts, widened with `trackContentSize`.
+ *
+ * `scroll()` forwards every option it does not read itself to `scrollInfo()`,
+ * which declares `trackContentSize` on its own `ScrollInfoOptions` — Motion's
+ * public `ScrollOptions` interface simply omits it.
+ */
+type ScrollOptions = NonNullable<Parameters<typeof scroll>[1]> & {
+  trackContentSize?: boolean;
+};
 
 export interface MotionScrollTimelineProps extends BaseProps {
   $children: {
@@ -13,6 +22,7 @@ export interface MotionScrollTimelineProps extends BaseProps {
   $options: {
     offset: string[];
     axis: 'x' | 'y';
+    trackContentSize: boolean;
   };
 }
 
@@ -53,6 +63,7 @@ export class MotionScrollTimeline<T extends BaseProps = BaseProps> extends Base<
     options: {
       offset: { type: Array, default: () => ['start end', 'end start'] },
       axis: { type: String, default: 'y' },
+      trackContentSize: Boolean,
     },
   };
 
@@ -108,10 +119,13 @@ export class MotionScrollTimeline<T extends BaseProps = BaseProps> extends Base<
       return;
     }
 
-    const { offset, axis } = this.$options;
+    const { offset, axis, trackContentSize } = this.$options;
     const options: ScrollOptions = { target: this.$el, axis };
     if (offset.length > 0) {
       options.offset = offset as ScrollOptions['offset'];
+    }
+    if (trackContentSize) {
+      options.trackContentSize = true;
     }
     this.__stops.push(scrollFn(controls, options));
   }

--- a/packages/ui-motion/src/dependencies.ts
+++ b/packages/ui-motion/src/dependencies.ts
@@ -1,4 +1,14 @@
-import type { animate, animateView, scroll, hover, press, inView } from 'motion';
+import type {
+  animate,
+  animateView,
+  scroll,
+  hover,
+  press,
+  inView,
+  transformProps,
+  readTransformValue,
+  getComputedStyle,
+} from 'motion';
 
 /**
  * The subset of the `motion` module the components consume. Declared
@@ -8,6 +18,11 @@ import type { animate, animateView, scroll, hover, press, inView } from 'motion'
  * does not ship it: `animateView` powers `MotionView`, `scroll` powers
  * `MotionScrollTimeline`, and `hover`, `press` and `inView` power the
  * matching `Motion` gesture options.
+ *
+ * `transformProps`, `readTransformValue` and `getComputedStyle` are Motion's
+ * own value readers. `Motion` uses them to capture the base value a gesture
+ * returns to, the way Motion's `VisualElement.readValueFromInstance()` does.
+ * They ship alongside the gesture functions in the full entry.
  */
 export interface MotionModule {
   animate: typeof animate;
@@ -16,6 +31,9 @@ export interface MotionModule {
   hover?: typeof hover;
   press?: typeof press;
   inView?: typeof inView;
+  transformProps?: typeof transformProps;
+  readTransformValue?: typeof readTransformValue;
+  getComputedStyle?: typeof getComputedStyle;
 }
 
 let motionInstance: MotionModule | undefined;


### PR DESCRIPTION
## What

Two independent alignments with what Motion itself does.

### Follow Motion React for the gesture return

A `hover` or `press` gesture used to end by rewinding its own animation (`controls.speed = -1`). Motion React never does that: it drives these gestures through its variant state machine, and ending one only deactivates the variant —

```js
// node_modules/framer-motion/dist/es/gestures/hover.mjs
node.animationState.setActive("whileHover", lifecycle === "Start");
```

Deactivating recomputes the target of every property the variant owned and animates **forward** to it (`animation-state.mjs` collects them in `removedKeys` and pushes a `fallbackAnimation`). Rewinding is a different thing: it plays the easing or spring curve backward, and it can only ever land where the gesture started because it has no notion of a base value at all.

The gesture handlers now animate forward to the base values of exactly the properties the gesture touched, with the same `transition` option.

**Base value mechanism.** Motion's own value readers, through the injected module: `readTransformValue(el, property)` for a property in `transformProps`, `getComputedStyle(el, property)` otherwise. That is exactly what Motion's `HTMLVisualElement.readValueFromInstance()` does, and it is the last step of React's `getBaseTarget()` chain. The read happens once per property, the first time a gesture touches it, and is never refreshed — the same one-shot hydration React applies to its `baseTarget` ("only hydrated on creation and when we first read a value"), which is what makes a return immune to a second gesture starting while the previous one is still returning. The earlier steps of React's chain need no equivalent here: our `initial` option is applied to the element on mount, so the DOM read already returns it, and there is no `style` prop to consult. A property neither reader can resolve is left out of the return rather than given an invented default.

`MotionModule` gains `transformProps`, `readTransformValue` and `getComputedStyle` as optional members. They ship in the full `motion` entry alongside `hover`, `press` and `inView`, which gesture options already require.

Everything else about gestures is unchanged: the return is transient like the gesture itself (never the current animation, no lifecycle events), empty options bind nothing, a missing gesture function still warns and skips, and `once` / `inViewMargin` / `inViewAmount` behave as before.

### Expose `scroll()`'s `trackContentSize`

`MotionScrollTimeline` gains a `trackContentSize` Boolean option (default `false`), forwarded into the `ScrollOptions` object alongside `target`, `axis` and `offset`. `scroll()` spreads the options it does not read itself down to `scrollInfo()`, which declares and implements `trackContentSize` — so the option reaches Motion untouched.

Two accuracy notes, both from the installed source rather than assumption:

- The option is real in `motion@13.0.0` but **absent from the public `ScrollOptions` interface** — only `ScrollInfoOptions` declares it. The local type alias is widened with a comment explaining why.
- It costs a **per-frame `scrollWidth` / `scrollHeight` comparison**, not a `ResizeObserver` (`frame.read(checkScrollDimensions, true)` in `render/dom/scroll/track.mjs`). A `ResizeObserver` is already registered for non-document containers regardless of this option. The docs say per-frame.

## Test plan

- `npm run test` — 106 files, 885 passed / 3 skipped / 1 todo.
- `npm run build --workspace=@studiometa/ui-motion` — passes.
- `npm run lint` — 0 errors, 20 warnings (all pre-existing).
- `cd packages/docs && node scripts/validate-reference.ts` — 66 entries, 273 symbols, 5 concepts.
- Playground deps rebuilt so the live previews run the new code.

New and updated specs:

- The hover and press end handlers trigger a new forward `animate()` call to the base values, carrying the `transition` option, and leave the gesture animation untouched (`speed` stays `1`, `playCount` stays `0`).
- A `hover` of `{ scale: 1.1 }` on an element with no declared `animate` returns `scale` to `1`.
- A base value is captured once: hovering again while the element sits at the gesture state still returns to the value captured on the first gesture.
- The in-view leave returns `opacity` to the base read from the computed style.
- `trackContentSize` reaches the `scroll()` options object, and is absent by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FVXrJ8idMfvt667yJadvB8
