### PR TITLE
Prepare the 1.11.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [v1.11.1](https://github.com/studiometa/ui/compare/1.11.0..1.11.1) (2026-09-01)
+
+This patch extends the `historyUrl` separation introduced in `1.11.0` to the declarative link and form handlers, which still bypassed it.
+
 ### Fixed
 
 - **Fetch:** apply the `historyUrl` separation to a link click and a form submit, not only to a bare `fetch()` call — the declarative handlers passed the resolved URL on, which read as a caller naming a destination and kept a `src` in the address bar ([#646](https://github.com/studiometa/ui/pull/646))

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "studiometa/ui",
   "type": "composer-plugin",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "description": "Accessible and composable JavaScript behaviors and Twig templates.",
   "license": "MIT",
   "require": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@studiometa/ui-workspace",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@studiometa/ui-workspace",
-      "version": "1.11.0",
+      "version": "1.11.1",
       "hasInstallScript": true,
       "workspaces": [
         "packages/*"
@@ -22411,11 +22411,11 @@
     },
     "packages/api": {
       "name": "@studiometa/ui-api",
-      "version": "1.11.0"
+      "version": "1.11.1"
     },
     "packages/docs": {
       "name": "@studiometa/ui-docs",
-      "version": "1.11.0",
+      "version": "1.11.1",
       "dependencies": {
         "@studiometa/js-toolkit": "3.9.0"
       },
@@ -22541,7 +22541,7 @@
     },
     "packages/eslint-plugin-ui": {
       "name": "@studiometa/eslint-plugin-ui",
-      "version": "1.11.0",
+      "version": "1.11.1",
       "license": "MIT",
       "dependencies": {
         "@oxlint/plugins": "1.63.0"
@@ -22556,7 +22556,7 @@
     },
     "packages/playground": {
       "name": "@studiometa/ui-playground",
-      "version": "1.11.0",
+      "version": "1.11.1",
       "dependencies": {
         "@studiometa/playground": "^0.3.13"
       },
@@ -22573,7 +22573,7 @@
     },
     "packages/tests": {
       "name": "@studiometa/ui-tests",
-      "version": "1.11.0",
+      "version": "1.11.1",
       "license": "MIT",
       "dependencies": {
         "@happy-dom/global-registrator": "^20.8.8",
@@ -22804,7 +22804,7 @@
     },
     "packages/ui": {
       "name": "@studiometa/ui",
-      "version": "1.11.0",
+      "version": "1.11.1",
       "license": "MIT",
       "dependencies": {
         "alien-signals": "^3.2.1",
@@ -22827,7 +22827,7 @@
     },
     "packages/ui-mapbox": {
       "name": "@studiometa/ui-mapbox",
-      "version": "1.11.0",
+      "version": "1.11.1",
       "license": "MIT",
       "devDependencies": {
         "@mapbox/mapbox-gl-geocoder": "^5.1.0",
@@ -22849,7 +22849,7 @@
     },
     "packages/ui-motion": {
       "name": "@studiometa/ui-motion",
-      "version": "1.11.0",
+      "version": "1.11.1",
       "license": "MIT",
       "devDependencies": {
         "@studiometa/js-toolkit": "^3.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-workspace",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "type": "module",
   "private": true,
   "workspaces": [

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-api",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "private": true,
   "type": "commonjs"
 }

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-docs",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/eslint-plugin-ui/package.json
+++ b/packages/eslint-plugin-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/eslint-plugin-ui",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "description": "ESLint plugin to help developers discover and use @studiometa/ui components",
   "publishConfig": {
     "access": "public"

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-playground",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-tests",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/ui-mapbox/package.json
+++ b/packages/ui-mapbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-mapbox",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "description": "Vanilla js-toolkit components to build Mapbox GL maps declaratively",
   "publishConfig": {
     "access": "public"

--- a/packages/ui-motion/package.json
+++ b/packages/ui-motion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui-motion",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "description": "Vanilla js-toolkit components to animate elements declaratively with Motion",
   "publishConfig": {
     "access": "public"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/ui",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "description": "Accessible and composable JavaScript behaviors and templates",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Prepares the `1.11.1` patch release.

## Changes

- **`CHANGELOG.md`**: move the `Unreleased` entry into a new `v1.11.1` section dated 2026-09-01, with a one-sentence summary. `## [Unreleased]` stays at the top, empty.
- **Version bump** to `1.11.1` via `npm version 1.11.1 --no-git-tag-version`. The `postversion` hook propagated it to the root `package.json`, `package-lock.json`, `composer.json`, and the eight workspaces under `packages/` (api, docs, eslint-plugin-ui, playground, tests, ui, ui-mapbox, ui-motion).

No tag was created by the bump — the tag is pushed after this merges, so `publish.yml` triggers on the merge commit.

## Content

The single fix in this release is #646: apply the `historyUrl` separation to a link click and a form submit, not only to a bare `fetch()` call. This completes the `historyUrl` work shipped in `1.11.0`.

## Verified locally

- `npm run test` — 895 passing, 3 skipped, 1 todo, across 106 files (exit 0)
- `npm run lint` — exit 0 (20 pre-existing warnings, 0 errors)
- `npm run build` — exit 0, `git status` clean afterwards, no stray files
- `npm run manifest:check` — exit 0