### PR TITLE
Fix Fetch keeping src in history on a click or a submit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- **Fetch:** apply the `historyUrl` separation to a link click and a form submit, not only to a bare `fetch()` call — the declarative handlers passed the resolved URL on, which read as a caller naming a destination and kept a `src` in the address bar ([#646](https://github.com/studiometa/ui/pull/646))
+
 ## [v1.11.0](https://github.com/studiometa/ui/compare/1.10.0..1.11.0) (2026-09-01)
 
 This release is led by `@studiometa/ui-motion`, a new package for declarative animation with [Motion](https://motion.dev), and by the `dom-update` protocol event — a shared announcement that lets a component substitute how an imminent DOM change is applied, which `DataBind`, `Dialog` and `Fetch` all now speak.

--- a/packages/tests/Fetch/Fetch.spec.ts
+++ b/packages/tests/Fetch/Fetch.spec.ts
@@ -300,7 +300,9 @@ describe('The Fetch class', () => {
       anchor.dispatchEvent(new MouseEvent('click', { button: 0 }));
 
       expect(fetchSpy).toHaveBeenCalledOnce();
-      expect(fetchSpy).toHaveBeenCalledWith(fetch.url, fetch.requestInit);
+      // No URL: the handler defers to the element, which is what lets `historyUrl`
+      // differ from the requested one.
+      expect(fetchSpy).toHaveBeenCalledWith(undefined, fetch.requestInit);
     });
 
     it('should not trigger fetch on link click with meta key', async () => {
@@ -778,6 +780,61 @@ describe('The Fetch class', () => {
       );
       // …and left a URL somebody can copy.
       expect(historySpy).toHaveBeenCalledWith({}, '', '/projects/page/2?orderby=title');
+      historySpy.mockRestore();
+    });
+
+    it('should push the destination when a link is clicked, not only on a bare fetch()', async () => {
+      // The declarative path is the one people use, and it was the one the first version
+      // of this missed: `onClick` passed `this.url` on, which reads as a caller naming a
+      // destination and put the `src` back in the address bar.
+      (window as any).happyDOM.setURL('https://example.com/');
+      const anchor = h('a', {
+        href: 'https://example.com/projects/page/2?orderby=title',
+        dataOptionSrc: '/projects/page/2?orderby=title&sections=listing',
+        dataOptionHistory: true,
+      });
+      const fetch = new Fetch(anchor);
+      const clientSpy = vi.fn(() => Promise.resolve(new Response('<div id="test">content</div>')));
+      vi.spyOn(fetch, 'client', 'get').mockImplementation(() => clientSpy);
+      const historySpy = vi.spyOn(window.history, 'pushState');
+      historySpy.mockImplementation(() => undefined);
+
+      await mount(fetch);
+      anchor.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+      await wait(50);
+
+      expect(clientSpy).toHaveBeenCalledWith(
+        new URL('https://example.com/projects/page/2?orderby=title&sections=listing'),
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      );
+      expect(historySpy).toHaveBeenCalledWith({}, '', '/projects/page/2?orderby=title');
+      historySpy.mockRestore();
+    });
+
+    it('should push the destination when a GET form is submitted', async () => {
+      (window as any).happyDOM.setURL('https://example.com/');
+      const input = h('input', { name: 'q', value: 'live' });
+      const form = h(
+        'form',
+        {
+          action: 'https://example.com/search',
+          method: 'get',
+          dataOptionSrc: '/search/suggest?sections=results',
+          dataOptionHistory: true,
+        },
+        [input],
+      );
+      const fetch = new Fetch(form);
+      const clientSpy = vi.fn(() => Promise.resolve(new Response('<div id="test">content</div>')));
+      vi.spyOn(fetch, 'client', 'get').mockImplementation(() => clientSpy);
+      const historySpy = vi.spyOn(window.history, 'pushState');
+      historySpy.mockImplementation(() => undefined);
+
+      await mount(fetch);
+      form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+      await wait(50);
+
+      expect(historySpy).toHaveBeenCalledWith({}, '', '/search?q=live');
       historySpy.mockRestore();
     });
 

--- a/packages/ui/src/Fetch/Fetch.ts
+++ b/packages/ui/src/Fetch/Fetch.ts
@@ -316,7 +316,10 @@ export class Fetch<T extends BaseProps = BaseProps>
       this.$el.target !== '_blank'
     ) {
       event.preventDefault();
-      this.fetch(this.url, this.requestInit);
+      // No URL: this is the element's own navigation, so `historyUrl` decides what the
+      // address bar gets. Passing `this.url` here would look identical and read as a
+      // caller naming a destination, which keeps a `src` in history.
+      this.fetch(undefined, this.requestInit);
     }
   }
 
@@ -329,7 +332,10 @@ export class Fetch<T extends BaseProps = BaseProps>
 
     if (this.$el.target !== '_blank') {
       event.preventDefault();
-      this.fetch(this.url, this.requestInit);
+      // No URL: this is the element's own navigation, so `historyUrl` decides what the
+      // address bar gets. Passing `this.url` here would look identical and read as a
+      // caller naming a destination, which keeps a `src` in history.
+      this.fetch(undefined, this.requestInit);
     }
   }
 


### PR DESCRIPTION
A defect in #643, shipped in 1.11.0. The `historyUrl` separation only took effect for a bare `fetch()` call, which is not how anyone uses the component.

Both declarative handlers pass the resolved URL on:

```ts
onClick()  { … this.fetch(this.url, this.requestInit); }
onSubmit() { … this.fetch(this.url, this.requestInit); }
```

`fetch()` reads an explicit URL as *a caller naming its own destination* and pushes it verbatim — correct for `Fetch.fetch('/somewhere')` from a decorator, wrong here, because a click is the element's own navigation. So a link with `src` and `history` still pushed the `src`, which is precisely the case the feature was written for.

The handlers now pass no URL and defer to the element.

## How it got through

The tests I added in #643 called `fetch()` directly and asserted `historyUrl` in isolation. Neither exercised a click. The two new tests dispatch a real `click` and a real `submit`, and assert both halves: the lighter endpoint is requested, and the address bar gets the element's own destination.

One existing expectation changed with it — `should handle click on links and trigger fetch` asserted `toHaveBeenCalledWith(fetch.url, fetch.requestInit)` and now expects `undefined` for the URL, with a comment saying why.

895 tests pass, lint clean.

Worth a `1.11.1` once merged: 1.11.0 advertises a feature that does not work on the path people use.