### PR TITLE
Prepare the 1.11.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [v1.11.0](https://github.com/studiometa/ui/compare/1.10.0..1.11.0) (2026-09-01)
+
+This release is led by `@studiometa/ui-motion`, a new package for declarative animation with [Motion](https://motion.dev), and by the `dom-update` protocol event — a shared announcement that lets a component substitute how an imminent DOM change is applied, which `DataBind`, `Dialog` and `Fetch` all now speak.
+
 ### Added
 
 - **@studiometa/ui-motion:** add a new `@studiometa/ui-motion` package with the `Motion`, `MotionScrollTimeline`, `MotionSequence` and `MotionView` components to animate elements declaratively with [Motion](https://motion.dev) ([#628](https://github.com/studiometa/ui/pull/628), [#629](https://github.com/studiometa/ui/pull/629), [#630](https://github.com/studiometa/ui/pull/630), [#633](https://github.com/studiometa/ui/pull/633), [#636](https://github.com/studiometa/ui/pull/636), [#637](https://github.com/studiometa/ui/pull/637), [#638](https://github.com/studiometa/ui/pull/638), [#640](https://github.com/studiometa/ui/pull/640), [#641](https://github.com/studiometa/ui/pull/641))
@@ -13,8 +17,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
-- **Fetch:** send every value of a repeated GET form field instead of the last one, so a checkbox group or a `<select multiple>` no longer reaches the server with one of its values
-- **Fetch:** push the element's own destination in history rather than the fetched URL, so a `src` pointing at a lighter endpoint no longer leaks into the address bar — see the new `historyUrl` getter
+- **Fetch:** send every value of a repeated GET form field instead of the last one, so a checkbox group or a `<select multiple>` no longer reaches the server with one of its values ([#643](https://github.com/studiometa/ui/pull/643))
+- **Fetch:** push the element's own destination in history rather than the fetched URL, so a `src` pointing at a lighter endpoint no longer leaks into the address bar — see the new `historyUrl` getter ([#643](https://github.com/studiometa/ui/pull/643))
 
 ### Changed
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "studiometa/ui",
   "type": "composer-plugin",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "description": "Accessible and composable JavaScript behaviors and Twig templates.",
   "license": "MIT",
   "require": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@studiometa/ui-workspace",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@studiometa/ui-workspace",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "hasInstallScript": true,
       "workspaces": [
         "packages/*"
@@ -22411,11 +22411,11 @@
     },
     "packages/api": {
       "name": "@studiometa/ui-api",
-      "version": "1.10.0"
+      "version": "1.11.0"
     },
     "packages/docs": {
       "name": "@studiometa/ui-docs",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "dependencies": {
         "@studiometa/js-toolkit": "3.9.0"
       },
@@ -22541,7 +22541,7 @@
     },
     "packages/eslint-plugin-ui": {
       "name": "@studiometa/eslint-plugin-ui",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "license": "MIT",
       "dependencies": {
         "@oxlint/plugins": "1.63.0"
@@ -22556,7 +22556,7 @@
     },
     "packages/playground": {
       "name": "@studiometa/ui-playground",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "dependencies": {
         "@studiometa/playground": "^0.3.13"
       },
@@ -22573,7 +22573,7 @@
     },
     "packages/tests": {
       "name": "@studiometa/ui-tests",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "license": "MIT",
       "dependencies": {
         "@happy-dom/global-registrator": "^20.8.8",
@@ -22804,7 +22804,7 @@
     },
     "packages/ui": {
       "name": "@studiometa/ui",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "license": "MIT",
       "dependencies": {
         "alien-signals": "^3.2.1",
@@ -22827,7 +22827,7 @@
     },
     "packages/ui-mapbox": {
       "name": "@studiometa/ui-mapbox",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "license": "MIT",
       "devDependencies": {
         "@mapbox/mapbox-gl-geocoder": "^5.1.0",
@@ -22849,7 +22849,7 @@
     },
     "packages/ui-motion": {
       "name": "@studiometa/ui-motion",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "license": "MIT",
       "devDependencies": {
         "@studiometa/js-toolkit": "^3.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-workspace",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "type": "module",
   "private": true,
   "workspaces": [

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-api",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "private": true,
   "type": "commonjs"
 }

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-docs",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/eslint-plugin-ui/package.json
+++ b/packages/eslint-plugin-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/eslint-plugin-ui",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "description": "ESLint plugin to help developers discover and use @studiometa/ui components",
   "publishConfig": {
     "access": "public"

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-playground",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-tests",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/ui-mapbox/package.json
+++ b/packages/ui-mapbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-mapbox",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "description": "Vanilla js-toolkit components to build Mapbox GL maps declaratively",
   "publishConfig": {
     "access": "public"

--- a/packages/ui-motion/package.json
+++ b/packages/ui-motion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-motion",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "description": "Vanilla js-toolkit components to animate elements declaratively with Motion",
   "publishConfig": {
     "access": "public"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "description": "Accessible and composable JavaScript behaviors and templates",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Release preparation, following the shape of #624 (1.10.0): a changelog commit, then a version commit. **No tag** — `publish.yml` fires on `push: tags: '*.*.*'`, so tagging is the release action and stays yours to take on the merge commit.

## Why minor

The unreleased set adds a package (`@studiometa/ui-motion`) and new features (`data-bind:if`, `Toaster` follow-ups, the `dom-update` protocol), alongside two fixes. Nothing removed, nothing renamed → `1.11.0`.

## Commits

**Add 1.11.0 changelog entry** — the `Unreleased` section becomes `v1.11.0` with a compare link and today's date, and an empty `Unreleased` stays at the top as at 1.10.0. The two `Fetch` fixes from #643 gained their PR reference, which they were missing.

The summary paragraph leads with `@studiometa/ui-motion` and the `dom-update` protocol event, since those are what a reader of this release most needs to know about.

**Prepare 1.11.0** — `npm version 1.11.0 --no-git-tag-version`, letting `postversion` do the propagation it exists for:

| | |
| --- | --- |
| Root | `package.json`, `package-lock.json` |
| Workspaces | api, docs, eslint-plugin-ui, playground, tests, ui, ui-mapbox, **ui-motion** |
| PHP | `composer.json`, via `scripts/update-composer-version.js` |

`ui-motion` is the one addition to the file set compared with the 1.10.0 bump — it did not exist then.

## Verified before pushing

- `npm run test` — 893 passed, 3 skipped, 1 todo
- `npm run lint` — clean
- `npm run build` — clean, and it left no stray files in the working tree
- `npm run manifest:check` — clean
- no local tag was created; `git tag -l '1.11*'` is empty

## After merging

Tag the merge commit `1.11.0` and push it to trigger `publish.yml`. #644 (the `2.x` cherry-pick) is independent and can land whenever.